### PR TITLE
fix: wire environment-uids-json through to repo-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
           spec-url: https://example.com/openapi.yaml
           environments-json: '["prod","stage"]'
           system-env-map-json: '{"prod":"uuid-prod","stage":"uuid-stage"}'
+          environment-uids-json: '{"dev":"uid-dev","staging":"uid-staging"}'
           governance-mapping-json: '{"core-banking":"Core Banking"}'
           env-runtime-urls-json: '{"prod":"https://api.example.com"}'
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
@@ -146,6 +147,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `spec-path` | | Optional repo-root-relative path to the local spec file used for repo metadata generation. |
 | `environments-json` | `["prod"]` | Environment slugs to materialize downstream. |
 | `system-env-map-json` | `{}` | Map of environment slug to system environment ID. |
+| `environment-uids-json` | `{}` | Map of environment slug to existing Postman environment UID. When provided, repo-sync reuses these environments instead of creating new ones. |
 | `governance-mapping-json` | `{}` | Map of domain to governance group name. |
 | `env-runtime-urls-json` | `{}` | Map of environment slug to runtime base URL. |
 | `postman-api-key` | | Required Postman API key for the bootstrap and sync phases. The composite always runs `postman-bootstrap-action`, which still requires a PMAK. |

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: JSON map of environment slug to system environment id.
     required: false
     default: '{}'
+  environment-uids-json:                                                                                                                                                                                                                                                                             
+    description: JSON map of environment slug to existing Postman environment UID. When provided, repo-sync reuses these environments instead of creating new ones.                                                                                                                                  
+    required: false                                                                                                                                                                                                                                                                                  
+    default: '{}'      
   governance-mapping-json:
     description: JSON map of business domain to governance group name.
     required: false
@@ -239,7 +243,7 @@ runs:
         ci-workflow-path: ${{ inputs.ci-workflow-path }}
         environments-json: ${{ inputs.environments-json }}
         system-env-map-json: ${{ inputs.system-env-map-json }}
-        environment-uids-json: '{}'
+        environment-uids-json: ${{ inputs.environment-uids-json }}
         env-runtime-urls-json: ${{ inputs.env-runtime-urls-json }}
         repo-write-mode: ${{ inputs.repo-write-mode }}
         current-ref: ${{ inputs.current-ref }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -148,6 +148,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'spec-path',
         'environments-json',
         'system-env-map-json',
+        'environment-uids-json',
         'governance-mapping-json',
         'env-runtime-urls-json',
         'postman-api-key',
@@ -397,6 +398,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['system-env-map-json']?.default).toBe('{}');
       expect(manifest.inputs['governance-mapping-json']?.default).toBe('{}');
       expect(manifest.inputs['env-runtime-urls-json']?.default).toBe('{}');
+      expect(manifest.inputs['environment-uids-json']?.default).toBe('{}');
     });
 
     it('every input has a description', () => {


### PR DESCRIPTION
## Description

The `repo_sync` step hardcoded `environment-uids-json: '{}'` when calling
`postman-repo-sync-action`, so existing environment UIDs were never passed
through. Every re-run created fresh environments instead of updating the
existing ones, accumulating duplicates in the workspace.

`postman-repo-sync-action` already supports `environment-uids-json` as an
input - the outer action just wasn't exposing or forwarding it.

This adds `environment-uids-json` as a passthrough input (default `'{}'` to
preserve existing behavior) and wires it through to repo-sync.

## Related Issue

N/A

## Checklist

- [x] `npm test` passes (no TypeScript changes - composite action only)
- [x] `npm run typecheck` passes (no TypeScript changes - composite action only)
- [x] `npm run lint` passes (no TypeScript changes - composite action only)
- [x] `npm run build` / `dist/` updated (skip - composite action, no compiled output)
- [x] No secrets or credentials in diff
- [x] Breaking changes documented (if any) - none, default is `'{}'` preserving existing behavior