### PR TITLE
chore(release): v2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",


### PR DESCRIPTION
Composite release v2.0.5: records hardening-wave sibling pins (bootstrap v2.9.4, repo-sync v2.1.4, insights v2.1.2).