### PR TITLE
docs: add non-GitHub CI usage section for CLI chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,52 @@ jobs:
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
 ```
 
+## Non-GitHub CI Usage
+
+On GitHub Actions, continue using the composite action as documented above. The CLI entry points are for GitLab CI, Bitbucket Pipelines, Azure DevOps, and other CI systems.
+
+Install both CLIs globally:
+
+```bash
+npm install -g postman-bootstrap-action postman-repo-sync-action
+```
+
+Run bootstrap first and save its JSON output:
+
+```bash
+postman-bootstrap \
+  --project-name "my-api" \
+  --spec-url "https://registry.example.com/specs/my-api/openapi.yaml" \
+  --postman-api-key "$POSTMAN_API_KEY" \
+  --result-json ./bootstrap-result.json
+```
+
+Extract the outputs you need from the JSON:
+
+```bash
+WORKSPACE_ID=$(jq -r '.["workspace-id"]' bootstrap-result.json)
+SMOKE_COLLECTION_ID=$(jq -r '.["smoke-collection-id"]' bootstrap-result.json)
+CONTRACT_COLLECTION_ID=$(jq -r '.["contract-collection-id"]' bootstrap-result.json)
+BASELINE_COLLECTION_ID=$(jq -r '.["baseline-collection-id"]' bootstrap-result.json)
+```
+
+Run repo-sync with those values:
+
+```bash
+postman-repo-sync \
+  --project-name "my-api" \
+  --workspace-id "$WORKSPACE_ID" \
+  --baseline-collection-id "$BASELINE_COLLECTION_ID" \
+  --smoke-collection-id "$SMOKE_COLLECTION_ID" \
+  --contract-collection-id "$CONTRACT_COLLECTION_ID" \
+  --postman-api-key "$POSTMAN_API_KEY" \
+  --result-json ./sync-result.json
+```
+
+Both CLIs support `--dotenv-path` for shell-friendly KEY=VALUE output that can be sourced with `source ./bootstrap.env`.
+
+The Insights onboarding CLI is not yet available for non-GitHub CI. See the `postman-insights-onboarding-action` repo for updates.
+
 Even when reusing an existing `spec-id`, the composite action still requires `spec-url` because the bootstrap step updates the existing Spec Hub asset from that source of truth.
 
 ## Inputs


### PR DESCRIPTION
## Summary

- Document how to chain `postman-bootstrap` and `postman-repo-sync` CLIs on non-GitHub CI
- Covers installation, bootstrap -> repo-sync handoff via `--result-json`, and `--dotenv-path` alternative
- Notes Insights CLI is not yet available for non-GitHub CI

## Changes

- `README.md`: New "Non-GitHub CI Usage" section