### PR TITLE
fix(junit): drop install-url regex check that broke bash parsing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -313,10 +313,6 @@ runs:
         mkdir -p "$RUNNER_TEMP/postman-junit"
 
         if ! command -v postman >/dev/null 2>&1; then
-          if ! [[ "$POSTMAN_CLI_INSTALL_URL" =~ ^https://[A-Za-z0-9.-]+/[A-Za-z0-9._~/?=&%-]+$ ]]; then
-            echo "::error::postman-cli-install-url must be an https URL with safe characters; got: $POSTMAN_CLI_INSTALL_URL"
-            exit 1
-          fi
           curl -fsSL "$POSTMAN_CLI_INSTALL_URL" | sh
           export PATH="$HOME/.postman/cli:$PATH"
         fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Public open-alpha composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -452,16 +452,6 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
     });
 
-    it('run_tests_junit validates install URL before use', () => {
-      const manifest = loadManifest();
-      const junitStep = manifest.runs.steps.find((s) => s.id === 'run_tests_junit');
-
-      expect(junitStep?.run).toContain('if ! [[ "$POSTMAN_CLI_INSTALL_URL"');
-      expect(junitStep?.run).toContain('https://[A-Za-z0-9.-]+/[A-Za-z0-9._~/?=&%-]+');
-      expect(junitStep?.run).toContain('::error::postman-cli-install-url must be an https URL');
-      expect(junitStep?.run).toContain('exit 1');
-    });
-
     it('insights step receives workspace-id from bootstrap output', () => {
       const manifest = loadManifest();
       const insightsStep = manifest.runs.steps.find((s) => s.id === 'insights_onboarding');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -439,6 +440,23 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
       expect(junitStep?.run).toContain('$POSTMAN_CLI_INSTALL_URL');
       expect(junitStep?.run).not.toContain('"${{ inputs.postman-cli-install-url }}"');
+    });
+
+    it('run_tests_junit script remains valid Bash', () => {
+      const manifest = loadManifest();
+      const junitStep = manifest.runs.steps.find((s) => s.id === 'run_tests_junit');
+
+      expect(junitStep?.shell).toBe('bash');
+      expect(junitStep?.run).toBeTruthy();
+      expect(() => execFileSync('bash', ['-n'], { input: junitStep?.run })).not.toThrow();
+    });
+
+    it('run_tests_junit does not validate the install URL with an inline Bash regex', () => {
+      const manifest = loadManifest();
+      const junitStep = manifest.runs.steps.find((s) => s.id === 'run_tests_junit');
+
+      expect(junitStep?.run).not.toContain('=~');
+      expect(junitStep?.run).not.toContain('postman-cli-install-url must be an https URL');
     });
 
     it('run_tests_junit checks jq before parsing JSON payloads', () => {


### PR DESCRIPTION
## Summary

The JUnit step added in #20 and hardened in #24 is failing on GitHub-hosted runners with:

```
syntax error in conditional expression: unexpected token `&'
syntax error near `&%'
##[error]Process completed with exit code 2.
```

`bash` parses `[[ ... =~ literal ]]` at compile time when the regex literal contains `&` (the `?=&%` segment in the URL allowlist), so the step exits 2 before installing the CLI. Result: no `postman collection run` executes, no XML is produced, and `upload-artifact` correctly reports "no files found, ignoring." Customers (e.g. GoodLeap) see "JUnit not landing in artifacts" with no obvious upstream cause.

`POSTMAN_CLI_INSTALL_URL` is wired exclusively from a hardcoded ternary on `inputs.postman-stack` (`prod` → `dl-cli.pstmn.io`, `beta` → `dl-cli.pstmn-beta.io`). There is no user-input path into this variable, so the runtime allowlist guards nothing. Drop it.

## Why drop instead of fix the regex

- The check was introduced when the URL was an action input (#24's PR description). It is no longer an input — only `postman-stack` is, and that is already allowlisted upstream by `validate_postman_stack`.
- Re-implementing the regex with a bound variable or `case` statement would either need to keep the literal URL in the run script (failing the existing "no shell interpolation" contract test) or stay as a regex that adds bash-parser surface area for future hardening attempts.

## Changes

- `action.yml`: remove the four-line `[[ ... =~ ... ]]` block in `run_tests_junit`.
- `tests/contract.test.ts`: drop the `validates install URL before use` contract test that pinned the removed syntax. The remaining install-url tests (env wiring, no shell interpolation, CLI invocation) still pass.

## Test plan

- [x] `npm test` — 51/51 contract tests pass locally.
- [x] `js-yaml` parse of `action.yml` succeeds.
- [x] `bash -n` of the embedded `run_tests_junit` script succeeds.
- [ ] CI green on this PR.
- [ ] After merge: re-run GoodLeap onboard workflow and confirm `postman-test-results` artifact contains `smoke.xml` / `contract.xml`.

## Customer impact

This is the blocker GoodLeap reported in their most recent run (logs_67964070353). Once merged, their next workflow invocation that consumes `@main` will produce JUnit artifacts.

Made with [Cursor](https://cursor.com)