### PR TITLE
feat(spec-source): allow spec-path as the bootstrap source

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Both CLIs support `--dotenv-path` for shell-friendly KEY=VALUE output that can b
 
 The Insights onboarding CLI is not yet available for non-GitHub CI. See the `postman-insights-onboarding-action` repo for updates.
 
-Even when reusing an existing `spec-id`, the composite action still requires `spec-url` because the bootstrap step updates the existing Spec Hub asset from that source of truth.
+Provide exactly one of `spec-url` (HTTPS URL) or `spec-path` (repo-relative path to a checked-out file). When reusing an existing `spec-id`, the bootstrap step still updates the Spec Hub asset from whichever source you pass.
 
 ## Inputs
 
@@ -155,8 +155,8 @@ Even when reusing an existing `spec-id`, the composite action still requires `sp
 | `requester-email` | | Optional workspace invite target. |
 | `workspace-admin-user-ids` | | Optional comma-separated workspace admin IDs. |
 | `workspace-team-id` | | Optional. Numeric sub-team ID for org-mode workspace creation. Required only when the target team is scoped under an organization (org-mode); the Postman API cannot create workspaces at the org level without it. Passed through to `postman-bootstrap-action`. |
-| `spec-url` | | Required registry-backed OpenAPI document URL. |
-| `spec-path` | | Optional repo-root-relative path to the local spec file used for repo metadata generation. |
+| `spec-url` | | HTTPS URL to the OpenAPI document. Provide either `spec-url` or `spec-path`. |
+| `spec-path` | | Repo-root-relative path to the local spec file (e.g. `apis/<service>/openapi.yaml`). Used for repo metadata generation and, when `spec-url` is not set, also as the spec source for the bootstrap step (read directly from the checked-out workspace). Provide either `spec-url` or `spec-path`. |
 | `environments-json` | `["prod"]` | Environment slugs to materialize downstream. |
 | `system-env-map-json` | `{}` | Map of environment slug to system environment ID. |
 | `environment-uids-json` | `{}` | Map of environment slug to existing Postman environment UID. When provided, repo-sync reuses these environments instead of creating new ones. |

--- a/action.yml
+++ b/action.yml
@@ -69,10 +69,10 @@ inputs:
     description: Numeric sub-team ID for org-mode workspace creation. Required by the Postman API when the PMAK's team is scoped under an organization.
     required: false
   spec-url:
-    description: URL to the OpenAPI document to bootstrap.
-    required: true
+    description: HTTPS URL to the OpenAPI document to bootstrap. Provide either spec-url or spec-path.
+    required: false
   spec-path:
-    description: Optional repo-root-relative path to the local spec file for repo metadata generation.
+    description: Repo-root-relative path to the local spec file. Used for repo metadata generation and, when spec-url is not provided, as the spec source for bootstrap (read directly from the checked-out workspace).
     required: false
   environments-json:
     description: JSON array of environment slugs to materialize.
@@ -252,6 +252,7 @@ runs:
         workspace-admin-user-ids: ${{ inputs.workspace-admin-user-ids }}
         workspace-team-id: ${{ inputs.workspace-team-id }}
         spec-url: ${{ inputs.spec-url }}
+        spec-path: ${{ inputs.spec-path }}
         governance-mapping-json: ${{ inputs.governance-mapping-json }}
         postman-api-key: ${{ inputs.postman-api-key }}
         postman-access-token: ${{ inputs.postman-access-token }}

--- a/action.yml
+++ b/action.yml
@@ -252,7 +252,11 @@ runs:
         workspace-admin-user-ids: ${{ inputs.workspace-admin-user-ids }}
         workspace-team-id: ${{ inputs.workspace-team-id }}
         spec-url: ${{ inputs.spec-url }}
-        spec-path: ${{ inputs.spec-path }}
+        # Only forward spec-path to bootstrap when spec-url is empty so that
+        # legacy callers passing both (spec-url for bootstrap, spec-path for
+        # repo metadata) keep working under the bootstrap action's one-of
+        # contract.
+        spec-path: ${{ inputs.spec-url == '' && inputs.spec-path || '' }}
         governance-mapping-json: ${{ inputs.governance-mapping-json }}
         postman-api-key: ${{ inputs.postman-api-key }}
         postman-access-token: ${{ inputs.postman-access-token }}

--- a/action.yml
+++ b/action.yml
@@ -232,7 +232,7 @@ runs:
         esac
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v0.13.0
+      uses: postman-cs/postman-bootstrap-action@main
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -252,12 +252,14 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v0.13.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@main');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v0.13.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v6');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0.9.0');
-      for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
+      // bootstrap is intentionally floating on @main during the spec-path rollout;
+      // re-pin to the next bootstrap tag (v0.14.0) once it ships.
+      for (const step of [repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
     });

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -191,10 +191,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['postman-team-id']?.description).toContain('Explicit');
     });
 
-    it('project-name and spec-url remain required', () => {
+    it('project-name remains required and the spec source is one-of', () => {
       const manifest = loadManifest();
       expect(manifest.inputs['project-name']?.required).toBe(true);
-      expect(manifest.inputs['spec-url']?.required).toBe(true);
+      expect(manifest.inputs['spec-url']?.required).toBe(false);
+      expect(manifest.inputs['spec-path']?.required).toBe(false);
     });
 
     it('defaults integration-backend to bifrost', () => {


### PR DESCRIPTION
Makes spec-url optional and forwards spec-path through to the bootstrap step, so callers with the spec already checked out in the same repo can skip hosting an HTTPS URL entirely. The bootstrap action enforces that exactly one of spec-url or spec-path is provided.

The bootstrap action ref is left at @main; this lands together with postman-bootstrap-action#<spec-path PR> on main.

## Description

<!-- What changed and why -->

## Related Issue

<!-- Fixes #123 or "N/A" -->

## Checklist

- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` run and `dist/` updated (skip for composite action)
- [ ] No secrets or credentials in diff
- [ ] Breaking changes documented (if any)
