### PR TITLE
feat(junit): emit JUnit results from smoke and contract collections

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -273,6 +273,57 @@ runs:
         ssl-extra-ca-certs: ${{ inputs.ssl-extra-ca-certs }}
         spec-id: ${{ steps.bootstrap.outputs.spec-id }}
         spec-path: ${{ inputs.spec-path }}
+    - id: run_tests_junit
+      name: Run smoke and contract collections with JUnit output
+      if: ${{ steps.bootstrap.outputs.collections-json != '' }}
+      shell: bash
+      continue-on-error: true
+      env:
+        POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
+        COLLECTIONS_JSON: ${{ steps.bootstrap.outputs.collections-json }}
+        ENVIRONMENT_UIDS_JSON: ${{ steps.repo_sync.outputs.environment-uids-json }}
+      run: |
+        set +e
+        mkdir -p "$RUNNER_TEMP/postman-junit"
+
+        if ! command -v postman >/dev/null 2>&1; then
+          curl -fsSL "https://dl-cli.pstmn.io/install/unix.sh" | sh
+          export PATH="$HOME/.postman/cli:$PATH"
+        fi
+
+        postman login --with-api-key "$POSTMAN_API_KEY" >/dev/null 2>&1 || true
+
+        SMOKE=$(printf '%s' "$COLLECTIONS_JSON"    | jq -r '.smoke // empty')
+        CONTRACT=$(printf '%s' "$COLLECTIONS_JSON" | jq -r '.contract // empty')
+        ENV_UID=$(printf '%s' "$ENVIRONMENT_UIDS_JSON" | jq -r 'to_entries | (.[0].value // empty)')
+
+        ENV_FLAG=()
+        if [ -n "$ENV_UID" ]; then
+          ENV_FLAG=(-e "$ENV_UID")
+        fi
+
+        if [ -n "$SMOKE" ]; then
+          postman collection run "$SMOKE" "${ENV_FLAG[@]}" \
+            --reporters cli,junit \
+            --reporter-junit-export "$RUNNER_TEMP/postman-junit/smoke.xml" || true
+        fi
+
+        if [ -n "$CONTRACT" ]; then
+          postman collection run "$CONTRACT" "${ENV_FLAG[@]}" \
+            --reporters cli,junit \
+            --reporter-junit-export "$RUNNER_TEMP/postman-junit/contract.xml" || true
+        fi
+    - id: upload_junit_artifact
+      name: Upload Postman JUnit results
+      if: always()
+      env:
+        POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: postman-test-results
+        path: ${{ runner.temp }}/postman-junit/*.xml
+        if-no-files-found: ignore
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -226,13 +226,13 @@ describe('postman-api-onboarding-action composite contract', () => {
   });
 
   describe('Phase 2: Step Wiring', () => {
-    it('is a composite action with three steps', () => {
+    it('is a composite action with the expected step count', () => {
       const manifest = loadManifest();
       expect(manifest.runs.using).toBe('composite');
-      expect(manifest.runs.steps).toHaveLength(3);
+      expect(manifest.runs.steps).toHaveLength(5);
     });
 
-    it('uses the configured bootstrap, repo-sync, and insights actions', () => {
+    it('uses the configured bootstrap, repo-sync, junit-runner, junit-uploader, and insights actions', () => {
       const manifest = loadManifest();
       const steps = manifest.runs.steps;
 
@@ -244,8 +244,12 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(steps[1]?.uses).toBe(
         'postman-cs/postman-repo-sync-action@main'
       );
-      expect(steps[2]?.id).toBe('insights_onboarding');
-      expect(steps[2]?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0');
+      expect(steps[2]?.id).toBe('run_tests_junit');
+      expect(steps[2]?.shell).toBe('bash');
+      expect(steps[3]?.id).toBe('upload_junit_artifact');
+      expect(steps[3]?.uses).toBe('actions/upload-artifact@v4');
+      expect(steps[4]?.id).toBe('insights_onboarding');
+      expect(steps[4]?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0');
     });
 
     it('insights step is conditional on enable-insights', () => {


### PR DESCRIPTION
Add two composite steps after repo_sync:

1. run_tests_junit: installs Postman CLI (idempotent), runs the smoke and contract collections produced by bootstrap against the first environment surfaced by repo_sync, and writes JUnit XML to $RUNNER_TEMP/postman-junit/. Uses continue-on-error so test failures never fail onboarding.

2. upload_junit_artifact: uploads the JUnit XML files as the postman-test-results artifact (always runs; ignores missing files).

This delivers JUnit output for downstream dashboards (e.g. JUnit ingestion in Jira/X-ray) for every onboarding run, regardless of whether generate-ci-workflow is true or false. No new inputs are required.

Update Phase 2 contract tests to reflect the new step count (5) and the additional step IDs.

## Description

<!-- What changed and why -->

## Related Issue

<!-- Fixes #123 or "N/A" -->

## Checklist

- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` run and `dist/` updated (skip for composite action)
- [ ] No secrets or credentials in diff
- [ ] Breaking changes documented (if any)
