### PR TITLE
docs: adopt Postman API Onboarding suite naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 One-step Postman onboarding for an API repo: a single composite action that bootstraps a workspace from your OpenAPI spec, syncs generated artifacts back to the repository, and optionally links Postman Insights.
 
+Part of the [Postman API Onboarding suite](https://github.com/postman-cs/postman-api-onboarding-action).
+
 ## Usage
 
 ```yaml
@@ -221,6 +223,18 @@ Running outside GitHub Actions (GitLab CI, Bitbucket Pipelines, Azure DevOps)? T
 Releases use immutable `v1.x.y` tags with `v1` as the rolling customer preview channel; pin an immutable tag for reproducibility. See [RELEASE_POLICY.md](RELEASE_POLICY.md).
 
 ## Resources
+
+### The suite
+
+| Action | Role |
+| --- | --- |
+| [Postman API Onboarding](https://github.com/postman-cs/postman-api-onboarding-action) | Entry point: chains workspace bootstrap, repo sync, and optional Insights linking |
+| [Postman Onboarding: Service Token](https://github.com/postman-cs/postman-resolve-service-token-action) | Mints the service-account access token and team ID |
+| [Postman Onboarding: AWS Spec Discovery](https://github.com/postman-cs/postman-aws-spec-discovery-action) | Discovers and exports API specs from AWS services |
+| [Postman Onboarding: Workspace Bootstrap](https://github.com/postman-cs/postman-bootstrap-action) | Creates the workspace, uploads the spec, generates collections |
+| [Postman Onboarding: Smoke Flow](https://github.com/postman-cs/postman-smoke-flow-action) | Applies a curated flow.yaml to the Smoke collection |
+| [Postman Onboarding: Repo Sync](https://github.com/postman-cs/postman-repo-sync-action) | Exports artifacts into the repo and wires CI, mocks, and monitors |
+| [Postman Onboarding: Insights Linking](https://github.com/postman-cs/postman-insights-onboarding-action) | Links Insights discovered services to the workspace |
 
 - Sibling actions in the onboarding suite:
   - [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action): mints the service-account access token and resolves the team ID

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Postman API Onboarding
-description: One-step Postman onboarding for API repos with workspace bootstrap, repo sync, and Insights linking (customer preview).
+description: 'One-step Postman onboarding: bootstrap, repo sync, optional Insights. Part of the Postman API Onboarding suite.'
 author: Postman
 branding:
   icon: send

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Public customer preview composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -73,10 +73,10 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(pkg.name).toBe('@postman-cse/onboarding-api');
     });
 
-    it('description references customer preview, not beta', () => {
+    it('description carries the suite suffix, not beta', () => {
       const manifest = loadManifest();
       const pkg = loadPackageJson();
-      expect(manifest.description).toContain('customer preview');
+      expect(manifest.description).toContain('Part of the Postman API Onboarding suite');
       expect(manifest.description).not.toContain('beta');
       expect(String(pkg.description)).toContain('customer preview');
       expect(String(pkg.description)).not.toContain('beta');
@@ -693,7 +693,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         for (const match of matches) {
           expect(
             inputNames.has(match[1]),
-            `Step "${step.id}" references non-existent input "${match[1]}"`
+            `Step "${step.id}" references non-existent input "${"$"}{match[1]}"`
           ).toBe(true);
         }
       }
@@ -709,7 +709,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         for (const match of matches) {
           expect(
             stepIds.has(match[1]),
-            `Output "${outputName}" references non-existent step "${match[1]}"`
+            `Output "${outputName}" references non-existent step "${"$"}{match[1]}"`
           ).toBe(true);
         }
       }


### PR DESCRIPTION
Suite naming across the listing surface: title prefix, suite suffix in the action description, suite line under the tagline, and a uniform suite table under Resources. Version bump for the listing-refresh release.