### PR TITLE
Rebrand open alpha to Customer Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # postman-api-onboarding-action
 
-Public open-alpha composite GitHub Action that orchestrates Postman onboarding by chaining:
+Public customer preview composite GitHub Action that orchestrates Postman onboarding by chaining:
 
 - `postman-cs/postman-bootstrap-action@v0`
 - `postman-cs/postman-repo-sync-action@v0`
 - `postman-cs/postman-insights-onboarding-action@v0` (optional, when `enable-insights: true`)
 
-This is the primary partner-facing entrypoint for the open-alpha suite.
+This is the primary partner-facing entrypoint for the customer preview suite.
 
 For existing services, the composite action can target an existing workspace/spec/collection set and can suppress or redirect generated CI workflow output for repos that already have their own pipeline layout.
 
@@ -175,7 +175,7 @@ Provide exactly one of `spec-url` (HTTPS URL) or `spec-path` (repo-relative path
 | `enable-insights` | `false` | When `true`, chains `postman-cs/postman-insights-onboarding-action@v0` after bootstrap and repo sync. |
 | `skip-built-in-tests` | `false` | When `true`, skips the built-in smoke/contract Postman CLI run and JUnit artifact upload. Use this when the caller workflow must perform additional post-onboarding setup (e.g. bearer-token injection, mTLS bootstrap, vault-hydrated secrets, dynamic env enrichment) before tests can authenticate, and will run the tests itself afterward. See [Deferring the test run](#deferring-the-test-run) below. |
 | `cluster-name` | | Optional Insights cluster name passed to the downstream Insights onboarding step. |
-| `integration-backend` | `bifrost` | Current public open-alpha backend. |
+| `integration-backend` | `bifrost` | Current public customer preview backend. |
 | `org-mode` | `false` | When `true`, includes `x-entity-team-id` header in Bifrost proxy calls. Non-org teams must omit this header. |
 | `ssl-client-cert` | | Base64-encoded PEM client certificate for mTLS. Passed through to repo-sync for CI workflow SSL support. |
 | `ssl-client-key` | | Base64-encoded PEM client private key. Passed through to repo-sync. |
@@ -257,9 +257,9 @@ The `postman-api-key` is a Postman API key (PMAK) used for all standard Postman 
 
 > **Note:** The PMAK is a long-lived key tied to your Postman account. It does not require periodic renewal like the `postman-access-token`.
 
-### Obtaining `postman-access-token` (Open Alpha)
+### Obtaining `postman-access-token` (Customer Preview)
 
-> **Open-alpha limitation:** The `postman-access-token` input requires a manually-extracted session token. There is currently no public API to exchange a Postman API key (PMAK) for an access token programmatically. This manual step will be eliminated before GA.
+> **Customer Preview limitation:** The `postman-access-token` input requires a manually-extracted session token. There is currently no public API to exchange a Postman API key (PMAK) for an access token programmatically. This manual step will be eliminated before GA.
 
 The `postman-access-token` is a Postman session token (`x-access-token`) required for internal API operations that the standard PMAK API key cannot perform -- specifically workspace-to-repo git sync (Bifrost), governance group assignment, and system environment associations. Without it, those steps are silently skipped during the onboarding pipeline.
 
@@ -330,11 +330,11 @@ npm install
 npm test
 ```
 
-## Open-Alpha Release Strategy
+## Customer Preview Release Strategy
 
-- Open-alpha channel tags use `v0.x.y`.
+- Customer Preview channel tags use `v0.x.y`.
 - Consumers can pin immutable tags such as `v0.2.0` for reproducibility.
-- Moving tag `v0` is used only as the rolling open-alpha channel.
+- Moving tag `v0` is used only as the rolling customer preview channel.
 
 ## REST Migration Seam
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -1,6 +1,6 @@
 # Release Policy
 
-This document governs how the Postman GitHub Actions open-alpha suite is released and documented.
+This document governs how the Postman GitHub Actions customer preview suite is released and documented.
 
 It applies to these repositories:
 
@@ -14,14 +14,14 @@ It applies to these repositories:
 - Keep each action independently releasable.
 - Keep suite-level guidance in one place without duplicating per-action API details.
 - Prevent composite releases from drifting away from the lower-level actions they depend on.
-- Make consumer version guidance explicit during open alpha.
+- Make consumer version guidance explicit during customer preview.
 
 ## Current state
 
 - Each repository owns its own CI workflow and its own `v*` tag-triggered GitHub release workflow.
 - The composite action references sibling actions through immutable release tags in `action.yml`.
 - Older released composite tags such as `v0.4`, `v0.4.1`, and `v0.5` resolved sibling actions through `@v0` aliases.
-- During the current open-alpha period, the public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier.
+- During the current customer preview period, the public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier.
 
 ## Source of truth
 
@@ -38,7 +38,7 @@ Do not duplicate full input and output tables across repositories. Link to the a
 ## Tag policy
 
 - Immutable release tags use the public `v0.x` or `v0.x.y` pattern.
-- The moving `v0` tag is the rolling open-alpha channel.
+- The moving `v0` tag is the rolling customer preview channel.
 - Never rewrite or force-push an existing release tag.
 - Every public tag should have a corresponding GitHub release with generated notes.
 
@@ -50,7 +50,7 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 ## Composite dependency policy
 
-### Current open-alpha rule
+### Current customer preview rule
 
 The composite action currently depends on:
 
@@ -83,7 +83,7 @@ Release from the bottom up:
 
 ## Compatibility matrix
 
-This matrix describes the current open-alpha release model.
+This matrix describes the current customer preview release model.
 
 | Composite reference used by consumers | Composite repository content | Lower-level dependency references | Result |
 | --- | --- | --- | --- |

--- a/REST_MIGRATION_SEAM.md
+++ b/REST_MIGRATION_SEAM.md
@@ -1,6 +1,6 @@
 # REST Migration Seam
 
-This open-alpha suite uses `integration-backend=bifrost` by default, but callers should not need to change their workflow syntax when the backend moves to REST.
+This customer preview suite uses `integration-backend=bifrost` by default, but callers should not need to change their workflow syntax when the backend moves to REST.
 
 ## Contract Invariants
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: postman-api-onboarding-action
-description: Public open-alpha composite action that orchestrates Postman bootstrap and repo sync.
+description: Public customer preview composite action that orchestrates Postman bootstrap and repo sync.
 inputs:
 
   workspace-id:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@postman-cse/onboarding-api",
   "version": "0.13.1",
-  "description": "Public open-alpha composite Postman API onboarding GitHub Action.",
+  "description": "Public customer preview composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",
     "README.md",

--- a/plans/existing-service-support.md
+++ b/plans/existing-service-support.md
@@ -1,7 +1,7 @@
 # Implementation Plan - Existing Service Support (Idempotency & Safe Sync)
 
 ## 1. 🔍 Analysis & Context
-*   **Objective:** Modify the beta action suite to be idempotent and non-destructive so it can be installed on existing repositories and/or existing Postman workspaces without clobbering existing CI pipelines or creating duplicate Postman assets.
+*   **Objective:** Modify the customer preview action suite to be idempotent and non-destructive so it can be installed on existing repositories and/or existing Postman workspaces without clobbering existing CI pipelines or creating duplicate Postman assets.
 *   **Affected Files:**
     *   `../../postman-bootstrap-action/action.yml`
     *   `../../postman-bootstrap-action/src/index.ts`

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -63,12 +63,12 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(pkg.name).toBe('@postman-cse/onboarding-api');
     });
 
-    it('description references open-alpha, not beta', () => {
+    it('description references customer preview, not beta', () => {
       const manifest = loadManifest();
       const pkg = loadPackageJson();
-      expect(manifest.description).toContain('open-alpha');
+      expect(manifest.description).toContain('customer preview');
       expect(manifest.description).not.toContain('beta');
-      expect(String(pkg.description)).toContain('open-alpha');
+      expect(String(pkg.description)).toContain('customer preview');
       expect(String(pkg.description)).not.toContain('beta');
     });
 
@@ -83,9 +83,9 @@ describe('postman-api-onboarding-action composite contract', () => {
       }
     });
 
-    it('REST_MIGRATION_SEAM.md references open-alpha, not beta', () => {
+    it('REST_MIGRATION_SEAM.md references customer preview, not beta', () => {
       const seam = loadRestMigrationSeam();
-      expect(seam).toContain('open-alpha');
+      expect(seam).toContain('customer preview');
       expect(seam).not.toMatch(/\bbeta\b/i);
     });
 


### PR DESCRIPTION
## Summary
- Replace Open Alpha terminology with Customer Preview language.
- Rename internal action-contract identifiers to Customer Preview where applicable.
- Keep existing v0 release mechanics unchanged while preparing npm/package metadata updates.
- Include rebuilt bundled artifacts where the action package tracks dist integrity.

## Validation
- Local package checks were run during the update pass.
- GitHub checks will validate this branch before merge.
