### PR TITLE
Use Go 1.24 for actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
       - name: Run actionlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           cache: npm
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - run: npm ci
       - run: npm test
       - name: Install actionlint


### PR DESCRIPTION
## Summary
- update actionlint setup to Go 1.24 because actionlint v1.7.11 requires Go >=1.24

## Validation
- actionlint -color=false
