### PR TITLE
fix: forward postman-{api,bifrost,observability}-base to insights step

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `postman-api-base` | `https://api.getpostman.com` | Optional Postman API base URL override. Defaults to prod. Pass through for beta/alpha stacks; propagated to bootstrap and repo-sync. |
 | `postman-bifrost-base` | `https://bifrost-premium-https-v4.gw.postman.com` | Optional Bifrost proxy base URL override. Defaults to prod. Propagated to bootstrap and repo-sync. |
 | `postman-gateway-base` | `https://gateway.postman.com` | Optional Postman gateway base URL override. Defaults to prod. Propagated to bootstrap only (repo-sync does not consume it). |
+| `postman-observability-base` | `https://api.observability.postman.com` | Optional Postman observability API base URL override for beta/alpha stacks. Defaults to prod. Forwarded to postman-insights-onboarding-action. |
 | `postman-cli-install-url` | `https://dl-cli.pstmn.io/install/unix.sh` | Optional Postman CLI install script URL. Defaults to prod. Used for the in-line CLI install in the JUnit runner step, and propagated to bootstrap and repo-sync. |
 | `github-token` | | Enables generated commits, workflow writes, and optional secret persistence in repo sync. |
 | `gh-fallback-token` | | Optional fallback token for workflow and commit APIs. |

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,10 @@ inputs:
     description: Postman gateway base URL; override for beta.
     required: false
     default: "https://gateway.postman.com"
+  postman-observability-base:
+    description: Postman observability API base URL; override for beta/alpha stacks. Forwarded to postman-insights-onboarding-action.
+    required: false
+    default: "https://api.observability.postman.com"
   postman-cli-install-url:
     description: URL of the install script for the Postman CLI.
     required: false
@@ -367,3 +371,6 @@ runs:
         postman-access-token: ${{ inputs.postman-access-token }}
         postman-team-id: ${{ inputs.postman-team-id }}
         github-token: ${{ inputs.github-token }}
+        postman-api-base: ${{ inputs.postman-api-base }}
+        postman-bifrost-base: ${{ inputs.postman-bifrost-base }}
+        postman-observability-base: ${{ inputs.postman-observability-base }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -160,6 +160,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'postman-api-base',
         'postman-bifrost-base',
         'postman-gateway-base',
+        'postman-observability-base',
         'postman-cli-install-url',
         'github-token',
         'gh-fallback-token',
@@ -453,6 +454,21 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(insightsStep?.with?.['cluster-name']).toBe('${{ inputs.cluster-name }}');
       expect(insightsStep?.with?.['postman-team-id']).toBe('${{ inputs.postman-team-id }}');
     });
+
+    it('insights step receives base URL overrides for beta/alpha stack routing', () => {
+      const manifest = loadManifest();
+      const insightsStep = manifest.runs.steps.find((s) => s.id === 'insights_onboarding');
+
+      expect(insightsStep?.with?.['postman-api-base']).toBe(
+        '${{ inputs.postman-api-base }}'
+      );
+      expect(insightsStep?.with?.['postman-bifrost-base']).toBe(
+        '${{ inputs.postman-bifrost-base }}'
+      );
+      expect(insightsStep?.with?.['postman-observability-base']).toBe(
+        '${{ inputs.postman-observability-base }}'
+      );
+    });
   });
 
   describe('Phase 3: Safe Defaults', () => {
@@ -508,6 +524,10 @@ describe('postman-api-onboarding-action composite contract', () => {
         'https://gateway.postman.com'
       );
       expect(manifest.inputs['postman-gateway-base']?.required).toBe(false);
+      expect(manifest.inputs['postman-observability-base']?.default).toBe(
+        'https://api.observability.postman.com'
+      );
+      expect(manifest.inputs['postman-observability-base']?.required).toBe(false);
       expect(manifest.inputs['postman-cli-install-url']?.default).toBe(
         'https://dl-cli.pstmn.io/install/unix.sh'
       );


### PR DESCRIPTION
## Summary

Fixes HIGH from [critic-sweep.md](../../pmak-service-account-beta/.omc/critic-sweep.md).

The composite's insights sub-step didn't receive base-URL overrides. When a caller set `postman-api-base: https://api.getpostman-beta.com`, bootstrap and repo-sync retargeted correctly but insights silently talked to prod. This defeats the end-to-end beta story from PRs #21/#22.

### Changes
- `action.yml`: added `postman-observability-base` input with prod default; forwarded `postman-api-base`, `postman-bifrost-base`, and `postman-observability-base` to the insights step's `with:` block
- `tests/contract.test.ts`: extended expected-input-set assertion; added forwarding test mirroring the bootstrap pattern
- `README.md`: documented the new input

Companion: postman-cs/postman-insights-onboarding-action#13 (landed the observability-base input on the insights side).

## Test plan
- [x] 48/48 tests pass
- [x] Typecheck clean
