### PR TITLE
fix: gate release alias publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,50 +40,47 @@ jobs:
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
           IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
-          PUBLISH_TAGS=("$PKG_VERSION")
+          ALIAS_TAGS=("$MAJOR")
           if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
-            PUBLISH_TAGS+=("$MAJOR.$MINOR")
+            ALIAS_TAGS+=("$MAJOR.$MINOR")
           fi
-          for PUBLISH_TAG in "${PUBLISH_TAGS[@]}"; do
-            if [ "$TAG_VERSION" = "$PUBLISH_TAG" ]; then
-              echo "publish_tag=true" >> "$GITHUB_OUTPUT"
+          if [ "$TAG_VERSION" = "$PKG_VERSION" ]; then
+            echo "npm_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          for ALIAS_TAG in "${ALIAS_TAGS[@]}"; do
+            if [ "$TAG_VERSION" = "$ALIAS_TAG" ]; then
+              echo "npm_publish=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Tag v$TAG_VERSION is a rolling customer preview alias for package version $PKG_VERSION; skipping npm publish."
               exit 0
             fi
           done
-          if [ "$TAG_VERSION" = "$MAJOR" ]; then
-            echo "publish_tag=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Tag v$TAG_VERSION is the rolling customer preview channel for package version $PKG_VERSION; skipping publish steps."
-            exit 0
-          fi
-          if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then
-            EXPECTED="v${PUBLISH_TAGS[0]}, v${PUBLISH_TAGS[1]}, or v$MAJOR"
+          if [ "${#ALIAS_TAGS[@]}" -eq 2 ]; then
+            EXPECTED="v$PKG_VERSION, v${ALIAS_TAGS[0]}, or v${ALIAS_TAGS[1]}"
           else
-            EXPECTED="v${PUBLISH_TAGS[0]} or v$MAJOR"
+            EXPECTED="v$PKG_VERSION or v${ALIAS_TAGS[0]}"
           fi
           echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
           exit 1
       - name: Publish GitHub release
-        if: steps.release_tag.outputs.publish_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
       - uses: actions/setup-node@v5
-        if: steps.release_tag.outputs.publish_tag == 'true'
+        if: steps.release_tag.outputs.npm_publish == 'true'
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Publish to npm
-        if: steps.release_tag.outputs.publish_tag == 'true'
+        if: steps.release_tag.outputs.npm_publish == 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Attach npm tarball to release
-        if: steps.release_tag.outputs.publish_tag == 'true'
         run: |
           npm pack
           mv ./*.tgz release.tgz
       - name: Upload tarball
-        if: steps.release_tag.outputs.publish_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: release.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
           "$ACTIONLINT_BIN"
       - name: Verify release tag matches package version
+        id: release_tag
         run: |
           if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
             echo "::error::Release workflow must run from a v* tag; got $GITHUB_REF"
@@ -39,39 +40,50 @@ jobs:
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
           IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
-          ALLOWED_TAGS=("$PKG_VERSION" "$MAJOR")
+          PUBLISH_TAGS=("$PKG_VERSION")
           if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
-            ALLOWED_TAGS+=("$MAJOR.$MINOR")
+            PUBLISH_TAGS+=("$MAJOR.$MINOR")
           fi
-          for ALLOWED_TAG in "${ALLOWED_TAGS[@]}"; do
-            if [ "$TAG_VERSION" = "$ALLOWED_TAG" ]; then
+          for PUBLISH_TAG in "${PUBLISH_TAGS[@]}"; do
+            if [ "$TAG_VERSION" = "$PUBLISH_TAG" ]; then
+              echo "publish_tag=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done
-          if [ "${#ALLOWED_TAGS[@]}" -eq 3 ]; then
-            EXPECTED="v${ALLOWED_TAGS[0]}, v${ALLOWED_TAGS[1]}, or v${ALLOWED_TAGS[2]}"
+          if [ "$TAG_VERSION" = "$MAJOR" ]; then
+            echo "publish_tag=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Tag v$TAG_VERSION is the rolling customer preview channel for package version $PKG_VERSION; skipping publish steps."
+            exit 0
+          fi
+          if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then
+            EXPECTED="v${PUBLISH_TAGS[0]}, v${PUBLISH_TAGS[1]}, or v$MAJOR"
           else
-            EXPECTED="v${ALLOWED_TAGS[0]} or v${ALLOWED_TAGS[1]}"
+            EXPECTED="v${PUBLISH_TAGS[0]} or v$MAJOR"
           fi
           echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
           exit 1
       - name: Publish GitHub release
+        if: steps.release_tag.outputs.publish_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
       - uses: actions/setup-node@v5
+        if: steps.release_tag.outputs.publish_tag == 'true'
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Publish to npm
+        if: steps.release_tag.outputs.publish_tag == 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Attach npm tarball to release
+        if: steps.release_tag.outputs.publish_tag == 'true'
         run: |
           npm pack
           mv ./*.tgz release.tgz
       - name: Upload tarball
+        if: steps.release_tag.outputs.publish_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: release.tgz

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -116,16 +116,21 @@ describe('postman-api-onboarding-action composite contract', () => {
       const releaseStep = steps.find((step) => step.name === 'Publish GitHub release');
       const npmSetupStep = steps.find((step) => step.uses === 'actions/setup-node@v5' && step.with?.['registry-url']);
       const publishStep = steps.find((step) => step.name === 'Publish to npm');
+      const attachStep = steps.find((step) => step.name === 'Attach npm tarball to release');
       const uploadStep = steps.find((step) => step.name === 'Upload tarball');
 
       expect(verifyStep?.id).toBe('release_tag');
-      expect(verifyStep?.run).toContain('publish_tag=true');
-      expect(verifyStep?.run).toContain('publish_tag=false');
-      expect(verifyStep?.run).toContain('rolling customer preview channel');
-      expect(releaseStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
-      expect(npmSetupStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
-      expect(publishStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
-      expect(uploadStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(verifyStep?.run).toContain('ALIAS_TAGS=("$MAJOR")');
+      expect(verifyStep?.run).toContain('ALIAS_TAGS+=("$MAJOR.$MINOR")');
+      expect(verifyStep?.run).toContain('npm_publish=true');
+      expect(verifyStep?.run).toContain('npm_publish=false');
+      expect(verifyStep?.run).toContain('skipping npm publish');
+      expect(verifyStep?.run).not.toContain('publish_tag');
+      expect(releaseStep?.if).toBeUndefined();
+      expect(npmSetupStep?.if).toBe("steps.release_tag.outputs.npm_publish == 'true'");
+      expect(publishStep?.if).toBe("steps.release_tag.outputs.npm_publish == 'true'");
+      expect(attachStep?.if).toBeUndefined();
+      expect(uploadStep?.if).toBeUndefined();
     });
 
     it('README documents all inputs from action.yml', () => {

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -29,6 +29,14 @@ type ActionManifest = {
   outputs: Record<string, { description?: string; value: string }>;
 };
 
+type WorkflowManifest = {
+  jobs: {
+    release: {
+      steps: Step[];
+    };
+  };
+};
+
 const HIDDEN_INPUTS = new Set(['postman-stack']);
 
 function loadManifest(): ActionManifest {
@@ -49,6 +57,12 @@ function loadReadme(): string {
 
 function loadRestMigrationSeam(): string {
   return readFileSync(path.join(repoRoot, 'REST_MIGRATION_SEAM.md'), 'utf8');
+}
+
+function loadReleaseWorkflow(): WorkflowManifest {
+  return parse(
+    readFileSync(path.join(repoRoot, '.github/workflows/release.yml'), 'utf8')
+  ) as WorkflowManifest;
 }
 
 describe('postman-api-onboarding-action composite contract', () => {
@@ -93,6 +107,25 @@ describe('postman-api-onboarding-action composite contract', () => {
       const pkg = loadPackageJson();
       expect(String(pkg.version)).toMatch(/^0\.\d+\.\d+$/);
       expect(String(pkg.version)).not.toMatch(/beta/);
+    });
+
+    it('skips npm publishing for rolling alias release tags', () => {
+      const workflow = loadReleaseWorkflow();
+      const steps = workflow.jobs.release.steps;
+      const verifyStep = steps.find((step) => step.name === 'Verify release tag matches package version');
+      const releaseStep = steps.find((step) => step.name === 'Publish GitHub release');
+      const npmSetupStep = steps.find((step) => step.uses === 'actions/setup-node@v5' && step.with?.['registry-url']);
+      const publishStep = steps.find((step) => step.name === 'Publish to npm');
+      const uploadStep = steps.find((step) => step.name === 'Upload tarball');
+
+      expect(verifyStep?.id).toBe('release_tag');
+      expect(verifyStep?.run).toContain('publish_tag=true');
+      expect(verifyStep?.run).toContain('publish_tag=false');
+      expect(verifyStep?.run).toContain('rolling customer preview channel');
+      expect(releaseStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(npmSetupStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(publishStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(uploadStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
     });
 
     it('README documents all inputs from action.yml', () => {


### PR DESCRIPTION
## Summary
- gate GitHub release/npm publish/tarball upload to immutable publish tags only
- let the rolling v0 customer-preview alias validate successfully without republishing npm
- keep supported zero-patch minor tags publishable

## Validation
- actionlint release workflow
- API: npm test, npm run typecheck, npm run lint