### PR TITLE
Release v1.2.3: telemetry propagation + region fix + child re-pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
           go-version: '1.24'
       - run: npm ci
       - run: npm test
+      - name: Verify composite sibling pins
+        run: node scripts/check-sibling-pins.mjs
       - name: Install actionlint
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
       - name: Run actionlint
@@ -52,7 +54,7 @@ jobs:
           done
           if [ "$TAG_VERSION" = "$MAJOR" ]; then
             echo "npm_publish=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Tag v$TAG_VERSION is the rolling customer preview alias for package version $PKG_VERSION; skipping npm publish."
+            echo "::notice::Tag v$TAG_VERSION is the rolling alias for package version $PKG_VERSION; skipping npm publish."
             exit 0
           fi
           if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       - id: onboard
         uses: postman-cs/postman-api-onboarding-action@v1
         with:
-          project-name: synthetic-telecom
+          project-name: core-payments
           spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
           postman-region: us
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -334,9 +334,12 @@ This composite action runs no code of its own and sends no telemetry. The wired
 child actions (workspace bootstrap, repo sync, and Insights onboarding) each send
 a single anonymous usage event when they complete, so the Postman team can
 measure onboarding adoption across CI systems. See each child action README for
-the exact event contents and the privacy basis.
+the exact event contents and the privacy basis. The `events.pm-cse.dev`
+endpoint is operated by the Postman Customer Success Engineering team, and
+Postman, Inc. processes the events only to measure onboarding adoption in
+aggregate.
 
-The kill switch and endpoint override propagate to every child without extra
+The kill switch and endpoint override are inherited by every child without extra
 configuration. Set one of the following at the workflow or job level and it
 reaches all child action processes:
 
@@ -346,7 +349,7 @@ POSTMAN_ACTIONS_TELEMETRY=off
 DO_NOT_TRACK=1
 ```
 
-`POSTMAN_ACTIONS_TELEMETRY_ENDPOINT` propagates the same way: events go to
+`POSTMAN_ACTIONS_TELEMETRY_ENDPOINT` is inherited the same way: events go to
 `https://events.pm-cse.dev/v1/events` unless you set this variable to a collector
 URL you operate at the workflow or job level.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 [![CI](https://github.com/postman-cs/postman-api-onboarding-action/actions/workflows/ci.yml/badge.svg)](https://github.com/postman-cs/postman-api-onboarding-action/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/postman-cs/postman-api-onboarding-action?sort=semver)](https://github.com/postman-cs/postman-api-onboarding-action/releases) [![npm](https://img.shields.io/npm/v/%40postman-cse%2Fonboarding-api)](https://www.npmjs.com/package/@postman-cse/onboarding-api) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-One-step Postman onboarding for an API repo: a single composite action that bootstraps a workspace from your OpenAPI spec, syncs generated artifacts back to the repository, and optionally links Postman Insights.
+Canonical entrypoint for the Postman API Onboarding suite. Use this composite action when a GitHub repository needs the full onboarding path: workspace bootstrap, OpenAPI upload, collection generation, repository artifact sync, built-in smoke and contract runs, and optional Postman Insights linking.
 
-Part of the [Postman API Onboarding suite](https://github.com/postman-cs/postman-api-onboarding-action).
+## Quick start
 
-## Usage
+This workflow is the happy path for a new API repository. It mints a service-account access token and team ID with [Postman Onboarding: Service Token](https://github.com/postman-cs/postman-resolve-service-token-action), then feeds those outputs into this composite action. The OpenAPI fixture is public, so the workflow is paste-runnable after `POSTMAN_API_KEY` is configured.
 
 ```yaml
+name: Postman API onboarding
+
+on:
+  workflow_dispatch:
+
 jobs:
   onboarding:
     runs-on: ubuntu-latest
@@ -17,45 +22,119 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
-      - uses: postman-cs/postman-api-onboarding-action@v1
+
+      - id: postman-token
+        uses: postman-cs/postman-resolve-service-token-action@v1
         with:
-          project-name: core-payments
-          spec-url: https://example.com/openapi.yaml
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+          postman-region: us
+
+      - id: onboard
+        uses: postman-cs/postman-api-onboarding-action@v1
+        with:
+          project-name: synthetic-telecom
+          spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+          postman-region: us
+          postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+          postman-access-token: ${{ steps.postman-token.outputs.token }}
+          postman-team-id: ${{ steps.postman-token.outputs.team-id }}
+          github-token: ${{ github.token }}
 ```
 
-That run creates (or reuses) a Postman workspace, uploads the spec, generates baseline/smoke/contract collections, materializes environments, registers a mock and monitor, commits exported artifacts to the repo, and runs the smoke and contract collections with JUnit output. See [docs/credentials.md](docs/credentials.md) for how to obtain `postman-api-key` and the optional `postman-access-token` that unlocks governance assignment and workspace-to-repo git linking.
+That run creates or reuses a [Postman workspace](https://learning.postman.com/docs/collaborating-in-postman/using-workspaces/overview/), uploads the spec, generates baseline, smoke, and contract collections, materializes [environments](https://learning.postman.com/docs/use/send-requests/variables/managing-environments/), registers a [mock server](https://learning.postman.com/docs/design-apis/mock-apis/set-up-mock-servers/) and [monitor](https://learning.postman.com/docs/monitoring-your-api/intro-monitors/), commits exported artifacts to the repository, and runs the smoke and contract collections with JUnit output.
+
+Use `postman-region: eu` for [EU data residency](https://learning.postman.com/docs/administration/enterprise/about-eu-data-residency/). Keep the same region on the service-token step and the composite action.
+
+## Which action should I use?
+
+| Scenario | Start with | Why |
+| --- | --- | --- |
+| Full GitHub onboarding from an OpenAPI spec | [Postman API Onboarding](https://github.com/postman-cs/postman-api-onboarding-action) | Canonical suite entrypoint. Chains bootstrap, repo sync, tests, and optional Insights. |
+| Mint an access token and resolve team ID | [Postman Onboarding: Service Token](https://github.com/postman-cs/postman-resolve-service-token-action) | Primary credential path for this composite action. Run it before onboarding. |
+| Discover an OpenAPI spec from AWS | [Postman Onboarding: AWS Spec Discovery](https://github.com/postman-cs/postman-aws-spec-discovery-action) | Produces a spec URL or artifact that can feed this composite action. |
+| Provision only the Postman workspace and collections | [Postman Onboarding: Workspace Bootstrap](https://github.com/postman-cs/postman-bootstrap-action) | Lower-level action for custom pipelines that do not want repo sync. |
+| Apply a curated Smoke flow | [Postman Onboarding: Smoke Flow](https://github.com/postman-cs/postman-smoke-flow-action) | Standalone flow update for the canonical Smoke collection. |
+| Sync generated artifacts without the composite wrapper | [Postman Onboarding: Repo Sync](https://github.com/postman-cs/postman-repo-sync-action) | Lower-level artifact, environment, mock, monitor, and CI workflow sync. |
+| Link an existing workspace to Insights | [Postman Onboarding: Insights Linking](https://github.com/postman-cs/postman-insights-onboarding-action) | Lower-level Insights service-to-workspace binding. |
+
+## Scenario guide
+
+- [Quick start](#quick-start): new GitHub API repository with service-token credential resolution.
+- [Governance and environments](#governance-and-environments): workspace ownership, governance groups, environments, and runtime URLs.
+- [Existing service refresh](#existing-service-refresh): reuse known Postman asset IDs while updating the spec and generated artifacts.
+- [Protected branches](#protected-branch-repos-commit-only-plus-pr): create a sync commit for a pull request instead of pushing directly.
+- [Insights linking](#insights-linking): connect discovered services to the onboarded workspace.
+- [AWS spec discovery](#aws-spec-discovery): discover the spec first, then feed the result into this composite action.
+- [Deferred tests](#deferred-tests): skip the built-in Postman CLI run when the caller workflow must enrich auth first.
+- [Support](SUPPORT.md), [security](SECURITY.md), and [release policy](RELEASE_POLICY.md): marketplace support, vulnerability reporting, and version guidance.
+
+## Credentials and region
+
+| Need | Inputs | Recommended source |
+| --- | --- | --- |
+| Postman API operations | `postman-api-key` | Store a [Postman API key](https://learning.postman.com/docs/reference/postman-api/authentication/) as `POSTMAN_API_KEY`. This key bootstraps workspaces, specs, collections, environments, mocks, and monitors. |
+| Governance, workspace linking, and Insights | `postman-access-token`, `postman-team-id` | Run `postman-resolve-service-token-action` before this action and pass `steps.<id>.outputs.token` plus `steps.<id>.outputs.team-id`. |
+| Legacy access-token fallback | `postman-access-token` | Read the access token from the [Postman CLI credential store](https://learning.postman.com/docs/postman-cli/postman-cli-auth/) populated by `postman login` only when the service-token action cannot be used. Do not use copied web-session credentials in shared workflows. |
+| Data residency | `postman-region` | Use `us` by default or `eu` for [EU data residency](https://learning.postman.com/docs/administration/enterprise/about-eu-data-residency/). Set the same region on service-token and onboarding steps. |
+| Repository writes | `github-token`, `gh-fallback-token` | Use `GITHUB_TOKEN` for normal commits and variables. Add a fallback token only when workflow-file APIs require it. |
+| Credential identity checks | `credential-preflight` | Use `warn` for advisory checks or `enforce` to fail before workspace creation when credentials resolve to different parent orgs. |
+
+See [docs/credentials.md](docs/credentials.md) for detailed credential setup.
+
+### Authentication matrix
+
+| Credential or permission | Where it appears | Required for | Source and permissions | Expiration behavior |
+| --- | --- | --- | --- | --- |
+| Service-account PMAK | `POSTMAN_API_KEY`, or `POSTMAN_SERVICE_ACCOUNT_API_KEY` in AWS examples | Standard Postman API operations and service-token minting | GitHub secret backed by a [Postman service account](https://learning.postman.com/docs/administration/service-accounts/) API key | Long-lived until rotated in Postman and updated in CI |
+| Generated access token | `steps.postman-token.outputs.token`, passed as `postman-access-token` | Governance, workspace linking, repo sync integration calls, and Insights | Minted by `postman-resolve-service-token-action` from the service-account PMAK | Fresh per workflow run; avoid storing unless a scheduled refresh workflow intentionally writes `POSTMAN_ACCESS_TOKEN` |
+| Team ID | `steps.postman-token.outputs.team-id`, passed as `postman-team-id`; direct bootstrap workflows may use `workspace-team-id` | Org-mode integration headers and sub-team workspace creation | Emitted by `postman-resolve-service-token-action`, or stored as a repository/org variable when the sub-team is fixed | Not a secret and does not expire, but update it if the target Postman team changes |
+| GitHub token | `github-token`, `gh-fallback-token`, or `${{ github.token }}` | Artifact commits, repository variables, generated workflow files, and optional secret writes | `GITHUB_TOKEN` needs `contents: write`; generated workflow updates need `actions: write`; repository secret writes need a PAT or GitHub App token with secrets write permission | `GITHUB_TOKEN` is job-scoped; PAT/App token lifetime follows its issuer policy |
+| AWS OIDC | `permissions: id-token: write` plus `aws-actions/configure-aws-credentials` | AWS Spec Discovery before onboarding | GitHub OIDC role assumption with least-privilege read permissions for API Gateway, AppSync, EventBridge, Lambda, or the providers you enable | Temporary AWS credentials for the job; no static AWS key is stored |
+
+Keep service-token, onboarding, and downstream actions on the same `postman-region`. Use `credential-preflight: enforce` when a workflow supplies both a PMAK and access token and must fail before creating assets if they resolve to different parent orgs.
 
 ## Examples
 
-### Basic onboarding with governance and environments
+The examples below include credential resolution when they need `postman-access-token` or `postman-team-id`.
+
+### Governance and environments
 
 ```yaml
 - uses: actions/checkout@v5
+- id: postman-token
+  uses: postman-cs/postman-resolve-service-token-action@v1
+  with:
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-region: us
+
 - uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
     domain: core-banking
     domain-code: AF
-    requester-email: owner@example.com
-    workspace-admin-user-ids: 101,102
-    spec-url: https://example.com/openapi.yaml
+    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    postman-region: us
     environments-json: '["prod","stage"]'
-    system-env-map-json: '{"prod":"uuid-prod","stage":"uuid-stage"}'
     governance-mapping-json: '{"core-banking":"Core Banking"}'
-    env-runtime-urls-json: '{"prod":"https://api.example.com"}'
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
-    postman-access-token: ${{ secrets.POSTMAN_ACCESS_TOKEN }}
+    postman-access-token: ${{ steps.postman-token.outputs.token }}
+    postman-team-id: ${{ steps.postman-token.outputs.team-id }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
     gh-fallback-token: ${{ secrets.GH_FALLBACK_TOKEN }}
 ```
 
-### Rerunning against an existing service
+### Existing service refresh
 
 Target an existing workspace/spec/collection set and suppress generated CI workflow output for repos that already have their own pipeline layout. `spec-url` (or `spec-path`) is still required because the bootstrap step updates the Spec Hub asset from source on every run.
 
 ```yaml
 - uses: actions/checkout@v5
+- id: postman-token
+  uses: postman-cs/postman-resolve-service-token-action@v1
+  with:
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-region: us
+
 - uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
@@ -64,9 +143,12 @@ Target an existing workspace/spec/collection set and suppress generated CI workf
     baseline-collection-id: col-baseline
     smoke-collection-id: col-smoke
     contract-collection-id: col-contract
-    spec-url: https://example.com/openapi.yaml
+    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    postman-region: us
     generate-ci-workflow: false
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-access-token: ${{ steps.postman-token.outputs.token }}
+    postman-team-id: ${{ steps.postman-token.outputs.team-id }}
 ```
 
 ### Protected-branch repos: commit-only plus PR
@@ -78,7 +160,8 @@ For repositories whose branch protection requires all changes to land through pu
   uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
-    spec-url: https://example.com/openapi.yaml
+    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    postman-region: us
     repo-write-mode: commit-only
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -86,42 +169,57 @@ For repositories whose branch protection requires all changes to land through pu
 
 The full pattern, including sync-branch creation and programmatic PR opening, is in [docs/protected-branch-workflows.md](docs/protected-branch-workflows.md).
 
-### Enabling Insights
+### Insights linking
 
 When `enable-insights: true`, the action chains `postman-cs/postman-insights-onboarding-action@v1` after bootstrap and repo sync, using the workspace from bootstrap plus the first environment from `environments-json`.
 
 ```yaml
 - uses: actions/checkout@v5
-- uses: postman-cs/postman-api-onboarding-action@v1
-  with:
-    project-name: core-payments
-    spec-url: https://example.com/openapi.yaml
-    enable-insights: true
-    cluster-name: my-cluster
-    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
-    postman-access-token: ${{ secrets.POSTMAN_ACCESS_TOKEN }}
-```
-
-### Chaining with resolve-service-token
-
-Instead of manually extracting a session token, mint the access token and resolve the team ID with [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action) and feed its outputs into onboarding:
-
-```yaml
-- uses: actions/checkout@v5
-- id: token
+- id: postman-token
   uses: postman-cs/postman-resolve-service-token-action@v1
   with:
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-region: us
+
 - uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
-    spec-url: https://example.com/openapi.yaml
+    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    postman-region: us
+    enable-insights: true
+    cluster-name: my-cluster
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
-    postman-access-token: ${{ steps.token.outputs.token }}
-    postman-team-id: ${{ steps.token.outputs.team-id }}
+    postman-access-token: ${{ steps.postman-token.outputs.token }}
+    postman-team-id: ${{ steps.postman-token.outputs.team-id }}
 ```
 
-### Deferring the built-in test run
+### AWS spec discovery
+
+Run AWS spec discovery before this composite action when the OpenAPI document should come from API Gateway or another AWS source. Feed the exported spec path into `spec-path`.
+
+```yaml
+- uses: actions/checkout@v5
+- id: postman-token
+  uses: postman-cs/postman-resolve-service-token-action@v1
+  with:
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-region: us
+
+- id: discover-spec
+  uses: postman-cs/postman-aws-spec-discovery-action@v1
+  with:
+    aws-region: us-east-1
+- uses: postman-cs/postman-api-onboarding-action@v1
+  with:
+    project-name: core-payments
+    spec-path: ${{ steps.discover-spec.outputs.spec-path }}
+    postman-region: us
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-access-token: ${{ steps.postman-token.outputs.token }}
+    postman-team-id: ${{ steps.postman-token.outputs.team-id }}
+```
+
+### Deferred tests
 
 Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onboarding setup (bearer-token minting, mTLS bootstrap, vault-hydrated secrets, dynamic env enrichment) before the smoke and contract suites can authenticate, then run the collections itself using the `collections-json` and `environment-uids-json` outputs. The full caller pattern is in [docs/deferred-tests.md](docs/deferred-tests.md).
 
@@ -159,21 +257,20 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `governance-mapping-json` | JSON map of business domain to governance group name. | no | `{}` |
 | `env-runtime-urls-json` | JSON map of environment slug to runtime base URL. | no | `{}` |
 | `postman-api-key` | Postman API key used for bootstrap and sync operations. | yes |  |
-| `postman-access-token` | Postman access token used for Bifrost and governance integration. | no |  |
-| `credential-preflight` | Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created; off skips the identity probes entirely (the reactive error guidance still applies). | no | `warn` |
-| `postman-team-id` | Explicit Postman team ID override for org-mode Bifrost calls. | no |  |
-| `postman-stack` | Postman stack profile. | no | `prod` |
+| `postman-access-token` | Postman access token used for governance, workspace linking, and integration operations. | no |  |
+| `credential-preflight` | Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created. | no | `warn` |
+| `postman-team-id` | Explicit Postman team ID override for org-mode integration calls. | no |  |
+| `postman-region` | Postman data residency region for public API and Postman CLI calls. One of us or eu. | no | `us` |
 | `github-token` | GitHub token used for repo variables and generated commits. | no |  |
 | `gh-fallback-token` | Fallback GitHub token for variable and workflow-file APIs. | no |  |
 | `repo-write-mode` | Repo mutation mode for generated assets and workflow files. | no | `commit-and-push` |
 | `current-ref` | Explicit ref override for detached checkout push semantics. | no |  |
-| `committer-name` | Commit author name for generated sync commits. | no | `Postman CSE` |
-| `committer-email` | Commit author email for generated sync commits. | no | `help@postman.com` |
+| `committer-name` | Commit author name for generated sync commits. | no | `Postman` |
+| `committer-email` | Commit author email for generated sync commits. | no | `support@postman.com` |
 | `enable-insights` | Whether to enable Postman Insights. | no | `false` |
 | `skip-built-in-tests` | When 'true', skip the built-in smoke and contract Postman CLI test run and JUnit artifact upload that normally happen inside this action. Set this to 'true' when the caller workflow needs to perform additional post-onboarding setup (e.g. bearer-token injection, mTLS bootstrap, vault-hydrated secrets, dynamic env enrichment) before the smoke and contract suites can authenticate successfully, and will run the tests itself afterward. Default 'false' preserves existing behavior for all current callers. | no | `false` |
 | `cluster-name` | Insights cluster name passed to the downstream Insights onboarding step. | no |  |
-| `integration-backend` | Integration backend used to coordinate onboarding phases. | no | `bifrost` |
-| `org-mode` | Whether the Postman team uses org-mode. When true, x-entity-team-id header is included in Bifrost proxy calls. Non-org teams must omit this header. | no | `false` |
+| `org-mode` | Whether the Postman team uses org-mode. When true, x-entity-team-id is included on integration calls. Non-org teams must omit this header. | no | `false` |
 | `ssl-client-cert` | Base64-encoded PEM client certificate for mTLS. Passed through to repo-sync for CI workflow generation. | no |  |
 | `ssl-client-key` | Base64-encoded PEM client private key. Passed through to repo-sync. | no |  |
 | `ssl-client-passphrase` | Passphrase for encrypted private key. Passed through to repo-sync. | no |  |
@@ -187,7 +284,6 @@ Tables are generated from `action.yml` by `npm run docs:tables`.
 <!-- outputs-table:start -->
 | Name | Description |
 | --- | --- |
-| `integration-backend` | Resolved integration backend for the onboarding run. |
 | `workspace-id` | Postman workspace ID. |
 | `workspace-url` | Postman workspace URL. |
 | `spec-id` | Uploaded Postman spec ID. |
@@ -212,40 +308,50 @@ Tables are generated from `action.yml` by `npm run docs:tables`.
 
 This is a composite action, the primary partner-facing entrypoint of the Postman onboarding suite. It chains three sibling actions in order:
 
-1. **Bootstrap** (`postman-cs/postman-bootstrap-action`) creates or reuses the workspace, uploads the spec, and generates baseline, smoke, and contract collections.
-2. **Repo sync** (`postman-cs/postman-repo-sync-action`) exports collection artifacts into the repository (Postman Collection v3 multi-file YAML), materializes environments, registers the mock server and smoke monitor, and optionally generates a CI workflow. Bootstrap outputs are explicitly mapped into repo-sync inputs in `action.yml`.
-3. **Insights** (`postman-cs/postman-insights-onboarding-action`, only when `enable-insights: true`) links discovered services to the workspace.
+1. **Bootstrap** (`postman-cs/postman-bootstrap-action`) creates or reuses the workspace, uploads the spec to [Spec Hub](https://learning.postman.com/docs/design-apis/specifications/overview/), and [generates](https://learning.postman.com/docs/design-apis/specifications/generate-collections/) baseline, smoke, and contract collections.
+2. **Repo sync** (`postman-cs/postman-repo-sync-action`) exports [Postman Collection v3](https://learning.postman.com/docs/use/use-collections/collections-schemas/) multi-file YAML artifacts into the repository, materializes environments, registers the mock server and smoke monitor, and optionally generates a CI workflow. Bootstrap outputs are explicitly mapped into repo-sync inputs in `action.yml`.
+3. **Insights** (`postman-cs/postman-insights-onboarding-action`, only when `enable-insights: true`) links [Postman Insights](https://learning.postman.com/docs/insights/overview/) discovered services to the workspace.
 
-Between repo sync and Insights, the action runs the generated smoke and contract collections with the Postman CLI and uploads JUnit results as a workflow artifact (skippable via `skip-built-in-tests`). Inputs are backend-neutral and kebab-case; the default `integration-backend` is `bifrost`. Full contract details, output mapping, and phase outcome semantics are in [docs/contract.md](docs/contract.md).
+Between repo sync and Insights, the action runs the generated smoke and contract collections with the [Postman CLI](https://learning.postman.com/docs/postman-cli/postman-cli-collections/) and uploads [JUnit results](https://learning.postman.com/docs/postman-cli/postman-cli-reporters/) as a workflow artifact (skippable via `skip-built-in-tests`). Inputs are backend-neutral and kebab-case. Full contract details, output mapping, and phase outcome semantics are in [docs/contract.md](docs/contract.md).
 
 Running outside GitHub Actions (GitLab CI, Bitbucket Pipelines, Azure DevOps)? The bootstrap and repo-sync CLIs cover that: see [docs/non-github-ci.md](docs/non-github-ci.md).
 
-Releases use immutable `v1.x.y` tags with `v1` as the rolling customer preview channel; pin an immutable tag for reproducibility. See [RELEASE_POLICY.md](RELEASE_POLICY.md).
+Releases use immutable `v1.x.y` tags with `v1` as the rolling release channel; pin an immutable tag for reproducibility. See [RELEASE_POLICY.md](RELEASE_POLICY.md).
 
 ## Resources
 
-### The suite
-
-| Action | Role |
-| --- | --- |
-| [Postman API Onboarding](https://github.com/postman-cs/postman-api-onboarding-action) | Entry point: chains workspace bootstrap, repo sync, and optional Insights linking |
-| [Postman Onboarding: Service Token](https://github.com/postman-cs/postman-resolve-service-token-action) | Mints the service-account access token and team ID |
-| [Postman Onboarding: AWS Spec Discovery](https://github.com/postman-cs/postman-aws-spec-discovery-action) | Discovers and exports API specs from AWS services |
-| [Postman Onboarding: Workspace Bootstrap](https://github.com/postman-cs/postman-bootstrap-action) | Creates the workspace, uploads the spec, generates collections |
-| [Postman Onboarding: Smoke Flow](https://github.com/postman-cs/postman-smoke-flow-action) | Applies a curated flow.yaml to the Smoke collection |
-| [Postman Onboarding: Repo Sync](https://github.com/postman-cs/postman-repo-sync-action) | Exports artifacts into the repo and wires CI, mocks, and monitors |
-| [Postman Onboarding: Insights Linking](https://github.com/postman-cs/postman-insights-onboarding-action) | Links Insights discovered services to the workspace |
-
-- Sibling actions in the onboarding suite:
-  - [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action): mints the service-account access token and resolves the team ID
-  - [postman-bootstrap-action](https://github.com/postman-cs/postman-bootstrap-action): workspace, spec upload, collection generation
-  - [postman-repo-sync-action](https://github.com/postman-cs/postman-repo-sync-action): artifact export, environments, mocks, monitors, CI templates
-  - [postman-insights-onboarding-action](https://github.com/postman-cs/postman-insights-onboarding-action): Insights-to-workspace linking
-  - [postman-smoke-flow-action](https://github.com/postman-cs/postman-smoke-flow-action): applies a curated flow.yaml to the canonical Smoke collection
-  - [postman-aws-spec-discovery-action](https://github.com/postman-cs/postman-aws-spec-discovery-action): AWS API and spec discovery
 - npm package: [@postman-cse/onboarding-api](https://www.npmjs.com/package/@postman-cse/onboarding-api)
 - Docs in this repo: [credentials](docs/credentials.md), [contract and output mapping](docs/contract.md), [protected-branch workflows](docs/protected-branch-workflows.md), [deferred tests](docs/deferred-tests.md), [non-GitHub CI](docs/non-github-ci.md)
-- Postman references: [Postman API](https://learning.postman.com/docs/developer/postman-api/intro-api/), [Postman CLI](https://learning.postman.com/docs/postman-cli/postman-cli-overview/), [Postman Insights](https://learning.postman.com/docs/insights/insights-overview/)
+- Marketplace docs: [support](SUPPORT.md), [security](SECURITY.md), [release policy](RELEASE_POLICY.md)
+- Postman API and auth references: [Postman API](https://learning.postman.com/docs/reference/postman-api/intro-api/), [API authentication](https://learning.postman.com/docs/reference/postman-api/authentication/), [service accounts](https://learning.postman.com/docs/administration/service-accounts/), [EU data residency](https://learning.postman.com/docs/administration/enterprise/about-eu-data-residency/)
+- Postman workspace resources: [workspaces](https://learning.postman.com/docs/collaborating-in-postman/using-workspaces/overview/), [Spec Hub](https://learning.postman.com/docs/design-apis/specifications/overview/), [import a specification](https://learning.postman.com/docs/design-apis/specifications/import-a-specification/), [generate collections](https://learning.postman.com/docs/design-apis/specifications/generate-collections/), [collections](https://learning.postman.com/docs/use/use-collections/overview/), [environments](https://learning.postman.com/docs/use/send-requests/variables/managing-environments/), [mock servers](https://learning.postman.com/docs/design-apis/mock-apis/set-up-mock-servers/), [monitors](https://learning.postman.com/docs/monitoring-your-api/intro-monitors/)
+- Postman CI and governance references: [Postman CLI collection runs](https://learning.postman.com/docs/postman-cli/postman-cli-collections/), [CLI reporters](https://learning.postman.com/docs/postman-cli/postman-cli-reporters/), [API governance rules](https://learning.postman.com/docs/api-governance/configurable-rules/configuring-api-governance-rules/), [Postman Insights](https://learning.postman.com/docs/insights/overview/)
+
+
+## Telemetry
+
+This composite action runs no code of its own and sends no telemetry. The wired
+child actions (workspace bootstrap, repo sync, and Insights onboarding) each send
+a single anonymous usage event when they complete, so the Postman team can
+measure onboarding adoption across CI systems. See each child action README for
+the exact event contents and the privacy basis.
+
+The kill switch and endpoint override propagate to every child without extra
+configuration. Set one of the following at the workflow or job level and it
+reaches all child action processes:
+
+```sh
+POSTMAN_ACTIONS_TELEMETRY=off
+# or the cross-tool standard
+DO_NOT_TRACK=1
+```
+
+`POSTMAN_ACTIONS_TELEMETRY_ENDPOINT` propagates the same way: events go to
+`https://events.pm-cse.dev/v1/events` unless you set this variable to a collector
+URL you operate at the workflow or job level.
+
+Step-level inputs on the child steps do not strip workflow or job environment, so
+no per-child configuration is needed to opt out.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
         uses: postman-cs/postman-api-onboarding-action@v1
         with:
           project-name: synthetic-telecom
-          spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+          spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
           postman-region: us
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
           postman-access-token: ${{ steps.postman-token.outputs.token }}
@@ -112,7 +112,7 @@ The examples below include credential resolution when they need `postman-access-
     project-name: core-payments
     domain: core-banking
     domain-code: AF
-    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
     postman-region: us
     environments-json: '["prod","stage"]'
     governance-mapping-json: '{"core-banking":"Core Banking"}'
@@ -143,7 +143,7 @@ Target an existing workspace/spec/collection set and suppress generated CI workf
     baseline-collection-id: col-baseline
     smoke-collection-id: col-smoke
     contract-collection-id: col-contract
-    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
     postman-region: us
     generate-ci-workflow: false
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
@@ -160,7 +160,7 @@ For repositories whose branch protection requires all changes to land through pu
   uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
-    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
     postman-region: us
     repo-write-mode: commit-only
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
@@ -184,7 +184,7 @@ When `enable-insights: true`, the action chains `postman-cs/postman-insights-onb
 - uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
-    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
     postman-region: us
     enable-insights: true
     cluster-name: my-cluster
@@ -330,7 +330,7 @@ Releases use immutable `v1.x.y` tags with `v1` as the rolling release channel; p
 
 ## Telemetry
 
-This composite action runs no code of its own and sends no telemetry. The wired
+This composite action emits no telemetry of its own. The wired
 child actions (workspace bootstrap, repo sync, and Insights onboarding) each send
 a single anonymous usage event when they complete, so the Postman team can
 measure onboarding adoption across CI systems. See each child action README for

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Releases use immutable `v1.x.y` tags with `v1` as the rolling release channel; p
 
 This composite action emits no telemetry of its own. The wired
 child actions (workspace bootstrap, repo sync, and Insights onboarding) each send
-a single anonymous usage event when they complete, so the Postman team can
+a single non-identifying usage event when they complete, so the Postman team can
 measure onboarding adoption across CI systems. See each child action README for
 the exact event contents and the privacy basis. The `events.pm-cse.dev`
 endpoint is operated by the Postman Customer Success Engineering team, and

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -1,6 +1,6 @@
 # Release Policy
 
-This document governs how the Postman GitHub Actions customer preview suite is released and documented.
+This document governs how the Postman API Onboarding GitHub Actions suite is released and documented.
 
 It applies to these repositories:
 
@@ -17,14 +17,13 @@ It applies to these repositories:
 - Keep each action independently releasable.
 - Keep suite-level guidance in one place without duplicating per-action API details.
 - Prevent composite releases from drifting away from the lower-level actions they depend on.
-- Make consumer version guidance explicit during customer preview.
+- Make consumer version guidance explicit for marketplace and direct GitHub Action usage.
 
 ## Current state
 
 - Each repository owns its own CI workflow and its own `v*` tag-triggered GitHub release workflow.
 - The composite action references sibling actions through immutable release tags in `action.yml`.
-- Older released composite tags such as `v0.4`, `v0.4.1`, and `v0.5` resolved sibling actions through `@v0` aliases.
-- During the current customer preview period, the public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier.
+- The public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier.
 
 ## Source of truth
 
@@ -39,36 +38,38 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 ## Tag policy
 
-- Immutable release tags use the public `v1.x` or `v1.x.y` pattern. Older `v0.x.y` tags remain published and immutable.
-- The moving `v1` tag is the rolling customer preview channel. The retired `v0` alias is frozen at the last v0 release and no longer moves.
+- Immutable release tags use the public `v1.x.y` pattern.
+- The moving `v1` tag is the rolling release channel.
 - Never rewrite or force-push an existing release tag.
 - Every public tag should have a corresponding GitHub release with generated notes.
 
 ## Consumer guidance
 
-- Recommend immutable tags such as `@v1.0.0` in examples and onboarding docs.
-- Treat `@v1` as a convenience channel, never as a reproducible reference.
+- Use `@v1` in quick-start examples when the goal is a short marketplace install path.
+- Recommend immutable tags such as `@v1.x.y` for reproducible production workflows.
+- Treat `@v1` as a convenience channel, not as a reproducible reference.
 - For security-sensitive environments, document that SHA pinning is the strongest option.
 
 ## Composite dependency policy
 
-### Current customer preview rule
+### Current rule
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v1.0.0`
-- `postman-cs/postman-repo-sync-action@v1.0.0`
-- `postman-cs/postman-insights-onboarding-action@v1.0.0` when Insights is enabled
+- `postman-cs/postman-bootstrap-action@v1.2.3`
+- `postman-cs/postman-repo-sync-action@v1.0.4`
+- `postman-cs/postman-insights-onboarding-action@v1.0.3` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 
-### Target policy before GA
+### Composite release rule
 
 The composite action references immutable sibling tags inside `action.yml`. Therefore:
 
 - Every composite release must record the exact sibling tags it uses.
 - Any change to a pinned sibling version requires a new composite release.
 - The compatibility matrix in this document and the README must be updated in the same change.
+- The release workflow must run `scripts/check-sibling-pins.mjs` so the composite cannot ship stale sibling refs.
 
 ## Release order
 
@@ -97,7 +98,7 @@ For those repos, pull requests targeting `main` must pass the central live e2e
 gate before approval or merge. The PR workflow dispatches
 `postman-cs/postman-actions-e2e` with the PR head SHA pinned for the changed
 action and waits for the correlated run to succeed. Branches must live in the
-target repository so GitHub can provide the internal e2e dispatch secret; forked
+target repository so GitHub can provide the central e2e dispatch secret; forked
 PRs cannot satisfy the required merge gate until moved to an in-repo branch.
 
 For those repos, immutable publishing tags must pass the central live e2e gate
@@ -107,7 +108,7 @@ exact action tag pinned, waits for the correlated workflow run to conclude
 successfully, and only then publishes. The release log must include the e2e run
 URL, correlation id, and conclusion.
 
-The rolling `v1` customer-preview alias validates locally but skips npm publish
+The rolling `v1` alias validates locally but skips npm publish
 and the live e2e gate.
 
 The composite action, Insights onboarding, and AWS spec discovery are not
@@ -117,12 +118,21 @@ the repo's release workflow blocks on that gate.
 
 ## Compatibility matrix
 
-This matrix describes the current customer preview release model.
+This matrix describes the current release model.
 
 | Composite reference used by consumers | Composite repository content | Lower-level dependency references | Result |
 | --- | --- | --- | --- |
 | `postman-api-onboarding-action@v1` | Rolling composite alias | Immutable sibling tags in the current composite content | Rolling composite channel with pinned siblings per composite revision |
 | Immutable composite release | Immutable composite repo tag | Immutable sibling tags | Fully reproducible |
+
+## Marketplace documentation surface
+
+Every composite release should keep these public docs aligned:
+
+- `README.md`: canonical suite entrypoint, happy-path workflow, scenario navigation, generated input and output tables, and version guidance.
+- `SUPPORT.md`: where users file bugs, support requests, and troubleshooting details.
+- `SECURITY.md`: vulnerability reporting and credential-handling expectations.
+- `RELEASE_POLICY.md`: maintainer release sequencing, tag policy, and compatibility guidance.
 
 ## Maintainer release checklist
 
@@ -132,18 +142,19 @@ Before pushing a new release tag:
 2. Run the repository's CI-equivalent checks locally when practical.
 3. Confirm the README examples still reflect the recommended consumer tag.
 4. Confirm `README.md` and `RELEASE_POLICY.md` still match the actual composite wiring.
-5. If lower-level actions changed behavior, verify whether the composite repo needs a coordinated release.
-6. For a live-e2e-gated repo, confirm `E2E_DISPATCH_TOKEN` is configured and the
+5. Confirm `SUPPORT.md` and `SECURITY.md` still match the current support and vulnerability-reporting paths.
+6. If lower-level actions changed behavior, verify whether the composite repo needs a coordinated release.
+7. For a live-e2e-gated repo, confirm `E2E_DISPATCH_TOKEN` is configured and the
    release workflow records a successful central e2e run before publish.
-7. Push the immutable release tag.
-8. Confirm that the matching GitHub release was published with generated notes.
+8. Push the immutable release tag.
+9. Confirm that the matching GitHub release was published with generated notes.
 
 ## What changes the policy
 
 Update this document whenever one of the following changes:
 
 - The tag naming strategy changes.
-- The composite action switches from floating aliases to immutable internal pins.
+- The composite action switches from floating aliases to immutable sibling pins.
 - The release order changes because suite dependencies changed.
 - A new action joins or leaves the suite.
 - The README's compatibility guidance would otherwise become inaccurate.

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -47,7 +47,7 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 - Use `@v1` in quick-start examples when the goal is a short marketplace install path.
 - Recommend immutable tags such as `@v1.x.y` for reproducible production workflows.
-- Treat `@v1` as a convenience channel, not as a reproducible reference.
+- Treat `@v1` as a convenience channel; pin an immutable `@v1.x.y` tag or commit SHA when you need a reproducible reference.
 - For security-sensitive environments, document that SHA pinning is the strongest option.
 
 ## Composite dependency policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,19 @@
 
 Only the latest `v1.x.y` release (tracked by the rolling `v1` alias) receives security fixes. Older tags remain published for reproducibility and are never retroactively modified.
 
+## Credential Handling
+
+This composite action accepts credentials and forwards them to the lower-level onboarding actions it chains.
+
+| Credential | Purpose | Guidance |
+| --- | --- | --- |
+| `postman-api-key` | Standard Postman API operations, including workspace, spec, collection, environment, mock, and monitor management. | Store it as a GitHub secret. Never echo it in caller workflow steps. |
+| `postman-access-token` | Governance, workspace linking, and Insights operations. | Prefer `postman-resolve-service-token-action` and pass its `token` output into this action. |
+| `postman-team-id` | Explicit team context for org-mode integration calls. | Prefer `postman-resolve-service-token-action` and pass its `team-id` output into this action. |
+| `postman-region` | Data residency region for Postman API and Postman CLI calls. | Use `us` or `eu`; keep the same region on service-token and onboarding steps. |
+
+The Postman CLI credential store created by `postman login` is a legacy fallback for `postman-access-token`. Service-token minting remains the primary CI path. Do not use copied web-session credentials in shared workflows.
+
 ## Reporting a Vulnerability
 
 Please do not open a public issue for security reports.
@@ -11,9 +24,10 @@ Please do not open a public issue for security reports.
 - Preferred: use GitHub private vulnerability reporting on this repository (Security tab, "Report a vulnerability").
 - Alternative: email [security@postman.com](mailto:security@postman.com) and mention the repository name.
 
-You should receive an acknowledgement within five business days. Please include reproduction steps, the action version tag, and any relevant (redacted) workflow logs.
+You should receive an acknowledgement within five business days. Please include reproduction steps, the action version tag or SHA, the Postman region, and any relevant redacted workflow logs.
 
 ## Scope Notes
 
 - This action handles Postman API keys and access tokens. Both are masked in logs by the action itself; never echo them in your own workflow steps.
-- Reports about secrets you exposed in your own workflow configuration are out of scope; rotate the credential in Postman immediately.
+- This composite action chains sibling actions. If the issue appears only when the composite action wires those steps together, report it here. If it is isolated to a lower-level action, mention that action in the report.
+- Reports about secrets exposed in your own workflow configuration are out of scope for a code fix. Rotate the credential in Postman immediately.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,29 @@
+# Support
+
+Use this repository for issues with the composite Postman API Onboarding action: workflow wiring, input and output behavior, phase outcomes, marketplace documentation, and the end-to-end GitHub Actions path.
+
+## Where to Get Help
+
+| Need | Where to go |
+| --- | --- |
+| Bug, documentation issue, or feature request for the composite action | Open a GitHub issue in this repository. |
+| Security vulnerability or suspected secret exposure in action behavior | Follow [SECURITY.md](SECURITY.md). Do not open a public issue. |
+| General Postman product support | Use your normal Postman support channel. |
+| Lower-level action failure outside the composite path | File in the specific action repository, or file here if the failure only happens through this composite action. |
+
+## Before Opening an Issue
+
+Include the details that let maintainers reproduce the workflow without exposing secrets:
+
+- Action reference used, such as `postman-cs/postman-api-onboarding-action@v1` or an immutable `v1.x.y` tag.
+- Whether the workflow used `postman-resolve-service-token-action` for `postman-access-token` and `postman-team-id`.
+- `postman-region` and whether `org-mode` was enabled.
+- Redacted workflow YAML for the failing steps.
+- Phase outputs when available: `bootstrap-outcome`, `repo-sync-outcome`, and `insights-outcome`.
+- Redacted logs around the first failure.
+
+Never paste Postman API keys, access tokens, service-token outputs, GitHub tokens, cookies, or private OpenAPI documents into issues.
+
+## Version Guidance
+
+Use `@v1` for the shortest marketplace install path. Use an immutable `@v1.x.y` tag or a commit SHA when reproducibility matters. See [RELEASE_POLICY.md](RELEASE_POLICY.md) for release sequencing and tag policy.

--- a/action.yml
+++ b/action.yml
@@ -105,17 +105,21 @@ inputs:
     description: Postman API key used for bootstrap and sync operations.
     required: true
   postman-access-token:
-    description: Postman access token used for Bifrost and governance integration.
+    description: Postman access token used for governance, workspace linking, and integration operations.
     required: false
   credential-preflight:
-    description: "Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created; off skips the identity probes entirely (the reactive error guidance still applies)."
+    description: "Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created."
     required: false
     default: warn
   postman-team-id:
-    description: Explicit Postman team ID override for org-mode Bifrost calls.
+    description: Explicit Postman team ID override for org-mode integration calls.
     required: false
+  postman-region:
+    description: Postman data residency region for public API and Postman CLI calls. One of us or eu.
+    required: false
+    default: us
   postman-stack:
-    description: Postman stack profile.
+    description: 'Postman stack profile. Use prod for Marketplace workflows; EU data residency requires prod.'
     required: false
     default: prod
   github-token:
@@ -134,11 +138,11 @@ inputs:
   committer-name:
     description: Commit author name for generated sync commits.
     required: false
-    default: Postman CSE
+    default: Postman
   committer-email:
     description: Commit author email for generated sync commits.
     required: false
-    default: help@postman.com
+    default: support@postman.com
   enable-insights:
     description: Whether to enable Postman Insights.
     required: false
@@ -163,7 +167,7 @@ inputs:
     required: false
     default: bifrost
   org-mode:
-    description: Whether the Postman team uses org-mode. When true, x-entity-team-id header is included in Bifrost proxy calls. Non-org teams must omit this header.
+    description: Whether the Postman team uses org-mode. When true, x-entity-team-id is included on integration calls. Non-org teams must omit this header.
     required: false
     default: 'false'
   ssl-client-cert:
@@ -240,11 +244,13 @@ runs:
   using: composite
   steps:
     - id: validate_postman_stack
-      name: Validate Postman stack
+      name: Validate Postman stack and region
       shell: bash
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_REGION: ${{ inputs.postman-region }}
         POSTMAN_STACK: ${{ inputs.postman-stack }}
+        CREDENTIAL_PREFLIGHT: ${{ inputs.credential-preflight }}
       run: |
         case "$POSTMAN_STACK" in
           prod|beta) ;;
@@ -253,9 +259,27 @@ runs:
             exit 1
             ;;
         esac
+        case "$POSTMAN_REGION" in
+          us|eu) ;;
+          *)
+            echo "::error::postman-region must be one of: us, eu; got: $POSTMAN_REGION"
+            exit 1
+            ;;
+        esac
+        if [ "$POSTMAN_STACK" = "beta" ] && [ "$POSTMAN_REGION" = "eu" ]; then
+          echo "::error::postman-region=eu is only supported with postman-stack=prod."
+          exit 1
+        fi
+        case "$CREDENTIAL_PREFLIGHT" in
+          warn|enforce) ;;
+          *)
+            echo "::error::credential-preflight must be one of: warn, enforce; got: $CREDENTIAL_PREFLIGHT"
+            exit 1
+            ;;
+        esac
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v1.2.0
+      uses: postman-cs/postman-bootstrap-action@v1.2.3
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -288,10 +312,11 @@ runs:
         postman-access-token: ${{ inputs.postman-access-token }}
         credential-preflight: ${{ inputs.credential-preflight }}
         integration-backend: ${{ inputs.integration-backend }}
+        postman-region: ${{ inputs.postman-region }}
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v1.0.0
+      uses: postman-cs/postman-repo-sync-action@v1.0.4
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -320,6 +345,7 @@ runs:
         gh-fallback-token: ${{ inputs.gh-fallback-token }}
         org-mode: ${{ inputs.org-mode }}
         integration-backend: ${{ inputs.integration-backend }}
+        postman-region: ${{ inputs.postman-region }}
         monitor-id: ${{ inputs.monitor-id }}
         mock-url: ${{ inputs.mock-url }}
         monitor-cron: ${{ inputs.monitor-cron }}
@@ -338,6 +364,7 @@ runs:
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
+        POSTMAN_REGION: ${{ inputs.postman-region }}
         COLLECTIONS_JSON: ${{ steps.bootstrap.outputs.collections-json }}
         ENVIRONMENT_UIDS_JSON: ${{ steps.repo_sync.outputs.environment-uids-json }}
         POSTMAN_CLI_INSTALL_URL: ${{ inputs.postman-stack == 'beta' && 'https://dl-cli.pstmn-beta.io/install/unix.sh' || 'https://dl-cli.pstmn.io/install/unix.sh' }}
@@ -355,7 +382,11 @@ runs:
           exit 1
         fi
 
-        postman login --with-api-key "$POSTMAN_API_KEY" >/dev/null 2>&1 || true
+        if [ "$POSTMAN_REGION" = "eu" ]; then
+          postman login --with-api-key "$POSTMAN_API_KEY" --region eu >/dev/null 2>&1 || true
+        else
+          postman login --with-api-key "$POSTMAN_API_KEY" >/dev/null 2>&1 || true
+        fi
 
         SMOKE=$(printf '%s' "$COLLECTIONS_JSON"    | jq -r '.smoke // empty')
         CONTRACT=$(printf '%s' "$COLLECTIONS_JSON" | jq -r '.contract // empty')
@@ -390,7 +421,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v1.0.0
+      uses: postman-cs/postman-insights-onboarding-action@v1.0.3
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -404,4 +435,5 @@ runs:
         credential-preflight: ${{ inputs.credential-preflight }}
         postman-team-id: ${{ inputs.postman-team-id }}
         github-token: ${{ inputs.github-token }}
+        postman-region: ${{ inputs.postman-region }}
         postman-stack: ${{ inputs.postman-stack }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Postman API Onboarding
-description: 'One-step Postman onboarding: bootstrap, repo sync, optional Insights. Part of the Postman API Onboarding suite.'
+description: 'Full Postman onboarding in one step: workspace bootstrap, repo sync, and optional Insights linking. Part of the Postman API Onboarding suite.'
 author: Postman
 branding:
   icon: send

--- a/action.yml
+++ b/action.yml
@@ -163,9 +163,8 @@ inputs:
     description: Insights cluster name passed to the downstream Insights onboarding step.
     required: false
   integration-backend:
-    description: Integration backend used to coordinate onboarding phases.
+    description: Advanced/internal. Integration backend used to coordinate onboarding phases; leave unset to use the default.
     required: false
-    default: bifrost
   org-mode:
     description: Whether the Postman team uses org-mode. When true, x-entity-team-id is included on integration calls. Non-org teams must omit this header.
     required: false

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,5 +2,6 @@ export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'header-max-length': [2, 'always', 100],
+    'body-max-line-length': [0, 'always', 100],
   },
 };

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -2,12 +2,13 @@
 
 ## Contract
 
-- Default `integration-backend` is `bifrost`.
+- The integration backend is selected by the action defaults.
 - Inputs are backend-neutral and kebab-case.
 - Bootstrap outputs are explicitly mapped into repo-sync inputs in `action.yml`.
 - Final outputs are surfaced from the two lower-level actions without exposing internal step mode controls.
 - Collection artifacts are exported in the Postman Collection v3 multi-file YAML directory structure (produced during the repo-sync step).
-- Workspace-to-repository linking supports both GitHub and GitLab (cloud and self-hosted) URLs via Bifrost.
+- Workspace-to-repository linking supports both GitHub and GitLab (cloud and self-hosted) URLs.
+- `credential-preflight` accepts `warn` and `enforce` only; there is no public opt-out mode.
 
 ## Output mapping
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -33,7 +33,7 @@ Primary path: mint the token with [postman-resolve-service-token-action](https:/
 - uses: postman-cs/postman-api-onboarding-action@v1
   with:
     project-name: core-payments
-    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
     postman-region: us
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
     postman-access-token: ${{ steps.postman_token.outputs.token }}

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -2,33 +2,55 @@
 
 ## Obtaining `postman-api-key`
 
-The `postman-api-key` is a Postman API key (PMAK) used for all standard Postman API operations: creating workspaces, uploading specs, generating collections, exporting artifacts, and managing environments.
+The `postman-api-key` is a [Postman API key](https://learning.postman.com/docs/reference/postman-api/authentication/) (PMAK) used for all standard Postman API operations: creating workspaces, uploading specs, generating collections, exporting artifacts, and managing environments.
+
+For CI, use a service-account PMAK. The same key can run the standard Postman API calls and mint the short-lived access token used by integration steps. See Postman's [service accounts documentation](https://learning.postman.com/docs/administration/service-accounts/) for setup and assignment guidance.
 
 To generate one:
 
-1. Open the Postman desktop app or web UI.
-2. Go to **Settings** (gear icon) > **Account Settings** > **API Keys**.
-3. Click **Generate API Key**, give it a label, and copy the key (starts with `PMAK-`).
-4. Set it as a GitHub secret:
+1. Create or select a [Postman service account](https://learning.postman.com/docs/administration/service-accounts/) for the onboarding automation.
+2. Generate a PMAK for that service account and copy the key (starts with `PMAK-`).
+3. Set it as a GitHub secret:
    ```bash
    gh secret set POSTMAN_API_KEY --repo <owner>/<repo>
    ```
 
-> **Note:** The PMAK is a long-lived key tied to your Postman account. It does not require periodic renewal like the `postman-access-token`.
+> **Note:** A personal user PMAK can still work for standard API operations, but service-account PMAKs are the supported CI credential because they can mint fresh access tokens at run time.
 
-## Obtaining `postman-access-token` (Customer Preview)
+## Obtaining `postman-access-token`
 
-> **Customer Preview limitation:** The `postman-access-token` input requires a manually-extracted session token. There is currently no public API to exchange a Postman API key (PMAK) for an access token programmatically. This manual step will be eliminated before GA. The [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action) can mint this token from a service-account PMAK; see the README Examples.
+The `postman-access-token` is required for onboarding operations that the standard PMAK API key cannot perform, specifically workspace-to-repo git sync, governance group assignment, and system environment associations. Without it, those integration steps are skipped during the onboarding pipeline.
 
-The `postman-access-token` is a Postman session token (`x-access-token`) required for internal API operations that the standard PMAK API key cannot perform, specifically workspace-to-repo git sync (Bifrost), governance group assignment, and system environment associations. Without it, those steps are silently skipped during the onboarding pipeline.
+Primary path: mint the token with [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action) and feed its outputs into onboarding:
 
-To obtain and configure the token:
+```yaml
+- id: postman_token
+  uses: postman-cs/postman-resolve-service-token-action@v1
+  with:
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-region: us
 
-1. **Log in via the Postman CLI** (requires a browser):
+- uses: postman-cs/postman-api-onboarding-action@v1
+  with:
+    project-name: core-payments
+    spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+    postman-region: us
+    postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+    postman-access-token: ${{ steps.postman_token.outputs.token }}
+    postman-team-id: ${{ steps.postman_token.outputs.team-id }}
+```
+
+For [EU data residency](https://learning.postman.com/docs/administration/enterprise/about-eu-data-residency/), change both `postman-region` values to `eu`.
+
+User/session access tokens from `postman login` are deprecated for CI. They expire, can belong to a different parent org than the PMAK, and should only be used as a legacy fallback while migrating to service accounts.
+
+Legacy fallback:
+
+1. **Log in via the [Postman CLI](https://learning.postman.com/docs/postman-cli/postman-cli-auth/)**:
    ```bash
    postman login
    ```
-   This opens a browser window for Postman's PKCE OAuth flow. Complete the sign-in.
+   Complete the interactive sign-in.
 
 2. **Extract the access token** from the CLI credential store:
    ```bash
@@ -45,18 +67,26 @@ To obtain and configure the token:
    ```
    Paste the token value when prompted.
 
-> **Important:** This token is session-scoped and will expire. When it does, operations that depend on it (workspace linking, governance, system environment associations) will silently degrade. You will need to repeat the login and secret update process. There is no automated refresh mechanism.
+> **Important:** The fallback token must come from the Postman CLI credential store populated by `postman login`. Do not paste copied cookies, DevTools values, or manually harvested session credentials into CI secrets.
 
-> **Note:** `postman login --with-api-key` stores a PMAK, which is not the session token these APIs require. You must use the interactive browser login.
+> **Note:** `postman login --with-api-key` stores a PMAK, which is not the access token these APIs require.
 
 ## Team ID derivation
 
-Pass `postman-team-id` only when a downstream org-mode Bifrost call needs an explicit team header. When omitted, the lower-level actions can leave `x-entity-team-id` unset and let Bifrost resolve team context from the access token.
+The service-token action emits `team-id` with the minted token. Pass it to `postman-team-id` only when a downstream org-mode integration call needs an explicit team header. When omitted, the lower-level actions can leave `x-entity-team-id` unset and let Postman resolve team context from the access token.
 
-## Org-mode Bifrost headers
+## Org-mode team headers
 
-The underlying actions include the `x-entity-team-id` header on Bifrost proxy calls only when an explicit team override is supplied. For non-org-mode tokens, omit `postman-team-id` so the header stays unset.
+The underlying actions include the `x-entity-team-id` header on integration calls only when an explicit team override is supplied. For non-org-mode tokens, omit `postman-team-id` so the header stays unset.
+
+Postman's [roles and permissions](https://learning.postman.com/docs/administration/roles-and-permissions/) and [manage roles](https://learning.postman.com/docs/administration/managing-your-team/team-members/manage-roles/) docs are the source of truth for team and workspace assignment behavior.
+
+## Credential preflight
+
+`credential-preflight` defaults to `warn`, which logs when `postman-api-key` and `postman-access-token` resolve to different parent orgs. Set it to `enforce` to fail before workspace creation. The public values are `warn` and `enforce`; there is no opt-out mode.
 
 ## API key auto-creation
 
 `postman-repo-sync-action` and `postman-insights-onboarding-action` can create or rotate a PMAK from `postman-access-token` when they encounter a clear auth failure, but this composite still requires `postman-api-key` up front because `postman-bootstrap-action` cannot start without it.
+
+For org-wide API key expiration, revocation, and exposed-key handling, see Postman's [managing API keys](https://learning.postman.com/docs/administration/managing-your-team/managing-api-keys/) guide.

--- a/docs/non-github-ci.md
+++ b/docs/non-github-ci.md
@@ -29,7 +29,7 @@ Run bootstrap first and save its JSON output:
 ```bash
 postman-bootstrap \
   --project-name "my-api" \
-  --spec-url "https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml" \
+  --spec-url "https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml" \
   --postman-api-key "$POSTMAN_API_KEY" \
   --postman-access-token "$POSTMAN_ACCESS_TOKEN" \
   --postman-team-id "$POSTMAN_TEAM_ID" \

--- a/docs/non-github-ci.md
+++ b/docs/non-github-ci.md
@@ -2,19 +2,38 @@
 
 On GitHub Actions, use the composite action as documented in the [README](../README.md). The CLI entry points are for GitLab CI, Bitbucket Pipelines, Azure DevOps, and other CI systems.
 
-Install both CLIs globally:
+Install the CLIs globally:
 
 ```bash
-npm install -g postman-bootstrap-action postman-repo-sync-action
+npm install -g @postman-cse/onboarding-bootstrap @postman-cse/onboarding-repo-sync @postman-cse/onboarding-resolve-service-token
 ```
+
+For CI jobs that need governance, workspace linking, or system environment association, mint a service-account access token before bootstrap:
+
+```bash
+POSTMAN_REGION="${POSTMAN_REGION:-us}"
+
+postman-resolve-service-token \
+  --postman-api-key "$POSTMAN_API_KEY" \
+  --postman-region "$POSTMAN_REGION" \
+  > postman-token.json
+
+POSTMAN_ACCESS_TOKEN=$(jq -r '.token' postman-token.json)
+POSTMAN_TEAM_ID=$(jq -r '.["team-id"]' postman-token.json)
+```
+
+Use `POSTMAN_REGION=eu` for EU data residency and pass the same region to every Postman CLI in the pipeline.
 
 Run bootstrap first and save its JSON output:
 
 ```bash
 postman-bootstrap \
   --project-name "my-api" \
-  --spec-url "https://registry.example.com/specs/my-api/openapi.yaml" \
+  --spec-url "https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml" \
   --postman-api-key "$POSTMAN_API_KEY" \
+  --postman-access-token "$POSTMAN_ACCESS_TOKEN" \
+  --postman-team-id "$POSTMAN_TEAM_ID" \
+  --postman-region "$POSTMAN_REGION" \
   --result-json ./bootstrap-result.json
 ```
 
@@ -37,9 +56,12 @@ postman-repo-sync \
   --smoke-collection-id "$SMOKE_COLLECTION_ID" \
   --contract-collection-id "$CONTRACT_COLLECTION_ID" \
   --postman-api-key "$POSTMAN_API_KEY" \
+  --postman-access-token "$POSTMAN_ACCESS_TOKEN" \
+  --postman-team-id "$POSTMAN_TEAM_ID" \
+  --postman-region "$POSTMAN_REGION" \
   --result-json ./sync-result.json
 ```
 
 Both CLIs support `--dotenv-path` for shell-friendly KEY=VALUE output that can be sourced with `source ./bootstrap.env`.
 
-The Insights onboarding CLI is not yet available for non-GitHub CI. See the [postman-insights-onboarding-action](https://github.com/postman-cs/postman-insights-onboarding-action) repo for updates.
+For Insights linking outside GitHub Actions, install `@postman-cse/onboarding-insights` and run `postman-insights-onboard` after the service has been discovered by Insights. See [postman-insights-onboarding-action/docs/cli.md](https://github.com/postman-cs/postman-insights-onboarding-action/blob/main/docs/cli.md) for the required service, workspace, and environment inputs.

--- a/docs/protected-branch-workflows.md
+++ b/docs/protected-branch-workflows.md
@@ -24,6 +24,11 @@ This enables idempotent reruns: reuse existing Postman assets (workspace ID, col
 ## Example
 
 ```yaml
+name: Postman protected-branch onboarding
+
+on:
+  workflow_dispatch:
+
 jobs:
   onboarding:
     runs-on: ubuntu-latest
@@ -38,14 +43,21 @@ jobs:
           BRANCH="postman-sync/$(date -u +%Y%m%d-%H%M%S)"
           git switch -c "$BRANCH"
           echo "SYNC_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+      - id: postman-token
+        uses: postman-cs/postman-resolve-service-token-action@v1
+        with:
+          postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
+          postman-region: us
       - id: onboard
         uses: postman-cs/postman-api-onboarding-action@v1
         with:
           project-name: core-payments
-          spec-url: https://example.com/openapi.yaml
+          spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+          postman-region: us
           repo-write-mode: commit-only
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
-          postman-access-token: ${{ secrets.POSTMAN_ACCESS_TOKEN }}
+          postman-access-token: ${{ steps.postman-token.outputs.token }}
+          postman-team-id: ${{ steps.postman-token.outputs.team-id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Open PR if artifacts changed
         if: steps.onboard.outputs.commit-sha != ''
@@ -59,3 +71,5 @@ jobs:
             --title "chore: sync Postman artifacts" \
             --body "Automated Postman onboarding artifact sync."
 ```
+
+For EU data residency, change both `postman-region` values to `eu`.

--- a/docs/protected-branch-workflows.md
+++ b/docs/protected-branch-workflows.md
@@ -52,7 +52,7 @@ jobs:
         uses: postman-cs/postman-api-onboarding-action@v1
         with:
           project-name: core-payments
-          spec-url: https://gist.githubusercontent.com/jaredboynton/a839de57db2c3c90b8f75906c56b00ee/raw/openapi.yaml
+          spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml
           postman-region: us
           repo-write-mode: commit-only
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}

--- a/examples/core-payments-openapi.yaml
+++ b/examples/core-payments-openapi.yaml
@@ -1,0 +1,139 @@
+openapi: 3.0.3
+info:
+  title: Core Payments API
+  version: 1.0.0
+  description: >-
+    Example OpenAPI definition used by the Postman API onboarding actions to
+    demonstrate spec upload, collection generation, and workspace provisioning.
+    Replace it with your own service's OpenAPI document.
+servers:
+  - url: https://api.example.com/v1
+    description: Production
+paths:
+  /payments:
+    get:
+      operationId: listPayments
+      summary: List payments
+      tags: [Payments]
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of payments to return.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: status
+          in: query
+          description: Filter payments by lifecycle status.
+          required: false
+          schema:
+            type: string
+            enum: [pending, settled, failed]
+      responses:
+        '200':
+          description: A page of payments.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Payment'
+                  next_cursor:
+                    type: string
+                    nullable: true
+    post:
+      operationId: createPayment
+      summary: Create a payment
+      tags: [Payments]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentRequest'
+      responses:
+        '201':
+          description: The created payment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '400':
+          description: The request was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /payments/{paymentId}:
+    get:
+      operationId: getPayment
+      summary: Retrieve a payment
+      tags: [Payments]
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          description: Unique identifier of the payment.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The requested payment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '404':
+          description: No payment matched the identifier.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Payment:
+      type: object
+      required: [id, amount, currency, status]
+      properties:
+        id:
+          type: string
+          description: Unique payment identifier.
+        amount:
+          type: integer
+          description: Amount in the smallest currency unit (for example, cents).
+        currency:
+          type: string
+          description: ISO 4217 currency code.
+          example: USD
+        status:
+          type: string
+          enum: [pending, settled, failed]
+        created_at:
+          type: string
+          format: date-time
+    PaymentRequest:
+      type: object
+      required: [amount, currency]
+      properties:
+        amount:
+          type: integer
+          minimum: 1
+        currency:
+          type: string
+          example: USD
+        description:
+          type: string
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "1.2.2",
-  "description": "Public customer preview composite Postman API onboarding GitHub Action.",
+  "version": "1.2.3",
+  "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",
     "README.md"

--- a/scripts/check-sibling-pins.mjs
+++ b/scripts/check-sibling-pins.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/* global console, process */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const requiredPins = [
+  { repo: 'postman-bootstrap-action', stepId: 'bootstrap' },
+  { repo: 'postman-repo-sync-action', stepId: 'repo_sync' },
+  { repo: 'postman-insights-onboarding-action', stepId: 'insights_onboarding' }
+];
+
+function semverFromTag(tag) {
+  const match = tag.match(/^v(1)\.(\d+)\.(\d+)$/);
+  if (!match) return undefined;
+  return match.slice(1).map(Number);
+}
+
+function compareSemver(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
+}
+
+function latestV1Tag(repo) {
+  const remote = 'https://github.com/postman-cs/' + repo + '.git';
+  const output = execFileSync('git', ['ls-remote', '--tags', remote, 'refs/tags/v1.*'], {
+    encoding: 'utf8'
+  });
+  const tags = output
+    .split('\n')
+    .map((line) => line.trim().split('/').pop())
+    .filter(Boolean)
+    .map((tag) => ({ tag, semver: semverFromTag(tag) }))
+    .filter((entry) => entry.semver);
+  if (tags.length === 0) {
+    throw new Error('No immutable v1 tags found for ' + repo);
+  }
+  tags.sort((left, right) => compareSemver(left.semver, right.semver));
+  return tags.at(-1).tag;
+}
+
+const manifest = parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8'));
+const failures = [];
+
+for (const { repo, stepId } of requiredPins) {
+  const step = manifest.runs.steps.find((candidate) => candidate.id === stepId);
+  const actual = step?.uses;
+  const latest = latestV1Tag(repo);
+  const expected = 'postman-cs/' + repo + '@' + latest;
+  if (actual !== expected) {
+    failures.push(stepId + ': expected ' + expected + ', found ' + (actual || '<missing>'));
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Composite sibling pins are stale:');
+  for (const failure of failures) {
+    console.error('- ' + failure);
+  }
+  process.exit(1);
+}
+
+console.log('Composite sibling pins match the latest immutable v1 tags.');

--- a/scripts/render-action-tables.mjs
+++ b/scripts/render-action-tables.mjs
@@ -19,6 +19,9 @@ const MARKERS = {
   outputs: ['<!-- outputs-table:start -->', '<!-- outputs-table:end -->'],
 };
 
+const HIDDEN_INPUTS = new Set(['integration-backend', 'postman-stack']);
+const HIDDEN_OUTPUTS = new Set(['integration-backend']);
+
 function cell(text) {
   return String(text ?? '')
     .replace(/\s+/g, ' ')
@@ -27,7 +30,7 @@ function cell(text) {
 }
 
 export function renderInputsTable(manifest) {
-  const rows = Object.entries(manifest.inputs).map(([name, spec]) => {
+  const rows = Object.entries(manifest.inputs).filter(([name]) => !HIDDEN_INPUTS.has(name)).map(([name, spec]) => {
     const required = spec.required ? 'yes' : 'no';
     const def = spec.default !== undefined && spec.default !== '' ? `\`${cell(spec.default)}\`` : '';
     return `| \`${name}\` | ${cell(spec.description)} | ${required} | ${def} |`;
@@ -36,7 +39,7 @@ export function renderInputsTable(manifest) {
 }
 
 export function renderOutputsTable(manifest) {
-  const rows = Object.entries(manifest.outputs).map(
+  const rows = Object.entries(manifest.outputs).filter(([name]) => !HIDDEN_OUTPUTS.has(name)).map(
     ([name, spec]) => `| \`${name}\` | ${cell(spec.description)} |`
   );
   return ['| Name | Description |', '| --- | --- |', ...rows].join('\n');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -240,9 +240,9 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['spec-path']?.required).toBe(false);
     });
 
-    it('defaults integration-backend to bifrost', () => {
+    it('keeps integration-backend internal with no visible manifest default', () => {
       const manifest = loadManifest();
-      expect(manifest.inputs['integration-backend']?.default).toBe('bifrost');
+      expect(manifest.inputs['integration-backend']?.default).toBeUndefined();
     });
 
     it('defaults enable-insights to false', () => {
@@ -542,6 +542,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       // login passes `--region eu` only for eu and omits the flag otherwise.
       expect(junitStep?.run).toContain('--region eu');
       expect(junitStep?.run).not.toContain('--region "$POSTMAN_REGION"');
+      expect(junitStep?.run).not.toContain('--region us');
+      expect(junitStep?.run).toContain('postman login --with-api-key "$POSTMAN_API_KEY" >/dev/null');
       expect(junitStep?.run).not.toContain('https://dl-cli.pstmn.io/install/unix.sh');
     });
 

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -37,7 +37,8 @@ type WorkflowManifest = {
   };
 };
 
-const HIDDEN_INPUTS = new Set(['postman-stack']);
+const HIDDEN_INPUTS = new Set(['integration-backend', 'postman-stack']);
+const HIDDEN_OUTPUTS = new Set(['integration-backend']);
 
 function loadManifest(): ActionManifest {
   return parse(
@@ -78,7 +79,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       const pkg = loadPackageJson();
       expect(manifest.description).toContain('Part of the Postman API Onboarding suite');
       expect(manifest.description).not.toContain('beta');
-      expect(String(pkg.description)).toContain('customer preview');
+      expect(String(pkg.description)).toContain('Postman API onboarding');
+      expect(String(pkg.description)).not.toContain('customer preview');
       expect(String(pkg.description)).not.toContain('beta');
     });
 
@@ -143,6 +145,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const manifest = loadManifest();
       const readme = loadReadme();
       for (const outputName of Object.keys(manifest.outputs)) {
+        if (HIDDEN_OUTPUTS.has(outputName)) continue;
         expect(readme).toContain(`\`${outputName}\``);
       }
     });
@@ -198,6 +201,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'postman-access-token',
         'credential-preflight',
         'postman-team-id',
+        'postman-region',
         'postman-stack',
         'github-token',
         'gh-fallback-token',
@@ -297,24 +301,28 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v1.2.0');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v1.0.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v1.2.3');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v1.0.4');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v1.0.0');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v1.0.3');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
     });
 
-    it('validates the hidden postman-stack input before downstream actions run', () => {
+    it('validates the hidden postman-stack and public postman-region inputs before downstream actions run', () => {
       const manifest = loadManifest();
       const validateStep = manifest.runs.steps.find((step) => step.id === 'validate_postman_stack');
 
       expect(manifest.inputs['postman-stack']?.default).toBe('prod');
+      expect(manifest.inputs['postman-region']?.default).toBe('us');
+      expect(validateStep?.env?.POSTMAN_REGION).toBe('${{ inputs.postman-region }}');
       expect(validateStep?.env?.POSTMAN_STACK).toBe('${{ inputs.postman-stack }}');
       expect(validateStep?.run).toContain('prod|beta');
       expect(validateStep?.run).toContain('postman-stack must be one of: prod, beta');
+      expect(validateStep?.run).toContain('us|eu');
+      expect(validateStep?.run).toContain('postman-region must be one of: us, eu');
     });
 
     it('insights step is conditional on enable-insights', () => {
@@ -433,6 +441,16 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['credential-preflight']?.default).toBe('warn');
     });
 
+    it('validates credential-preflight as warn or enforce only before downstream actions run', () => {
+      const manifest = loadManifest();
+      const validateStep = manifest.runs.steps.find((step) => step.id === 'validate_postman_stack');
+
+      expect(validateStep?.env?.CREDENTIAL_PREFLIGHT).toBe('${{ inputs.credential-preflight }}');
+      expect(validateStep?.run).toContain('warn|enforce');
+      expect(validateStep?.run).toContain('credential-preflight must be one of: warn, enforce');
+      expect(validateStep?.run).not.toMatch(/\b(disabled|false|none|off|skip)\b/);
+    });
+
     it('passes credential-preflight to bootstrap, repo-sync, and insights', () => {
       const manifest = loadManifest();
       const bootstrapStep = manifest.runs.steps.find((s) => s.id === 'bootstrap');
@@ -495,6 +513,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const manifest = loadManifest();
       const bootstrapStep = manifest.runs.steps.find((s) => s.id === 'bootstrap');
 
+      expect(bootstrapStep?.with?.['postman-region']).toBe('${{ inputs.postman-region }}');
       expect(bootstrapStep?.with?.['postman-stack']).toBe('${{ inputs.postman-stack }}');
       expect(bootstrapStep?.with?.['postman-api-base']).toBeUndefined();
       expect(bootstrapStep?.with?.['postman-bifrost-base']).toBeUndefined();
@@ -506,6 +525,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const manifest = loadManifest();
       const repoSyncStep = manifest.runs.steps.find((s) => s.id === 'repo_sync');
 
+      expect(repoSyncStep?.with?.['postman-region']).toBe('${{ inputs.postman-region }}');
       expect(repoSyncStep?.with?.['postman-stack']).toBe('${{ inputs.postman-stack }}');
       expect(repoSyncStep?.with?.['postman-api-base']).toBeUndefined();
       expect(repoSyncStep?.with?.['postman-bifrost-base']).toBeUndefined();
@@ -518,6 +538,10 @@ describe('postman-api-onboarding-action composite contract', () => {
       const junitStep = manifest.runs.steps.find((s) => s.id === 'run_tests_junit');
 
       expect(junitStep?.run).toContain('$POSTMAN_CLI_INSTALL_URL');
+      // us is the CLI default and `--region us` is rejected by the Postman CLI, so the
+      // login passes `--region eu` only for eu and omits the flag otherwise.
+      expect(junitStep?.run).toContain('--region eu');
+      expect(junitStep?.run).not.toContain('--region "$POSTMAN_REGION"');
       expect(junitStep?.run).not.toContain('https://dl-cli.pstmn.io/install/unix.sh');
     });
 
@@ -581,6 +605,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
       expect(insightsStep?.with?.['cluster-name']).toBe('${{ inputs.cluster-name }}');
       expect(insightsStep?.with?.['postman-team-id']).toBe('${{ inputs.postman-team-id }}');
+      expect(insightsStep?.with?.['postman-region']).toBe('${{ inputs.postman-region }}');
       expect(insightsStep?.with?.['postman-stack']).toBe('${{ inputs.postman-stack }}');
     });
 
@@ -588,6 +613,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const manifest = loadManifest();
       const insightsStep = manifest.runs.steps.find((s) => s.id === 'insights_onboarding');
 
+      expect(insightsStep?.with?.['postman-region']).toBe('${{ inputs.postman-region }}');
       expect(insightsStep?.with?.['postman-stack']).toBe('${{ inputs.postman-stack }}');
       expect(insightsStep?.with?.['postman-api-base']).toBeUndefined();
       expect(insightsStep?.with?.['postman-bifrost-base']).toBeUndefined();
@@ -616,14 +642,14 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['repo-write-mode']?.default).toBe('commit-and-push');
     });
 
-    it('committer-name defaults to Postman CSE', () => {
+    it('committer-name defaults to Postman', () => {
       const manifest = loadManifest();
-      expect(manifest.inputs['committer-name']?.default).toBe('Postman CSE');
+      expect(manifest.inputs['committer-name']?.default).toBe('Postman');
     });
 
-    it('committer-email defaults to help@postman.com', () => {
+    it('committer-email defaults to support@postman.com', () => {
       const manifest = loadManifest();
-      expect(manifest.inputs['committer-email']?.default).toBe('help@postman.com');
+      expect(manifest.inputs['committer-email']?.default).toBe('support@postman.com');
     });
 
     it('JSON map inputs default to empty object', () => {
@@ -634,10 +660,12 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['environment-uids-json']?.default).toBe('{}');
     });
 
-    it('postman-stack defaults to prod and explicit base URL inputs are hidden from the composite', () => {
+    it('postman-stack and postman-region default to public production without explicit base URL inputs', () => {
       const manifest = loadManifest();
       expect(manifest.inputs['postman-stack']?.default).toBe('prod');
       expect(manifest.inputs['postman-stack']?.required).toBe(false);
+      expect(manifest.inputs['postman-region']?.default).toBe('us');
+      expect(manifest.inputs['postman-region']?.required).toBe(false);
       expect(manifest.inputs['postman-api-base']).toBeUndefined();
       expect(manifest.inputs['postman-bifrost-base']).toBeUndefined();
       expect(manifest.inputs['postman-gateway-base']).toBeUndefined();

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -17,6 +17,14 @@ function npmRegistrySetupStep(): string {
 }
 
 describe('release workflow publishing contract', () => {
+  it('verifies composite sibling pins before publishing', () => {
+    expect(namedStep('Verify composite sibling pins')).toContain('node scripts/check-sibling-pins.mjs');
+    expect(releaseWorkflow.indexOf('npm test')).toBeLessThan(releaseWorkflow.indexOf('node scripts/check-sibling-pins.mjs'));
+    expect(releaseWorkflow.indexOf('node scripts/check-sibling-pins.mjs')).toBeLessThan(
+      releaseWorkflow.indexOf('Verify release tag matches package version')
+    );
+  });
+
   it('keeps v1 as the only rolling alias and v1.x as a zero-patch publish tag', () => {
     expect(releaseWorkflow).toContain('PUBLISH_TAGS=("$PKG_VERSION")');
     expect(releaseWorkflow).toContain('PUBLISH_TAGS+=("$MAJOR.$MINOR")');


### PR DESCRIPTION
## Release v1.2.3: telemetry propagation + region fix + child re-pin

- **Telemetry propagation**: forwards `POSTMAN_ACTIONS_TELEMETRY`, `DO_NOT_TRACK`, and `POSTMAN_ACTIONS_TELEMETRY_ENDPOINT` to the chained child actions so opt-out and endpoint overrides flow through the whole pipeline.
- **Region fix**: the inline `postman login` passes `--region eu` only for `eu`, omits it for us.
- **Sibling pins** advanced to the coordinated tags: `bootstrap@v1.2.3`, `repo-sync@v1.0.4`, `insights@v1.0.3`.
- **Marketplace readiness**: `RELEASE_POLICY.md`, `SUPPORT.md`, README updates.
- Composite action: no runtime bundle.

### Validation
- npm test, npm run typecheck, npm run lint, npm run build, npm run check:dist all green.
- Live onboarding e2e (non-org + org sandbox teams) passes end to end.

### Release (maintainer)
After merge, from `main`:
```
git pull
git tag -a v1.2.3 -m "v1.2.3" && git push origin v1.2.3
git tag -f v1 v1.2.3 && git push -f origin v1
```
The v1.2.3 tag triggers release.yml: validate -> live-e2e gate -> npm publish --provenance -> GitHub release. The v1 push is detected as the rolling alias (publish/gate skipped).

**Ordering**: tag the three children (bootstrap v1.2.3, repo-sync v1.0.4, insights v1.0.3) before tagging this composite, or the release-time `check-sibling-pins` gate (which compares each pin to the latest immutable `v1.x.y` tag on the child remote) will fail.
Then publish the GitHub release to the Marketplace from its release page.
