### PR TITLE
feat: expose configurable base URLs for beta/alpha stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `postman-api-key` | | Required Postman API key for the bootstrap and sync phases. The composite always runs `postman-bootstrap-action`, which still requires a PMAK. |
 | `postman-access-token` | | Enables governance assignment, Bifrost integration, and API key generation fallback. |
 | `postman-team-id` | | Explicit Postman team ID override for org-mode Bifrost calls. Passed to the downstream actions when provided. |
+| `postman-api-base` | `https://api.getpostman.com` | Optional Postman API base URL override. Defaults to prod. Pass through for beta/alpha stacks; propagated to bootstrap and repo-sync. |
+| `postman-bifrost-base` | `https://bifrost-premium-https-v4.gw.postman.com` | Optional Bifrost proxy base URL override. Defaults to prod. Propagated to bootstrap and repo-sync. |
+| `postman-gateway-base` | `https://gateway.postman.com` | Optional Postman gateway base URL override. Defaults to prod. Propagated to bootstrap only (repo-sync does not consume it). |
+| `postman-cli-install-url` | `https://dl-cli.pstmn.io/install/unix.sh` | Optional Postman CLI install script URL. Defaults to prod. Used for the in-line CLI install in the JUnit runner step, and propagated to bootstrap and repo-sync. |
 | `github-token` | | Enables generated commits, workflow writes, and optional secret persistence in repo sync. |
 | `gh-fallback-token` | | Optional fallback token for workflow and commit APIs. |
 | `repo-write-mode` | `commit-and-push` | Repo mutation mode passed to repo sync. |

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,22 @@ inputs:
   postman-team-id:
     description: Explicit Postman team ID override for org-mode Bifrost calls.
     required: false
+  postman-api-base:
+    description: Postman API base URL; override for beta/alpha stacks.
+    required: false
+    default: "https://api.getpostman.com"
+  postman-bifrost-base:
+    description: Bifrost proxy base URL; override for beta.
+    required: false
+    default: "https://bifrost-premium-https-v4.gw.postman.com"
+  postman-gateway-base:
+    description: Postman gateway base URL; override for beta.
+    required: false
+    default: "https://gateway.postman.com"
+  postman-cli-install-url:
+    description: URL of the install script for the Postman CLI.
+    required: false
+    default: "https://dl-cli.pstmn.io/install/unix.sh"
   github-token:
     description: GitHub token used for repo variables and generated commits.
     required: false
@@ -234,6 +250,10 @@ runs:
         postman-api-key: ${{ inputs.postman-api-key }}
         postman-access-token: ${{ inputs.postman-access-token }}
         integration-backend: ${{ inputs.integration-backend }}
+        postman-api-base: ${{ inputs.postman-api-base }}
+        postman-bifrost-base: ${{ inputs.postman-bifrost-base }}
+        postman-gateway-base: ${{ inputs.postman-gateway-base }}
+        postman-cli-install-url: ${{ inputs.postman-cli-install-url }}
     - id: repo_sync
       name: Sync Repository and Workspace
       uses: postman-cs/postman-repo-sync-action@main
@@ -273,6 +293,9 @@ runs:
         ssl-extra-ca-certs: ${{ inputs.ssl-extra-ca-certs }}
         spec-id: ${{ steps.bootstrap.outputs.spec-id }}
         spec-path: ${{ inputs.spec-path }}
+        postman-api-base: ${{ inputs.postman-api-base }}
+        postman-bifrost-base: ${{ inputs.postman-bifrost-base }}
+        postman-cli-install-url: ${{ inputs.postman-cli-install-url }}
     - id: run_tests_junit
       name: Run smoke and contract collections with JUnit output
       if: ${{ steps.bootstrap.outputs.collections-json != '' }}
@@ -288,7 +311,7 @@ runs:
         mkdir -p "$RUNNER_TEMP/postman-junit"
 
         if ! command -v postman >/dev/null 2>&1; then
-          curl -fsSL "https://dl-cli.pstmn.io/install/unix.sh" | sh
+          curl -fsSL "${{ inputs.postman-cli-install-url }}" | sh
           export PATH="$HOME/.postman/cli:$PATH"
         fi
 

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -11,6 +11,8 @@ type Step = {
   name?: string;
   uses?: string;
   if?: string;
+  shell?: string;
+  run?: string;
   env?: Record<string, string>;
   with?: Record<string, string>;
 };
@@ -154,6 +156,10 @@ describe('postman-api-onboarding-action composite contract', () => {
         'postman-api-key',
         'postman-access-token',
         'postman-team-id',
+        'postman-api-base',
+        'postman-bifrost-base',
+        'postman-gateway-base',
+        'postman-cli-install-url',
         'github-token',
         'gh-fallback-token',
         'repo-write-mode',
@@ -361,6 +367,48 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.with?.['integration-backend']).toBe('${{ inputs.integration-backend }}');
     });
 
+    it('passes base URL overrides and CLI install URL through to bootstrap', () => {
+      const manifest = loadManifest();
+      const bootstrapStep = manifest.runs.steps.find((s) => s.id === 'bootstrap');
+
+      expect(bootstrapStep?.with?.['postman-api-base']).toBe(
+        '${{ inputs.postman-api-base }}'
+      );
+      expect(bootstrapStep?.with?.['postman-bifrost-base']).toBe(
+        '${{ inputs.postman-bifrost-base }}'
+      );
+      expect(bootstrapStep?.with?.['postman-gateway-base']).toBe(
+        '${{ inputs.postman-gateway-base }}'
+      );
+      expect(bootstrapStep?.with?.['postman-cli-install-url']).toBe(
+        '${{ inputs.postman-cli-install-url }}'
+      );
+    });
+
+    it('passes postman-api-base, postman-bifrost-base, and postman-cli-install-url to repo-sync but not postman-gateway-base', () => {
+      const manifest = loadManifest();
+      const repoSyncStep = manifest.runs.steps.find((s) => s.id === 'repo_sync');
+
+      expect(repoSyncStep?.with?.['postman-api-base']).toBe(
+        '${{ inputs.postman-api-base }}'
+      );
+      expect(repoSyncStep?.with?.['postman-bifrost-base']).toBe(
+        '${{ inputs.postman-bifrost-base }}'
+      );
+      expect(repoSyncStep?.with?.['postman-cli-install-url']).toBe(
+        '${{ inputs.postman-cli-install-url }}'
+      );
+      expect(repoSyncStep?.with?.['postman-gateway-base']).toBeUndefined();
+    });
+
+    it('run_tests_junit installs the Postman CLI from postman-cli-install-url', () => {
+      const manifest = loadManifest();
+      const junitStep = manifest.runs.steps.find((s) => s.id === 'run_tests_junit');
+
+      expect(junitStep?.run).toContain('"${{ inputs.postman-cli-install-url }}"');
+      expect(junitStep?.run).not.toContain('https://dl-cli.pstmn.io/install/unix.sh');
+    });
+
     it('insights step receives workspace-id from bootstrap output', () => {
       const manifest = loadManifest();
       const insightsStep = manifest.runs.steps.find((s) => s.id === 'insights_onboarding');
@@ -422,6 +470,26 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['governance-mapping-json']?.default).toBe('{}');
       expect(manifest.inputs['env-runtime-urls-json']?.default).toBe('{}');
       expect(manifest.inputs['environment-uids-json']?.default).toBe('{}');
+    });
+
+    it('base URL and CLI install URL inputs default to prod endpoints', () => {
+      const manifest = loadManifest();
+      expect(manifest.inputs['postman-api-base']?.default).toBe(
+        'https://api.getpostman.com'
+      );
+      expect(manifest.inputs['postman-api-base']?.required).toBe(false);
+      expect(manifest.inputs['postman-bifrost-base']?.default).toBe(
+        'https://bifrost-premium-https-v4.gw.postman.com'
+      );
+      expect(manifest.inputs['postman-bifrost-base']?.required).toBe(false);
+      expect(manifest.inputs['postman-gateway-base']?.default).toBe(
+        'https://gateway.postman.com'
+      );
+      expect(manifest.inputs['postman-gateway-base']?.required).toBe(false);
+      expect(manifest.inputs['postman-cli-install-url']?.default).toBe(
+        'https://dl-cli.pstmn.io/install/unix.sh'
+      );
+      expect(manifest.inputs['postman-cli-install-url']?.required).toBe(false);
     });
 
     it('every input has a description', () => {


### PR DESCRIPTION
## Summary

Adds four optional inputs with prod defaults so beta/alpha callers can point the onboarding pipeline at non-prod Postman endpoints, and passes them through to the two downstream composite actions. Default behavior (no new inputs set) is byte-identical to current prod.

### New inputs

| Input | Default |
| --- | --- |
| `postman-api-base` | `https://api.getpostman.com` |
| `postman-bifrost-base` | `https://bifrost-premium-https-v4.gw.postman.com` |
| `postman-gateway-base` | `https://gateway.postman.com` |
| `postman-cli-install-url` | `https://dl-cli.pstmn.io/install/unix.sh` |

### Pass-through wiring

- **Bootstrap** (`postman-cs/postman-bootstrap-action@main`): all four inputs.
- **Repo sync** (`postman-cs/postman-repo-sync-action@main`): `postman-api-base`, `postman-bifrost-base`, `postman-cli-install-url`. Repo-sync does not accept `postman-gateway-base` per the companion PR.
- **JUnit runner step** (in-line `curl ... | sh`): now reads from `postman-cli-install-url` instead of the hard-coded `dl-cli.pstmn.io` URL.

### Companion PRs

- postman-cs/postman-bootstrap-action#25 (feat/configurable-base-urls) - adds matching inputs on bootstrap
- postman-cs/postman-repo-sync-action#24 (feat/configurable-base-urls) - adds matching inputs on repo-sync

Those two PRs must merge before this one is useful to consumers, since this composite passes the inputs through by name.

## Test plan

- [x] `npm ci` clean install on `main` state
- [x] `npm run typecheck` passes on branch
- [x] `npm run lint` passes on branch
- [x] `npm test` passes on branch (45 tests, up from 41; 4 new: pass-through to bootstrap, pass-through to repo-sync minus gateway-base, defaults assertion, curl URL substitution assertion)
- [x] README inputs table updated with the four new rows and marked as optional / prod defaults
- [x] Default behavior unchanged: prod URLs hard-coded as defaults; manifest diff against main shows zero existing-input mutations
- [ ] Manual: run the composite with all four inputs unset in a prod workflow and confirm byte-identical outputs to prior run (follow-up E2E)
- [ ] Manual: run the composite with beta overrides and confirm the values propagate through to bootstrap and repo-sync step `with:` blocks (follow-up E2E)