### PR TITLE
fix: gate api release alias publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,47 +40,50 @@ jobs:
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
           IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
-          ALIAS_TAGS=("$MAJOR")
+          PUBLISH_TAGS=("$PKG_VERSION")
           if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
-            ALIAS_TAGS+=("$MAJOR.$MINOR")
+            PUBLISH_TAGS+=("$MAJOR.$MINOR")
           fi
-          if [ "$TAG_VERSION" = "$PKG_VERSION" ]; then
-            echo "npm_publish=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          for ALIAS_TAG in "${ALIAS_TAGS[@]}"; do
-            if [ "$TAG_VERSION" = "$ALIAS_TAG" ]; then
-              echo "npm_publish=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::Tag v$TAG_VERSION is a rolling customer preview alias for package version $PKG_VERSION; skipping npm publish."
+          for PUBLISH_TAG in "${PUBLISH_TAGS[@]}"; do
+            if [ "$TAG_VERSION" = "$PUBLISH_TAG" ]; then
+              echo "publish_tag=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done
-          if [ "${#ALIAS_TAGS[@]}" -eq 2 ]; then
-            EXPECTED="v$PKG_VERSION, v${ALIAS_TAGS[0]}, or v${ALIAS_TAGS[1]}"
+          if [ "$TAG_VERSION" = "$MAJOR" ]; then
+            echo "publish_tag=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Tag v$TAG_VERSION is the rolling customer preview channel for package version $PKG_VERSION; skipping publish steps."
+            exit 0
+          fi
+          if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then
+            EXPECTED="v${PUBLISH_TAGS[0]}, v${PUBLISH_TAGS[1]}, or v$MAJOR"
           else
-            EXPECTED="v$PKG_VERSION or v${ALIAS_TAGS[0]}"
+            EXPECTED="v${PUBLISH_TAGS[0]} or v$MAJOR"
           fi
           echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
           exit 1
       - name: Publish GitHub release
+        if: steps.release_tag.outputs.publish_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
       - uses: actions/setup-node@v5
-        if: steps.release_tag.outputs.npm_publish == 'true'
+        if: steps.release_tag.outputs.publish_tag == 'true'
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Publish to npm
-        if: steps.release_tag.outputs.npm_publish == 'true'
+        if: steps.release_tag.outputs.publish_tag == 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Attach npm tarball to release
+        if: steps.release_tag.outputs.publish_tag == 'true'
         run: |
           npm pack
           mv ./*.tgz release.tgz
       - name: Upload tarball
+        if: steps.release_tag.outputs.publish_tag == 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: release.tgz

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -120,17 +120,14 @@ describe('postman-api-onboarding-action composite contract', () => {
       const uploadStep = steps.find((step) => step.name === 'Upload tarball');
 
       expect(verifyStep?.id).toBe('release_tag');
-      expect(verifyStep?.run).toContain('ALIAS_TAGS=("$MAJOR")');
-      expect(verifyStep?.run).toContain('ALIAS_TAGS+=("$MAJOR.$MINOR")');
-      expect(verifyStep?.run).toContain('npm_publish=true');
-      expect(verifyStep?.run).toContain('npm_publish=false');
-      expect(verifyStep?.run).toContain('skipping npm publish');
-      expect(verifyStep?.run).not.toContain('publish_tag');
-      expect(releaseStep?.if).toBeUndefined();
-      expect(npmSetupStep?.if).toBe("steps.release_tag.outputs.npm_publish == 'true'");
-      expect(publishStep?.if).toBe("steps.release_tag.outputs.npm_publish == 'true'");
-      expect(attachStep?.if).toBeUndefined();
-      expect(uploadStep?.if).toBeUndefined();
+      expect(verifyStep?.run).toContain('publish_tag=true');
+      expect(verifyStep?.run).toContain('publish_tag=false');
+      expect(verifyStep?.run).toContain('rolling customer preview channel');
+      expect(releaseStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(npmSetupStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(publishStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(attachStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
+      expect(uploadStep?.if).toBe("steps.release_tag.outputs.publish_tag == 'true'");
     });
 
     it('README documents all inputs from action.yml', () => {


### PR DESCRIPTION
## Summary
- align API release alias gating with the other actions
- skip GitHub release/npm/tarball publish steps for rolling v0 alias tags
- keep immutable publish tags responsible for npm and release artifacts

## Validation
- actionlint .github/workflows/release.yml
- npm test
- npm run typecheck
- npm run lint