### PR TITLE
feat(tests): add skip-built-in-tests input to defer smoke/contract run

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Provide exactly one of `spec-url` (HTTPS URL) or `spec-path` (repo-relative path
 | `committer-name` | `Postman CSE` | Commit author name for generated sync commits. |
 | `committer-email` | `help@postman.com` | Commit author email for generated sync commits. |
 | `enable-insights` | `false` | When `true`, chains `postman-cs/postman-insights-onboarding-action@v0` after bootstrap and repo sync. |
+| `skip-built-in-tests` | `false` | When `true`, skips the built-in smoke/contract Postman CLI run and JUnit artifact upload. Use this when the caller workflow must perform additional post-onboarding setup (e.g. bearer-token injection, mTLS bootstrap, vault-hydrated secrets, dynamic env enrichment) before tests can authenticate, and will run the tests itself afterward. See [Deferring the test run](#deferring-the-test-run) below. |
 | `cluster-name` | | Optional Insights cluster name passed to the downstream Insights onboarding step. |
 | `integration-backend` | `bifrost` | Current public open-alpha backend. |
 | `org-mode` | `false` | When `true`, includes `x-entity-team-id` header in Bifrost proxy calls. Non-org teams must omit this header. |
@@ -179,6 +180,53 @@ Provide exactly one of `spec-url` (HTTPS URL) or `spec-path` (repo-relative path
 | `ssl-client-key` | | Base64-encoded PEM client private key. Passed through to repo-sync. |
 | `ssl-client-passphrase` | | Passphrase for encrypted private key. Passed through to repo-sync. |
 | `ssl-extra-ca-certs` | | Base64-encoded PEM additional CA certificates. Passed through to repo-sync. |
+
+### Deferring the test run
+
+Set `skip-built-in-tests: true` when the caller workflow needs a hook between onboarding and the smoke/contract test run. The action will still bootstrap the workspace, sync the repo, materialize environments, register the mock and monitor, and (optionally) chain Insights — it just won't execute the smoke/contract collections or upload their JUnit artifact. The caller is then responsible for running the tests after whatever post-onboarding setup is required.
+
+Common patterns that need this:
+
+- **Bearer-token / OAuth / Auth0 / Okta / Cognito JWT** — tests require an env variable like `{{bearerToken}}` that has to be minted at run time (often per stage, often short-lived). The caller mints the token, injects it into the active environment, then runs tests.
+- **mTLS / custom-CA bootstrap** — tests require client certs or CA bundles that have to be materialized onto the runner before the Postman CLI can reach the service under test.
+- **Vault-hydrated secrets** — tests reference secrets that live in HashiCorp Vault, AWS Secrets Manager, Doppler, etc., and must be pulled into the env at run time.
+- **Dynamic environment enrichment** — tests require values that are only knowable post-deploy (deployed image tag, ephemeral hostname, feature-flag state, etc.).
+
+Caller pattern when `skip-built-in-tests: true`:
+
+```yaml
+- id: onboard
+  uses: postman-cs/postman-api-onboarding-action@main
+  with:
+    # ...standard inputs...
+    skip-built-in-tests: 'true'
+
+- name: Inject post-onboarding setup
+  # ...mint token / hydrate secrets / fetch certs / etc.,
+  # then PUT updates to the relevant Postman environments
+  # via the API...
+
+- name: Run smoke and contract collections with JUnit output
+  shell: bash
+  env:
+    POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+    COLLECTIONS_JSON: ${{ steps.onboard.outputs.collections-json }}
+    ENVIRONMENT_UIDS_JSON: ${{ steps.onboard.outputs.environment-uids-json }}
+  run: |
+    # postman collection run "$SMOKE"    --reporters cli,junit ...
+    # postman collection run "$CONTRACT" --reporters cli,junit ...
+
+- uses: actions/upload-artifact@v6
+  if: always()
+  with:
+    name: postman-test-results
+    path: ${{ runner.temp }}/postman-junit/*.xml
+    if-no-files-found: ignore
+```
+
+The `collections-json`, `environment-uids-json`, and `workspace-id` outputs of the onboarding step expose everything a caller needs to reproduce the built-in test run on the caller's own terms.
+
+`skip-built-in-tests` defaults to `false`, so existing callers continue to get the built-in smoke/contract run and JUnit artifact upload with no change.
 
 ### Team ID derivation
 

--- a/action.yml
+++ b/action.yml
@@ -244,7 +244,7 @@ runs:
         esac
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@fix/score-static-over-server-prefix
+      uses: postman-cs/postman-bootstrap-action@main
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,18 @@ inputs:
     description: Whether to enable Postman Insights.
     required: false
     default: 'false'
+  skip-built-in-tests:
+    description: |
+      When 'true', skip the built-in smoke and contract Postman CLI test run
+      and JUnit artifact upload that normally happen inside this action. Set
+      this to 'true' when the caller workflow needs to perform additional
+      post-onboarding setup (e.g. bearer-token injection, mTLS bootstrap,
+      vault-hydrated secrets, dynamic env enrichment) before the smoke and
+      contract suites can authenticate successfully, and will run the tests
+      itself afterward. Default 'false' preserves existing behavior for all
+      current callers.
+    required: false
+    default: 'false'
   cluster-name:
     description: Insights cluster name passed to the downstream Insights onboarding step.
     required: false
@@ -232,7 +244,7 @@ runs:
         esac
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@main
+      uses: postman-cs/postman-bootstrap-action@fix/score-static-over-server-prefix
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -304,7 +316,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: run_tests_junit
       name: Run smoke and contract collections with JUnit output
-      if: ${{ steps.bootstrap.outputs.collections-json != '' }}
+      if: ${{ steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' }}
       shell: bash
       continue-on-error: true
       env:
@@ -351,7 +363,7 @@ runs:
         fi
     - id: upload_junit_artifact
       name: Upload Postman JUnit results
-      if: always()
+      if: always() && inputs.skip-built-in-tests != 'true'
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       uses: actions/upload-artifact@v6

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -260,7 +260,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@fix/score-static-over-server-prefix');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@main');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v0.13.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v6');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -169,6 +169,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'committer-name',
         'committer-email',
         'enable-insights',
+        'skip-built-in-tests',
         'cluster-name',
         'integration-backend',
         'org-mode',
@@ -206,6 +207,13 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('defaults enable-insights to false', () => {
       const manifest = loadManifest();
       expect(manifest.inputs['enable-insights']?.default).toBe('false');
+    });
+
+    it('defaults skip-built-in-tests to false so existing callers see no behavior change', () => {
+      const manifest = loadManifest();
+      expect(manifest.inputs['skip-built-in-tests']).toBeDefined();
+      expect(manifest.inputs['skip-built-in-tests']?.required).toBe(false);
+      expect(manifest.inputs['skip-built-in-tests']?.default).toBe('false');
     });
 
     it('has the complete expected output set', () => {
@@ -252,13 +260,14 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@main');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@fix/score-static-over-server-prefix');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v0.13.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v6');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0.9.0');
-      // bootstrap is intentionally floating on @main during the spec-path rollout;
-      // re-pin to the next bootstrap tag (v0.14.0) once it ships.
+      // bootstrap is floating on the fix/score-static-over-server-prefix branch
+      // for the Fox-spec end-to-end test (fulfillment-svc rides this onboarding
+      // branch). Re-pin to the next bootstrap tag once that PR merges.
       for (const step of [repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
@@ -279,6 +288,16 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = manifest.runs.steps.find((s) => s.id === 'insights_onboarding');
       expect(insightsStep?.if).toContain('enable-insights');
       expect(insightsStep?.if).toContain("'true'");
+    });
+
+    it('run_tests_junit and upload_junit_artifact are gated on skip-built-in-tests', () => {
+      const manifest = loadManifest();
+      const junitStep = manifest.runs.steps.find((s) => s.id === 'run_tests_junit');
+      const uploadStep = manifest.runs.steps.find((s) => s.id === 'upload_junit_artifact');
+      expect(junitStep?.if).toContain('skip-built-in-tests');
+      expect(junitStep?.if).toContain("'true'");
+      expect(uploadStep?.if).toContain('skip-built-in-tests');
+      expect(uploadStep?.if).toContain("'true'");
     });
 
     it('maps bootstrap outputs explicitly into repo-sync inputs', () => {


### PR DESCRIPTION
## Summary

Adds a new input `skip-built-in-tests` (default `false`, no behavior change for existing callers). When set to `true`, both the `run_tests_junit` step and its corresponding `upload_junit_artifact` step are skipped, deferring the smoke / contract run to the caller workflow. The caller is then free to perform any post-onboarding setup the freshly-created environments need before running the suites itself.

## Why this exists

The composite currently runs smoke / contract immediately after repo sync, at a fixed position in the composite's step list. That ordering is wrong for any caller that needs to perform post-onboarding setup before the smoke and contract collections can authenticate successfully — tests run against the freshly created environments before the caller has had a chance to populate them.

Real-world patterns that need this hook today or imminently:

- **Bearer / OAuth / Auth0 / Okta / Cognito JWT.** Tests need a variable like `{{bearerToken}}` that's minted at workflow runtime, often per stage, often short-lived. Cannot be pre-populated because the value changes every run.
- **mTLS / custom-CA bootstrap.** Tests need client certs or CA bundles materialized on the runner before the Postman CLI can reach the service under test.
- **Vault-hydrated secrets.** Tests reference secrets in HashiCorp Vault / AWS Secrets Manager / Doppler / etc., pulled into the env at run time.
- **Dynamic environment enrichment.** Tests need values only knowable post-deploy (deployed image tag, ephemeral hostname, feature-flag state, etc.).

In all of those, the composite's current behavior produces a deterministically-failing first test run, which is noise at best and misleading CI signal at worst.

The first real driver is the GoodLeap Directory Service rollout, which mints a fresh bearer token per workflow run and needs to inject it into the active environment before smoke / contract can run. The same shape unlocks the next bearer-auth or vault-backed customer.

## What the change touches

- **`action.yml`** — declare the new input; gate the two JUnit-related steps on `inputs.skip-built-in-tests != 'true'`.
- **`README.md`** — new "Deferring the test run" section under Inputs documenting the caller pattern, with a worked YAML example using `collections-json`, `environment-uids-json`, and `workspace-id` outputs.
- **`tests/contract.test.ts`** — declare the new input in the expected-inputs set; assert default `false`; assert the gating on both JUnit steps.

No changes to `postman-bootstrap-action` or `postman-repo-sync-action` — this is purely a hook surface on the composite.

## Compatibility

Default `false` preserves existing behavior for every current caller. No input renames, no output changes, no step removals — only one new optional input and two `if:` expressions extended with a `&&` clause.

## Test plan

- [x] `npm test` — 55/55 contract tests pass (53 prior + 2 new)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Real-workflow validation: GoodLeap heatmap repo's next run (uses the template at `postman-cs/goodleap-postman-onboarding-template` with `skip-built-in-tests: true` once this merges) — confirms the DS bearer-token injection lands before the smoke / contract run.

## Documentation

- Caller pattern + canonical YAML example in `README.md` → "Deferring the test run".
- Worked example consumes existing outputs only; no new outputs introduced.

## Backwards compatibility & rollout

- No semver-bump rationale: feature addition, opt-in, default off.
- Existing callers see byte-identical behavior.
- Floats safely on `@main` for the GoodLeap template (which pins to `@main`); other callers see no change until they explicitly set the flag.


Made with [Cursor](https://cursor.com)