### PR TITLE
docs(monitor): reflect run-once-when-empty monitor-cron behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `release-label` | | Optional release label for versioned specs and collections. Derived from git tag/branch when omitted. |
 | `monitor-id` | | Existing smoke monitor ID. When set, the action validates and reuses this monitor instead of creating a new one. |
 | `mock-url` | | Existing mock server URL. When set, the action validates and reuses this mock instead of creating a new one. |
-| `monitor-cron` | `""` | Cron expression for monitor scheduling (e.g. `0 */6 * * *`). When empty, the monitor is created in a disabled state. |
+| `monitor-cron` | `""` | Cron expression for monitor scheduling (e.g. `0 */6 * * *`). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run). |
 | `generate-ci-workflow` | `true` | Pass through to repo sync; set `false` for repos that already manage CI. |
 | `ci-workflow-path` | `.github/workflows/ci.yml` | Pass through to repo sync to redirect generated workflow output. |
 | `project-name` | | Service name used across bootstrap and repo sync. |

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
     description: Existing mock server URL. When set, the action validates and reuses this mock instead of creating a new one.
     required: false
   monitor-cron:
-    description: Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created in a disabled state.
+    description: Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run).
     required: false
     default: ""
   generate-ci-workflow:


### PR DESCRIPTION
Update action.yml and README to describe the new behavior of the upstream repo-sync action: when monitor-cron is empty, the monitor is created disabled and triggered to run once per workflow invocation.

## Description

<!-- What changed and why -->

## Related Issue

<!-- Fixes #123 or "N/A" -->

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` run and `dist/` updated (skip for composite action)
- [x] No secrets or credentials in diff
- [x] Breaking changes documented (if any)
