### PR TITLE
Env URL inference and CLI monitor wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Public open-alpha composite GitHub Action that orchestrates Postman onboarding by chaining:
 
-- `postman-cs/postman-bootstrap-action@v0`
-- `postman-cs/postman-repo-sync-action@v0`
+- `postman-cs/postman-bootstrap-action`
+- a resolve step that infers env runtime URLs from the spec when not provided
+- `postman-cs/postman-repo-sync-action`
 
-This is the primary partner-facing entrypoint for the open-alpha suite.
+This is the primary partner-facing entrypoint for the open-alpha suite. When `env-runtime-urls-json` is empty, the first server URL from the OpenAPI spec is used for all environments. Monitors are created as CLI monitors (run on every CI pipeline) unless `monitor-cron` is set for a cloud schedule.
 
 For existing services, the composite action can target an existing workspace/spec/collection set and can suppress or redirect generated CI workflow output for repos that already have their own pipeline layout.
 
@@ -80,7 +81,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `contract-collection-id` | | Reuse an existing contract collection. |
 | `monitor-id` | | Existing smoke monitor ID. When set the action skips monitor creation. |
 | `mock-url` | | Existing mock server URL. When set the action skips mock creation. |
-| `monitor-cron` | `""` | Cron expression for monitor scheduling (e.g. `0 */6 * * *`). When empty the monitor is created without a schedule. |
+| `monitor-cron` | `""` | Cron expression for monitor scheduling (e.g. `0 */6 * * *`). When empty a **CLI monitor** is created and runs on every pipeline run; when set, a **cloud monitor** runs on that schedule. |
 | `generate-ci-workflow` | `true` | Pass through to repo sync; set `false` for repos that already manage CI. |
 | `ci-workflow-path` | `.github/workflows/ci.yml` | Pass through to repo sync to redirect generated workflow output. |
 | `project-name` | | Service name used across bootstrap and repo sync. |
@@ -92,7 +93,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `environments-json` | `["prod"]` | Environment slugs to materialize downstream. |
 | `system-env-map-json` | `{}` | Map of environment slug to system environment ID. |
 | `governance-mapping-json` | `{}` | Map of domain to governance group name. |
-| `env-runtime-urls-json` | `{}` | Map of environment slug to runtime base URL. |
+| `env-runtime-urls-json` | `{}` | Map of environment slug to runtime base URL. When empty, the first server URL from the OpenAPI spec is inferred and used for all environments (see **Inferring runtime URLs** below). |
 | `postman-api-key` | | Required for bootstrap and repo sync Postman operations. |
 | `postman-access-token` | | Enables governance assignment and Bifrost integration work. |
 | `github-token` | | Enables repository variable persistence and generated commits. |
@@ -156,17 +157,28 @@ The `postman-access-token` is a Postman session token (`x-access-token`) require
 
 > **Note:** `postman login --with-api-key` stores a PMAK — **not** the session token these APIs require. You must use the interactive browser login.
 
+### Inferring runtime URLs
+
+If `env-runtime-urls-json` is not provided (or is `{}`), the composite uses the bootstrap step’s **spec-server-url** output — the first entry in the OpenAPI spec’s `servers` array — and applies it to every environment in `environments-json`. Set `env-runtime-urls-json` explicitly when your deployed URLs differ from the spec or you have multiple environments with different base URLs.
+
+### Monitors: CLI vs cloud
+
+- **No `monitor-cron`** (default): A CLI monitor is created. The generated CI workflow runs `postman monitor run` on every pipeline run, so smoke tests run in your CI without a Postman cloud schedule.
+- **`monitor-cron` set**: A cloud monitor is created and runs on that schedule from Postman’s infrastructure.
+
+The composite outputs **monitor-type** (`cli` or `cloud`) from the repo-sync step.
+
 ## Output Mapping
 
 The composite action wires:
 
-- `workspace-id`, `workspace-url`, `spec-id`, and `collections-json` from `bootstrap`.
-- `environment-uids-json`, `mock-url`, `monitor-id`, `repo-sync-summary-json`, and `commit-sha` from `repo_sync`.
+- `workspace-id`, `workspace-url`, `spec-id`, `collections-json`, and `spec-server-url` from `bootstrap`.
+- `environment-uids-json`, `mock-url`, `monitor-id`, `monitor-type`, `repo-sync-summary-json`, and `commit-sha` from `repo_sync`.
 - Existing-service passthrough inputs to `bootstrap`: `workspace-id`, `spec-id`, `baseline-collection-id`, `smoke-collection-id`, and `contract-collection-id`.
 - Existing-repo passthrough inputs to `repo_sync`: `generate-ci-workflow` and `ci-workflow-path`.
 - When `enable-insights: true`, the Insights onboarding step runs after repo sync using the workspace ID from bootstrap.
 
-See [action.yml](/Users/jaredboynton/__devlocal/postman-api-onboarding-action/action.yml) for exact step mappings.
+See [action.yml](action.yml) for exact step mappings.
 
 ## Local Development
 

--- a/action.yml
+++ b/action.yml
@@ -124,6 +124,9 @@ outputs:
   collections-json:
     description: JSON summary of generated collections.
     value: ${{ steps.bootstrap.outputs.collections-json }}
+  spec-server-url:
+    description: First server URL extracted from the OpenAPI spec.
+    value: ${{ steps.bootstrap.outputs.spec-server-url }}
   environment-uids-json:
     description: JSON map of environment slug to Postman environment uid.
     value: ${{ steps.repo_sync.outputs.environment-uids-json }}
@@ -147,7 +150,7 @@ runs:
   steps:
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v0
+      uses: postman-cs/postman-bootstrap-action@hammad/infer-env-urls
       with:
         project-name: ${{ inputs.project-name }}
         workspace-id: ${{ inputs.workspace-id }}
@@ -169,6 +172,19 @@ runs:
         gh-fallback-token: ${{ inputs.gh-fallback-token }}
         github-auth-mode: ${{ inputs.github-auth-mode }}
         integration-backend: ${{ inputs.integration-backend }}
+    - id: resolve_env_urls
+      name: Resolve runtime URLs
+      shell: bash
+      run: |
+        EXPLICIT='${{ inputs.env-runtime-urls-json }}'
+        SERVER='${{ steps.bootstrap.outputs.spec-server-url }}'
+        if [ "$EXPLICIT" != '{}' ] && [ -n "$EXPLICIT" ]; then
+          echo "json=$EXPLICIT" >> "$GITHUB_OUTPUT"
+        elif [ -n "$SERVER" ]; then
+          echo "json=$(echo '${{ inputs.environments-json }}' | jq -c --arg u "$SERVER" '[.[] | {(.): $u}] | add // {}')" >> "$GITHUB_OUTPUT"
+        else
+          echo "json={}" >> "$GITHUB_OUTPUT"
+        fi
     - id: repo_sync
       name: Sync Repository and Workspace
       uses: postman-cs/postman-repo-sync-action@hammad/cli-monitor
@@ -186,7 +202,7 @@ runs:
         environments-json: ${{ inputs.environments-json }}
         system-env-map-json: ${{ inputs.system-env-map-json }}
         environment-uids-json: '{}'
-        env-runtime-urls-json: ${{ inputs.env-runtime-urls-json }}
+        env-runtime-urls-json: ${{ steps.resolve_env_urls.outputs.json }}
         repo-write-mode: ${{ inputs.repo-write-mode }}
         current-ref: ${{ inputs.current-ref }}
         committer-name: ${{ inputs.committer-name }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -73,11 +73,12 @@ describe('postman-api-onboarding-action composite contract', () => {
     const manifest = loadManifest();
     const steps = manifest.runs.steps;
 
-    expect(steps).toHaveLength(3);
+    expect(steps).toHaveLength(4);
     expect(steps[0]?.id).toBe('bootstrap');
-    expect(steps[0]?.uses).toBe('postman-cs/postman-bootstrap-action@v0');
-    expect(steps[1]?.id).toBe('repo_sync');
-    expect(steps[1]?.uses).toBe('postman-cs/postman-repo-sync-action@hammad/cli-monitor');
+    expect(steps[0]?.uses).toBe('postman-cs/postman-bootstrap-action@hammad/infer-env-urls');
+    expect(steps[1]?.id).toBe('resolve_env_urls');
+    expect(steps[2]?.id).toBe('repo_sync');
+    expect(steps[2]?.uses).toBe('postman-cs/postman-repo-sync-action@hammad/cli-monitor');
   });
 
   it('maps bootstrap outputs explicitly into repo-sync inputs', () => {
@@ -114,6 +115,9 @@ describe('postman-api-onboarding-action composite contract', () => {
     expect(repoSyncStep?.with?.['ci-workflow-path']).toBe(
       '${{ inputs.ci-workflow-path }}'
     );
+    expect(repoSyncStep?.with?.['env-runtime-urls-json']).toBe(
+      '${{ steps.resolve_env_urls.outputs.json }}'
+    );
   });
 
   it('surfaces final outputs from bootstrap and repo-sync steps', () => {
@@ -124,6 +128,9 @@ describe('postman-api-onboarding-action composite contract', () => {
     );
     expect(manifest.outputs['collections-json']?.value).toBe(
       '${{ steps.bootstrap.outputs.collections-json }}'
+    );
+    expect(manifest.outputs['spec-server-url']?.value).toBe(
+      '${{ steps.bootstrap.outputs.spec-server-url }}'
     );
     expect(manifest.outputs['environment-uids-json']?.value).toBe(
       '${{ steps.repo_sync.outputs.environment-uids-json }}'


### PR DESCRIPTION
Uses bootstrap `@hammad/infer-env-urls` and adds a resolve step: when `env-runtime-urls-json` is empty, uses first server URL from spec for all environments. Repo-sync uses `@hammad/cli-monitor`. README updated for inference and CLI/cloud monitors.