### PR TITLE
Prepare API 0.13.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Public customer preview composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",
@@ -12,6 +12,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/postman-cs/postman-api-onboarding-action"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Bump API package to 0.13.3 after the v0.13.2 npm publish failed provenance validation.
- Add package repository metadata required by npm provenance checks.

## Validation
- npm test
- npm run typecheck
- npm run lint
