### PR TITLE
chore: advance sibling pins to hardening-wave releases

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -56,8 +56,8 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.9.1`
-- `postman-cs/postman-repo-sync-action@v2.1.3`
+- `postman-cs/postman-bootstrap-action@v2.9.4`
+- `postman-cs/postman-repo-sync-action@v2.1.4`
 - `postman-cs/postman-insights-onboarding-action@v2.1.2` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -320,7 +320,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.9.1
+      uses: postman-cs/postman-bootstrap-action@v2.9.4
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -363,7 +363,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.3
+      uses: postman-cs/postman-repo-sync-action@v2.1.4
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -319,8 +319,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.1');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.3');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.4');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.4');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');


### PR DESCRIPTION
Advance composite pins: bootstrap v2.9.4, repo-sync v2.1.4 (hardening wave: gateway transport-rejection/timeout handling, exact root-PATCH readback, inner Bifrost error inspection, strict uid parsing, safe item reconciliation, stale artifact removal). Live e2e matrix green on both legs; per-repo release gates passed.