### PR TITLE
Re-pin composite actions and harden release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,35 @@ jobs:
         run: |
           ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
           "$ACTIONLINT_BIN"
+      - name: Verify release tag matches package version
+        run: |
+          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+            echo "::error::Release workflow must run from a v* tag; got $GITHUB_REF"
+            exit 1
+          fi
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
+          ALLOWED_TAGS=("$PKG_VERSION" "$MAJOR")
+          if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
+            ALLOWED_TAGS+=("$MAJOR.$MINOR")
+          fi
+          for ALLOWED_TAG in "${ALLOWED_TAGS[@]}"; do
+            if [ "$TAG_VERSION" = "$ALLOWED_TAG" ]; then
+              exit 0
+            fi
+          done
+          if [ "${#ALLOWED_TAGS[@]}" -eq 3 ]; then
+            EXPECTED="v${ALLOWED_TAGS[0]}, v${ALLOWED_TAGS[1]}, or v${ALLOWED_TAGS[2]}"
+          else
+            EXPECTED="v${ALLOWED_TAGS[0]} or v${ALLOWED_TAGS[1]}"
+          fi
+          echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
+          exit 1
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-      - name: Verify version matches tag
-        run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$TAG" != "$PKG_VERSION" ]; then
-            echo "::error::Tag v$TAG does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
       - uses: actions/setup-node@v5
         with:
           node-version: '24'

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -54,9 +54,9 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v0.13.0`
-- `postman-cs/postman-repo-sync-action@v0.13.0`
-- `postman-cs/postman-insights-onboarding-action@v0.9.0` when Insights is enabled
+- `postman-cs/postman-bootstrap-action@main`
+- `postman-cs/postman-repo-sync-action@v0.13.1`
+- `postman-cs/postman-insights-onboarding-action@v0.9.1` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -282,7 +282,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v0.13.0
+      uses: postman-cs/postman-repo-sync-action@v0.13.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -380,7 +380,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v0.9.0
+      uses: postman-cs/postman-insights-onboarding-action@v0.9.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Public customer preview composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -262,10 +262,10 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(validateStep?.shell).toBe('bash');
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@main');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v0.13.0');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v0.13.1');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0.9.0');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v0.9.1');
       // bootstrap is floating on the fix/score-static-over-server-prefix branch
       // for the Fox-spec end-to-end test (fulfillment-svc rides this onboarding
       // branch). Re-pin to the next bootstrap tag once that PR merges.


### PR DESCRIPTION
## Summary
- Re-pin repo-sync to v0.13.1 and insights to v0.9.1.
- Bump API package to 0.13.4 for a fresh composite release.
- Move package version validation before GitHub release creation and accept supported v0 / zero-patch minor tags.

## Validation
- npm test
- npm run typecheck
- npm run lint
- actionlint -color=false