### PR TITLE
feat: pin bootstrap to v1.2.0 for runtime parameter and header assertions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -255,7 +255,7 @@ runs:
         esac
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v1.1.0
+      uses: postman-cs/postman-bootstrap-action@v1.2.0
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Public customer preview composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -297,7 +297,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v1.1.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v1.2.0');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v1.0.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');


### PR DESCRIPTION
Bumps the bootstrap pin to v1.2.0 and the composite version to 1.2.0.

Bootstrap v1.2.0 (released through the live e2e gate) adds runtime validation of array query/header parameters across the decodable serialization styles, scalar path parameter values with server-prefix alignment, required cookie presence plus scalar cookie values, and array-of-scalar response headers, and warns on multipart per-part encoding headers. It also carries the discriminator dispatch, form-field, and JSON-content parameter checks from the prior round.

Release notes: https://github.com/postman-cs/postman-bootstrap-action/releases/tag/v1.2.0
