### PR TITLE
chore(release): prepare Wave 2 composite v2.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      npm_publish: ${{ steps.release_tag.outputs.npm_publish }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -101,3 +103,19 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: release.tgz
+
+  advance-major-alias:
+    needs: release
+    if: ${{ needs.release.outputs.npm_publish == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Force-move rolling major alias tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="v${VERSION%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          COMMIT="$(git rev-parse "HEAD^{commit}")"
+          git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$COMMIT"
+          git push origin "$MAJOR" --force

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -56,9 +56,9 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.9.0`
-- `postman-cs/postman-repo-sync-action@v2.1.1`
-- `postman-cs/postman-insights-onboarding-action@v2.1.1` when Insights is enabled
+- `postman-cs/postman-bootstrap-action@v2.9.1`
+- `postman-cs/postman-repo-sync-action@v2.1.3`
+- `postman-cs/postman-insights-onboarding-action@v2.1.2` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -320,7 +320,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.9.0
+      uses: postman-cs/postman-bootstrap-action@v2.9.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -363,7 +363,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.1
+      uses: postman-cs/postman-repo-sync-action@v2.1.3
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -480,7 +480,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v2.1.1
+      uses: postman-cs/postman-insights-onboarding-action@v2.1.2
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -319,11 +319,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.0');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.1');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.1');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.3');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.1');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -7,7 +7,7 @@ const releaseWorkflow = readFileSync(join(process.cwd(), '.github/workflows/rele
 
 function namedStep(name: string): string {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = releaseWorkflow.match(new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n?$)`));
+  const match = releaseWorkflow.match(new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n  [a-zA-Z0-9_-]+:|\\n?$)`));
   return match?.[0] ?? '';
 }
 
@@ -48,5 +48,13 @@ describe('release workflow publishing contract', () => {
     expect(namedStep('Publish to npm')).toContain("if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'");
     expect(namedStep('Attach npm tarball to release')).not.toMatch(/\n\s+if:/);
     expect(namedStep('Upload tarball')).not.toMatch(/\n\s+if:/);
+  });
+
+  it('advances the rolling major alias after an immutable release publishes', () => {
+    expect(releaseWorkflow).toContain('advance-major-alias:');
+    expect(releaseWorkflow).toContain("needs: release");
+    expect(releaseWorkflow).toContain("if: ${{ needs.release.outputs.npm_publish == 'true' }}");
+    expect(namedStep('Force-move rolling major alias tag')).toContain('git tag -fa "$MAJOR"');
+    expect(namedStep('Force-move rolling major alias tag')).toContain('git push origin "$MAJOR" --force');
   });
 });


### PR DESCRIPTION
## Summary
- pin bootstrap v2.9.1, repo-sync v2.1.3, and insights v2.1.2
- prepare npm package metadata for v2.0.4
- advance the rolling v2 alias after immutable publication

## Verification
- npm test
- npm run typecheck
- npm run lint
- node scripts/check-sibling-pins.mjs
- actionlint