### PR TITLE
feat: pass SSL certificate inputs through to repo-sync action

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `cluster-name` | | Optional Insights cluster name passed to the downstream Insights onboarding step. |
 | `integration-backend` | `bifrost` | Current public open-alpha backend. |
 | `org-mode` | `false` | When `true`, includes `x-entity-team-id` header in Bifrost proxy calls. Non-org teams must omit this header. |
+| `ssl-client-cert` | | Base64-encoded PEM client certificate for mTLS. Passed through to repo-sync for CI workflow SSL support. |
+| `ssl-client-key` | | Base64-encoded PEM client private key. Passed through to repo-sync. |
+| `ssl-client-passphrase` | | Passphrase for encrypted private key. Passed through to repo-sync. |
+| `ssl-extra-ca-certs` | | Base64-encoded PEM additional CA certificates. Passed through to repo-sync. |
 
 ### Team ID derivation
 

--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,18 @@ inputs:
     description: Whether the Postman team uses org-mode. When true, x-entity-team-id header is included in Bifrost proxy calls. Non-org teams must omit this header.
     required: false
     default: 'false'
+  ssl-client-cert:
+    description: Base64-encoded PEM client certificate for mTLS. Passed through to repo-sync for CI workflow generation.
+    required: false
+  ssl-client-key:
+    description: Base64-encoded PEM client private key. Passed through to repo-sync.
+    required: false
+  ssl-client-passphrase:
+    description: Passphrase for encrypted private key. Passed through to repo-sync.
+    required: false
+  ssl-extra-ca-certs:
+    description: Base64-encoded PEM additional CA certificates. Passed through to repo-sync.
+    required: false
 outputs:
   integration-backend:
     description: Resolved integration backend for the onboarding run.
@@ -209,6 +221,10 @@ runs:
         monitor-id: ${{ inputs.monitor-id }}
         mock-url: ${{ inputs.mock-url }}
         monitor-cron: ${{ inputs.monitor-cron }}
+        ssl-client-cert: ${{ inputs.ssl-client-cert }}
+        ssl-client-key: ${{ inputs.ssl-client-key }}
+        ssl-client-passphrase: ${{ inputs.ssl-client-passphrase }}
+        ssl-extra-ca-certs: ${{ inputs.ssl-extra-ca-certs }}
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -158,7 +158,11 @@ describe('postman-api-onboarding-action composite contract', () => {
         'enable-insights',
         'cluster-name',
         'integration-backend',
-        'org-mode'
+        'org-mode',
+        'ssl-client-cert',
+        'ssl-client-key',
+        'ssl-client-passphrase',
+        'ssl-extra-ca-certs'
       ]);
     });
 


### PR DESCRIPTION
## Summary

- Add ssl-client-cert, ssl-client-key, ssl-client-passphrase, ssl-extra-ca-certs passthrough inputs
- Enables mTLS support in CI workflows created by repo-sync

## Changes

- `action.yml`: 4 new optional SSL inputs + passthrough to repo-sync step