### PR TITLE
Refresh behavior fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `smoke-collection-id` | | Reuse an existing smoke collection. |
 | `contract-collection-id` | | Reuse an existing contract collection. |
 | `sync-examples` | `true` | Whether linked spec/collection relations should enable example syncing during cloud linkage. |
-| `collection-sync-mode` | `refresh` | Collection lifecycle policy. `refresh` regenerates from latest spec (default), `reuse` keeps existing, `version` creates release-scoped collections. |
+| `collection-sync-mode` | `refresh` | Collection lifecycle policy. `refresh` keeps tracked collection IDs in sync with the latest spec, and `version` creates release-scoped collections. |
 | `spec-sync-mode` | `update` | Spec lifecycle policy. `update` keeps canonical spec current, `version` creates release-scoped spec. |
 | `release-label` | | Optional release label for versioned specs and collections. Derived from git tag/branch when omitted. |
 | `monitor-id` | | Existing smoke monitor ID. When set, the action validates and reuses this monitor instead of creating a new one. |

--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,7 @@ runs:
   steps:
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: pavan-nelakuditi/postman-bootstrap-action@refresh_behavior_fix
+      uses: postman-cs/postman-bootstrap-action@main
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -236,7 +236,7 @@ runs:
         integration-backend: ${{ inputs.integration-backend }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: pavan-nelakuditi/postman-repo-sync-action@refresh_behavior_fix
+      uses: postman-cs/postman-repo-sync-action@main
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: 'true'
   collection-sync-mode:
-    description: Collection lifecycle policy (reuse, refresh, or version). Default refresh ensures collections stay in sync with the spec.
+    description: Collection lifecycle policy (refresh or version). Default refresh ensures tracked collections stay in sync with the spec.
     required: false
     default: refresh
   spec-sync-mode:
@@ -211,7 +211,7 @@ runs:
   steps:
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v0
+      uses: pavan-nelakuditi/postman-bootstrap-action@refresh_behavior_fix
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -236,7 +236,7 @@ runs:
         integration-backend: ${{ inputs.integration-backend }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v0
+      uses: pavan-nelakuditi/postman-repo-sync-action@refresh_behavior_fix
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -238,11 +238,11 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(steps[0]?.id).toBe('bootstrap');
       expect(steps[0]?.uses).toBe(
-        'pavan-nelakuditi/postman-bootstrap-action@refresh_behavior_fix'
+        'postman-cs/postman-bootstrap-action@main'
       );
       expect(steps[1]?.id).toBe('repo_sync');
       expect(steps[1]?.uses).toBe(
-        'pavan-nelakuditi/postman-repo-sync-action@refresh_behavior_fix'
+        'postman-cs/postman-repo-sync-action@main'
       );
       expect(steps[2]?.id).toBe('insights_onboarding');
       expect(steps[2]?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -232,14 +232,18 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.runs.steps).toHaveLength(3);
     });
 
-    it('uses the postman-cs bootstrap, repo-sync, and insights actions', () => {
+    it('uses the configured bootstrap, repo-sync, and insights actions', () => {
       const manifest = loadManifest();
       const steps = manifest.runs.steps;
 
       expect(steps[0]?.id).toBe('bootstrap');
-      expect(steps[0]?.uses).toBe('postman-cs/postman-bootstrap-action@v0');
+      expect(steps[0]?.uses).toBe(
+        'pavan-nelakuditi/postman-bootstrap-action@refresh_behavior_fix'
+      );
       expect(steps[1]?.id).toBe('repo_sync');
-      expect(steps[1]?.uses).toBe('postman-cs/postman-repo-sync-action@v0');
+      expect(steps[1]?.uses).toBe(
+        'pavan-nelakuditi/postman-repo-sync-action@refresh_behavior_fix'
+      );
       expect(steps[2]?.id).toBe('insights_onboarding');
       expect(steps[2]?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0');
     });


### PR DESCRIPTION
## Summary

This PR updates the onboarding wrapper to match the new collection lifecycle contract:
- `collection-sync-mode=refresh`
- `collection-sync-mode=version`

The separate `reuse` collection-sync mode is removed.

This PR also updates the wrapper wiring/docs so the public composite action description reflects the new refresh behavior:
- refresh keeps tracked collection IDs in sync with the latest spec
- version creates release-scoped collections

## Changes

- removed `reuse` from wrapper input documentation
- updated action wiring references back to `postman-cs/...@main`
- updated contract tests accordingly