### PR TITLE
fix: Wave 1 validation credentials and repo-write-mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
           declare -A pid
           run() { local n=$1; shift; ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!; }
 
-          run lint       npm run lint
-          run typecheck  npm run typecheck
-          run test       npm test
-          run actionlint "$ACTIONLINT_BIN"
+          run lint          npm run lint
+          run typecheck     npm run typecheck
+          run test          npm test
+          run sibling-pins  node scripts/check-sibling-pins.mjs
+          run actionlint    "$ACTIONLINT_BIN"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             run commitlint npx commitlint \
               --from "${{ github.event.pull_request.base.sha }}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # postman-api-onboarding-action
 
-Composite GitHub Action -- the primary partner-facing entrypoint. Chains bootstrap -> repo-sync -> (optional) insights. Contains NO runtime TypeScript; only `action.yml` wiring, tests, and type definitions.
+Composite GitHub Action -- primary partner-facing entrypoint. Chains bootstrap -> repo-sync -> (optional) insights. Contains NO runtime TypeScript; only `action.yml` wiring, tests, and type definitions.
 
 ## How It Works
 
@@ -31,22 +31,23 @@ npm run typecheck
 
 - `project-name` (required), `spec-url` (required)
 - `workspace-id`, `spec-id`, `*-collection-id` -- for existing service reruns
-- `postman-access-token` (primary asset credential; every wrapped-action asset op runs through the access-token gateway), `postman-api-key` (required; mints/re-mints the access token and authenticates the Postman CLI logins)
+- `postman-access-token` (primary asset credential; every wrapped-action asset op runs through access-token gateway), `postman-api-key` (mints/re-mints access token and authenticates Postman CLI logins). Individually optional; at least one is required.
 - `enable-insights` -- chains insights onboarding step
 - `generate-ci-workflow`, `ci-workflow-path` -- controls CI generation in target repo
 
 ## Gotchas
 
 - Sibling action refs are pinned; update them deliberately during coordinated releases
-- `spec-url` is always required, even when reusing an existing `spec-id` (bootstrap updates from source)
-- `POSTMAN_TEAM_ID` env var is passed via `env:` block, not as an input
-- `package.json` version is NOT the release identifier -- git tags are
+- Do not advance sibling immutable release pins from this composite; never log credentials from inputs
+- `spec-url` is always required, even when reusing existing `spec-id` (bootstrap updates from source)
+- `POSTMAN_TEAM_ID` env var is passed via `env:` block, not as input
+- `package.json` version is NOT release identifier -- git tags are
 
 ## CI
 
-`.github/workflows/ci.yml` runs a single `gate` job that fans out lint, typecheck, test, commitlint, and actionlint
+`.github/workflows/ci.yml` runs single `gate` job that fans out lint, typecheck, test, sibling-pins, commitlint, and actionlint
 as backgrounded shell processes on one runner: wall-clock is `max(gate)`, not
 `sum`, setup runs once, and every gate prints its result under a `::group::`
 block even when another fails.
 
-See the workspace `docs/CI.md` for the shared rationale.
+See workspace monorepo CI doc for shared rationale.

--- a/README.md
+++ b/README.md
@@ -255,14 +255,14 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `environment-uids-json` | JSON map of environment slug to existing Postman environment UID. When provided, repo-sync reuses these environments instead of creating new ones. | no | `{}` |
 | `governance-mapping-json` | JSON map of business domain to governance group name. | no | `{}` |
 | `env-runtime-urls-json` | JSON map of environment slug to runtime base URL. | no | `{}` |
-| `postman-api-key` | Postman API key (PMAK). Threaded to the wrapped actions to mint and re-mint the access token and to authenticate the Postman CLI logins (bootstrap spec lint, repo-sync generated-CI collection run). | yes |  |
-| `postman-access-token` | Postman access token (x-access-token). Primary credential threaded to the wrapped actions; every Postman asset operation runs through the access-token gateway. Mint it with postman-resolve-service-token-action. | no |  |
+| `postman-api-key` | Postman API key (PMAK). Threaded to the wrapped actions to mint and re-mint the access token and to authenticate the Postman CLI logins (bootstrap spec lint, repo-sync generated-CI collection run). Individually optional; at least one of postman-api-key or postman-access-token is required. | no |  |
+| `postman-access-token` | Postman access token (x-access-token). Primary credential threaded to the wrapped actions; every Postman asset operation runs through the access-token gateway. Mint it with postman-resolve-service-token-action. Individually optional; at least one of postman-api-key or postman-access-token is required. | no |  |
 | `credential-preflight` | Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created. | no | `warn` |
 | `postman-team-id` | Explicit Postman team ID override for org-mode integration calls. | no |  |
 | `postman-region` | Postman data residency region for public API and Postman CLI calls. One of us or eu. | no | `us` |
 | `github-token` | GitHub token used for repo variables and generated commits. | no |  |
 | `gh-fallback-token` | Fallback GitHub token for variable and workflow-file APIs. | no |  |
-| `repo-write-mode` | Repo mutation mode for generated assets and workflow files. | no | `commit-and-push` |
+| `repo-write-mode` | Repo mutation mode for generated assets and workflow files. One of none, commit-only, or commit-and-push. | no | `commit-and-push` |
 | `current-ref` | Explicit ref override for detached checkout push semantics. | no |  |
 | `committer-name` | Commit author name for generated sync commits. | no | `Postman` |
 | `committer-email` | Commit author email for generated sync commits. | no | `support@postman.com` |

--- a/action.yml
+++ b/action.yml
@@ -124,10 +124,10 @@ inputs:
     required: false
     default: '{}'
   postman-api-key:
-    description: Postman API key (PMAK). Threaded to the wrapped actions to mint and re-mint the access token and to authenticate the Postman CLI logins (bootstrap spec lint, repo-sync generated-CI collection run).
-    required: true
+    description: Postman API key (PMAK). Threaded to the wrapped actions to mint and re-mint the access token and to authenticate the Postman CLI logins (bootstrap spec lint, repo-sync generated-CI collection run). Individually optional; at least one of postman-api-key or postman-access-token is required.
+    required: false
   postman-access-token:
-    description: Postman access token (x-access-token). Primary credential threaded to the wrapped actions; every Postman asset operation runs through the access-token gateway. Mint it with postman-resolve-service-token-action.
+    description: Postman access token (x-access-token). Primary credential threaded to the wrapped actions; every Postman asset operation runs through the access-token gateway. Mint it with postman-resolve-service-token-action. Individually optional; at least one of postman-api-key or postman-access-token is required.
     required: false
   credential-preflight:
     description: "Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created."
@@ -151,7 +151,7 @@ inputs:
     description: Fallback GitHub token for variable and workflow-file APIs.
     required: false
   repo-write-mode:
-    description: Repo mutation mode for generated assets and workflow files.
+    description: Repo mutation mode for generated assets and workflow files. One of none, commit-only, or commit-and-push.
     required: false
     default: commit-and-push
   current-ref:
@@ -278,6 +278,9 @@ runs:
         POSTMAN_REGION: ${{ inputs.postman-region }}
         POSTMAN_STACK: ${{ inputs.postman-stack }}
         CREDENTIAL_PREFLIGHT: ${{ inputs.credential-preflight }}
+        REPO_WRITE_MODE: ${{ inputs.repo-write-mode }}
+        POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
+        POSTMAN_ACCESS_TOKEN: ${{ inputs.postman-access-token }}
       run: |
         case "$POSTMAN_STACK" in
           prod|beta) ;;
@@ -304,6 +307,17 @@ runs:
             exit 1
             ;;
         esac
+        case "$REPO_WRITE_MODE" in
+          none|commit-only|commit-and-push) ;;
+          *)
+            echo "::error::repo-write-mode must be one of: none, commit-only, commit-and-push; got: $REPO_WRITE_MODE"
+            exit 1
+            ;;
+        esac
+        if [ -z "$POSTMAN_API_KEY" ] && [ -z "$POSTMAN_ACCESS_TOKEN" ]; then
+          echo "::error::One of postman-api-key or postman-access-token is required."
+          exit 1
+        fi
     - id: bootstrap
       name: Bootstrap Postman Assets
       uses: postman-cs/postman-bootstrap-action@v2.9.0

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -87,6 +87,6 @@ The [roles and permissions](https://learning.postman.com/docs/administration/rol
 
 ## API key auto-creation
 
-`postman-repo-sync-action` and `postman-insights-onboarding-action` can create or rotate a PMAK from `postman-access-token` when they encounter a clear auth failure, but this composite still requires `postman-api-key` up front because `postman-bootstrap-action` cannot start without it.
+`postman-api-key` and `postman-access-token` are individually optional, but at least one is required. Access-token-only runs match the wrapped bootstrap/repo-sync contract: the composite fails in the first validation step when neither credential is present. Built-in Postman CLI smoke/contract tests still need a PMAK (they use `postman login --with-api-key`); without one the composite skips those tests with a warning. `postman-repo-sync-action` and `postman-insights-onboarding-action` can create or rotate a PMAK from `postman-access-token` when they encounter a clear auth failure.
 
 For org-wide API key expiration, revocation, and exposed-key handling, see the [managing API keys](https://learning.postman.com/docs/administration/managing-your-team/managing-api-keys/) guide.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ciWorkflow = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+
+describe('PR CI sibling-pin freshness', () => {
+  it('runs check-sibling-pins.mjs as a normal PR gate', () => {
+    expect(ciWorkflow).toContain('node scripts/check-sibling-pins.mjs');
+    expect(ciWorkflow).toMatch(/run\s+sibling-pins\s+node scripts\/check-sibling-pins\.mjs/);
+  });
+});

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -232,9 +232,12 @@ describe('postman-api-onboarding-action composite contract', () => {
       ]);
     });
 
-    it('postman-api-key is required because bootstrap depends on it', () => {
+    it('postman-api-key and postman-access-token are individually optional; validation requires at least one', () => {
       const manifest = loadManifest();
-      expect(manifest.inputs['postman-api-key']?.required).toBe(true);
+      expect(manifest.inputs['postman-api-key']?.required).toBe(false);
+      expect(manifest.inputs['postman-access-token']?.required).toBe(false);
+      const validateStep = manifest.runs.steps.find((step) => step.id === 'validate_postman_stack');
+      expect(validateStep?.run).toContain('One of postman-api-key or postman-access-token is required');
     });
 
     it('postman-team-id remains an optional explicit override', () => {
@@ -338,6 +341,33 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(validateStep?.run).toContain('postman-stack must be one of: prod, beta');
       expect(validateStep?.run).toContain('us|eu');
       expect(validateStep?.run).toContain('postman-region must be one of: us, eu');
+    });
+
+    it('validates repo-write-mode in the first composite step before any child runs', () => {
+      const manifest = loadManifest();
+      const steps = manifest.runs.steps;
+      const validateStep = steps[0];
+
+      expect(validateStep?.id).toBe('validate_postman_stack');
+      expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
+      expect(validateStep?.run).toContain('none|commit-only|commit-and-push');
+      expect(validateStep?.run).toContain(
+        'repo-write-mode must be one of: none, commit-only, commit-and-push'
+      );
+      expect(manifest.inputs['repo-write-mode']?.default).toBe('commit-and-push');
+      expect(steps.findIndex((step) => step.uses?.includes('postman-bootstrap-action'))).toBeGreaterThan(
+        0
+      );
+    });
+
+    it('invokes bootstrap, repo-sync, and insights exactly once in that order', () => {
+      const childIds = loadManifest()
+        .runs.steps.map((step) => step.id)
+        .filter(
+          (id): id is string =>
+            id === 'bootstrap' || id === 'repo_sync' || id === 'insights_onboarding'
+        );
+      expect(childIds).toEqual(['bootstrap', 'repo_sync', 'insights_onboarding']);
     });
 
     it('insights step is conditional on enable-insights', () => {
@@ -463,15 +493,13 @@ describe('postman-api-onboarding-action composite contract', () => {
       }
     });
 
-    it('passes postman-api-key and postman-access-token to bootstrap and repo-sync', () => {
+    it('passes postman-api-key and postman-access-token to bootstrap, repo-sync, and insights', () => {
       const manifest = loadManifest();
-      const bootstrapStep = manifest.runs.steps.find((s) => s.id === 'bootstrap');
-      const repoSyncStep = manifest.runs.steps.find((s) => s.id === 'repo_sync');
-
-      expect(bootstrapStep?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
-      expect(bootstrapStep?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
-      expect(repoSyncStep?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
-      expect(repoSyncStep?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
+      for (const stepId of ['bootstrap', 'repo_sync', 'insights_onboarding'] as const) {
+        const step = manifest.runs.steps.find((s) => s.id === stepId);
+        expect(step?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
+        expect(step?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
+      }
     });
 
     it('credential-preflight defaults to warn and is optional', () => {
@@ -483,11 +511,14 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('validates credential-preflight as warn or enforce only before downstream actions run', () => {
       const manifest = loadManifest();
       const validateStep = manifest.runs.steps.find((step) => step.id === 'validate_postman_stack');
+      const preflightCase = validateStep?.run?.match(
+        /case "\$CREDENTIAL_PREFLIGHT" in[\s\S]*?esac/
+      )?.[0];
 
       expect(validateStep?.env?.CREDENTIAL_PREFLIGHT).toBe('${{ inputs.credential-preflight }}');
-      expect(validateStep?.run).toContain('warn|enforce');
-      expect(validateStep?.run).toContain('credential-preflight must be one of: warn, enforce');
-      expect(validateStep?.run).not.toMatch(/\b(disabled|false|none|off|skip)\b/);
+      expect(preflightCase).toContain('warn|enforce');
+      expect(preflightCase).toContain('credential-preflight must be one of: warn, enforce');
+      expect(preflightCase).not.toMatch(/\b(disabled|false|none|off|skip)\b/);
     });
 
     it('passes credential-preflight to bootstrap, repo-sync, and insights', () => {

--- a/tests/validate-inputs.test.ts
+++ b/tests/validate-inputs.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+type Step = {
+  id?: string;
+  run?: string;
+  env?: Record<string, string>;
+  uses?: string;
+  with?: Record<string, string>;
+};
+
+type ActionManifest = {
+  inputs: Record<string, { description?: string; default?: string; required?: boolean }>;
+  runs: { steps: Step[] };
+};
+
+function loadManifest(): ActionManifest {
+  return parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8')) as ActionManifest;
+}
+
+function validationScript(): string {
+  const step = loadManifest().runs.steps.find((candidate) => candidate.id === 'validate_postman_stack');
+  if (!step?.run) {
+    throw new Error('validate_postman_stack step is missing a run script');
+  }
+  return step.run;
+}
+
+function runValidation(env: Record<string, string>): { status: number; stderr: string; stdout: string } {
+  try {
+    const stdout = execFileSync('bash', ['-c', validationScript()], {
+      env: {
+        PATH: process.env.PATH ?? '',
+        POSTMAN_STACK: 'prod',
+        POSTMAN_REGION: 'us',
+        CREDENTIAL_PREFLIGHT: 'warn',
+        REPO_WRITE_MODE: 'commit-and-push',
+        POSTMAN_API_KEY: 'PMAK-test',
+        POSTMAN_ACCESS_TOKEN: '',
+        ...env
+      },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string; stdout?: string };
+    return {
+      status: typeof failure.status === 'number' ? failure.status : 1,
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? ''
+    };
+  }
+}
+
+describe('composite first-step input validation', () => {
+  it('declares postman-api-key and postman-access-token individually optional', () => {
+    const manifest = loadManifest();
+    expect(manifest.inputs['postman-api-key']?.required).toBe(false);
+    expect(manifest.inputs['postman-access-token']?.required).toBe(false);
+  });
+
+  it('keeps the documented repo-write-mode default when the input is absent from the manifest contract', () => {
+    const manifest = loadManifest();
+    expect(manifest.inputs['repo-write-mode']?.required).toBe(false);
+    expect(manifest.inputs['repo-write-mode']?.default).toBe('commit-and-push');
+  });
+
+  it('wires credential and repo-write-mode env into the first validation step before any child', () => {
+    const steps = loadManifest().runs.steps;
+    const validateStep = steps[0];
+    expect(validateStep?.id).toBe('validate_postman_stack');
+    expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
+    expect(validateStep?.env?.POSTMAN_API_KEY).toBe('${{ inputs.postman-api-key }}');
+    expect(validateStep?.env?.POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.postman-access-token }}');
+    expect(steps.findIndex((step) => step.id === 'bootstrap')).toBeGreaterThan(0);
+  });
+
+  it.each([
+    { label: 'PMAK-only', env: { POSTMAN_API_KEY: 'PMAK-only', POSTMAN_ACCESS_TOKEN: '' }, status: 0 },
+    { label: 'token-only', env: { POSTMAN_API_KEY: '', POSTMAN_ACCESS_TOKEN: 'token-only' }, status: 0 },
+    {
+      label: 'both',
+      env: { POSTMAN_API_KEY: 'PMAK-both', POSTMAN_ACCESS_TOKEN: 'token-both' },
+      status: 0
+    },
+    { label: 'neither', env: { POSTMAN_API_KEY: '', POSTMAN_ACCESS_TOKEN: '' }, status: 1 }
+  ])('credential matrix: $label', ({ env, status }) => {
+    const result = runValidation(env);
+    expect(result.status).toBe(status);
+    if (status !== 0) {
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        'One of postman-api-key or postman-access-token is required'
+      );
+    }
+  });
+
+  it.each(['none', 'commit-only', 'commit-and-push'])('accepts valid repo-write-mode=%s', (mode) => {
+    const result = runValidation({ REPO_WRITE_MODE: mode });
+    expect(result.status).toBe(0);
+  });
+
+  it.each(['push-only', 'commit', 'invalid', ''])('rejects invalid repo-write-mode=%s before children run', (mode) => {
+    const result = runValidation({ REPO_WRITE_MODE: mode });
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      'repo-write-mode must be one of: none, commit-only, commit-and-push'
+    );
+  });
+});
+
+describe('child invocation order and credential forwarding', () => {
+  it('invokes bootstrap, repo-sync, and insights exactly once in that order', () => {
+    const steps = loadManifest().runs.steps;
+    const childIds = steps
+      .map((step) => step.id)
+      .filter((id): id is string => id === 'bootstrap' || id === 'repo_sync' || id === 'insights_onboarding');
+
+    expect(childIds).toEqual(['bootstrap', 'repo_sync', 'insights_onboarding']);
+    expect(steps.filter((step) => step.id === 'bootstrap')).toHaveLength(1);
+    expect(steps.filter((step) => step.id === 'repo_sync')).toHaveLength(1);
+    expect(steps.filter((step) => step.id === 'insights_onboarding')).toHaveLength(1);
+  });
+
+  it('forwards both credentials completely to bootstrap, repo-sync, and insights', () => {
+    const steps = loadManifest().runs.steps;
+    for (const stepId of ['bootstrap', 'repo_sync', 'insights_onboarding'] as const) {
+      const step = steps.find((candidate) => candidate.id === stepId);
+      expect(step?.with?.['postman-api-key'], `${stepId} postman-api-key`).toBe(
+        '${{ inputs.postman-api-key }}'
+      );
+      expect(step?.with?.['postman-access-token'], `${stepId} postman-access-token`).toBe(
+        '${{ inputs.postman-access-token }}'
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Validate `repo-write-mode` in the first composite step (`none` | `commit-only` | `commit-and-push`) and fail before any child; keep absent-input default `commit-and-push`.
- Reconcile credential contract: `postman-api-key` and `postman-access-token` are individually optional, but at least one is required (supports access-token-only).
- Add structural tests for PMAK-only / token-only / both / neither, valid/invalid modes, exact child invocation order, and complete credential forwarding.
- Wire `scripts/check-sibling-pins.mjs` into normal PR CI (`sibling-pins` gate). Does **not** advance child immutable refs.

## Test plan
- [x] `npm test` (89)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `node scripts/check-sibling-pins.mjs` (pins current; no ref bumps in this PR)
- [ ] CI gate job green on this PR