### PR TITLE
feat: expose workspace-team-id for org-mode sub-team routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `domain-code` | | Short prefix used in workspace naming. |
 | `requester-email` | | Optional workspace invite target. |
 | `workspace-admin-user-ids` | | Optional comma-separated workspace admin IDs. |
-| `workspace-team-id` | | Numeric sub-team ID for org-mode workspace creation. |
+| `workspace-team-id` | | Optional. Numeric sub-team ID for org-mode workspace creation. Required only when the target team is scoped under an organization (org-mode); the Postman API cannot create workspaces at the org level without it. Passed through to `postman-bootstrap-action`. |
 | `spec-url` | | Required registry-backed OpenAPI document URL. |
 | `spec-path` | | Optional repo-root-relative path to the local spec file used for repo metadata generation. |
 | `environments-json` | `["prod"]` | Environment slugs to materialize downstream. |

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,9 @@ inputs:
   workspace-admin-user-ids:
     description: Comma-separated workspace admin user ids.
     required: false
+  workspace-team-id:
+    description: Numeric sub-team ID for org-mode workspace creation. Required by the Postman API when the PMAK's team is scoped under an organization.
+    required: false
   spec-url:
     description: URL to the OpenAPI document to bootstrap.
     required: true
@@ -245,6 +248,7 @@ runs:
         domain-code: ${{ inputs.domain-code }}
         requester-email: ${{ inputs.requester-email }}
         workspace-admin-user-ids: ${{ inputs.workspace-admin-user-ids }}
+        workspace-team-id: ${{ inputs.workspace-team-id }}
         spec-url: ${{ inputs.spec-url }}
         governance-mapping-json: ${{ inputs.governance-mapping-json }}
         postman-api-key: ${{ inputs.postman-api-key }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -146,6 +146,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'domain-code',
         'requester-email',
         'workspace-admin-user-ids',
+        'workspace-team-id',
         'spec-url',
         'spec-path',
         'environments-json',
@@ -365,6 +366,27 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(bootstrapStep?.with?.['integration-backend']).toBe('${{ inputs.integration-backend }}');
       expect(repoSyncStep?.with?.['integration-backend']).toBe('${{ inputs.integration-backend }}');
+    });
+
+    it('passes workspace-team-id to bootstrap but not to repo-sync or insights', () => {
+      const manifest = loadManifest();
+      const bootstrapStep = manifest.runs.steps.find((s) => s.id === 'bootstrap');
+      const repoSyncStep = manifest.runs.steps.find((s) => s.id === 'repo_sync');
+      const insightsStep = manifest.runs.steps.find((s) => s.id === 'insights_onboarding');
+
+      expect(bootstrapStep?.with?.['workspace-team-id']).toBe(
+        '${{ inputs.workspace-team-id }}'
+      );
+      expect(repoSyncStep?.with?.['workspace-team-id']).toBeUndefined();
+      expect(insightsStep?.with?.['workspace-team-id']).toBeUndefined();
+    });
+
+    it('workspace-team-id input is optional with no default', () => {
+      const manifest = loadManifest();
+      expect(manifest.inputs['workspace-team-id']).toBeDefined();
+      expect(manifest.inputs['workspace-team-id']?.required).toBe(false);
+      expect(manifest.inputs['workspace-team-id']?.default).toBeUndefined();
+      expect(manifest.inputs['workspace-team-id']?.description).toContain('org-mode');
     });
 
     it('passes base URL overrides and CLI install URL through to bootstrap', () => {


### PR DESCRIPTION
## Summary

The composite action silently dropped any `workspace-team-id` input passed by callers because it was never declared. On org-mode accounts the Postman API cannot create workspaces at the org level, so the downstream `postman-cs/postman-bootstrap-action` requires a numeric sub-team ID.

The downstream action already accepts `workspace-team-id`, but with no pass-through in the composite, real runs surfaced:

```
Warning: Unexpected input(s) 'workspace-team-id', valid inputs are [...]
Error: bootstrap requires workspace-team-id for org-mode accounts
```

This was reproduced in Hammad's onboarding run.

## Changes

- `action.yml`: declare optional `workspace-team-id` input and thread it into the bootstrap step's `with:` block. No default, no version bump.
- Repo-sync and insights-onboarding are unchanged; neither consumes this input.
- `tests/contract.test.ts`: extend the expected-input-set assertion and add explicit wiring + optionality checks mirroring the pattern used for `postman-api-base`.
- `README.md`: clarify the input is optional and required only when the target team is org-mode.

## Behavior

- Default behavior is unchanged when the input is omitted (empty string passes through to bootstrap, which already no-ops on empty).
- Callers on org-mode tenants can now thread the numeric sub-team ID end-to-end, unblocking workspace creation.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` -- 47 passed (was 45; +2 new assertions cover the pass-through and optionality)
- [ ] Re-run Hammad's failing workflow with `workspace-team-id` set to validate end-to-end