### PR TITLE
feat: pin bootstrap to v1.1.0 for hardened dynamic contract tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -255,7 +255,7 @@ runs:
         esac
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v1.0.0
+      uses: postman-cs/postman-bootstrap-action@v1.1.0
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Public customer preview composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -297,7 +297,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v1.0.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v1.1.0');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v1.0.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');


### PR DESCRIPTION
Bumps the bootstrap pin to v1.1.0, which ships the hardened dynamic contract test generation (schema $defs packing with recursion support, security credential presence checks, runtime parameter and JSON request body validation, OAS encoding object conformance, example validation, and documented CONTRACT_ warning codes for every skip). Released through the gated bootstrap pipeline; live e2e passed on both the PR gate and the central release gate. Contract test updated for the new pin. Version bumped to 1.1.0.