### PR TITLE
fix: refresh Wave 1 sibling pins

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -57,8 +57,8 @@ Do not duplicate full input and output tables across repositories. Link to the a
 The composite action currently depends on:
 
 - `postman-cs/postman-bootstrap-action@v2.9.0`
-- `postman-cs/postman-repo-sync-action@v2.1.0`
-- `postman-cs/postman-insights-onboarding-action@v2.1.0` when Insights is enabled
+- `postman-cs/postman-repo-sync-action@v2.1.1`
+- `postman-cs/postman-insights-onboarding-action@v2.1.1` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -363,7 +363,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.0
+      uses: postman-cs/postman-repo-sync-action@v2.1.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -480,7 +480,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v2.1.0
+      uses: postman-cs/postman-insights-onboarding-action@v2.1.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -320,10 +320,10 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(validateStep?.shell).toBe('bash');
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.0');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.0');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.1');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.0');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.1');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }


### PR DESCRIPTION
## Summary
- pin repo-sync and Insights to their published Wave 1 releases
- update the composite contract and release policy
- prepare the replacement v2.0.3 release after the immutable v2.0.2 release gate failed before publication

## Validation
- npm test
- npm run typecheck
- npm run lint
- node scripts/check-sibling-pins.mjs