### PR TITLE
Forward multi-file API definition inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `workspace-team-id` | Numeric sub-team ID for org-mode workspace creation. Required by the Postman API when the PMAK's team is scoped under an organization. | no |  |
 | `spec-url` | HTTPS URL to the OpenAPI document to bootstrap. Provide either spec-url or spec-path. | no |  |
 | `spec-path` | Repo-root-relative path to the local spec file. Used for repo metadata generation and, when spec-url is not provided, as the spec source for bootstrap (read directly from the checked-out workspace). | no |  |
+| `spec-files-json` | Optional content-free JSON inventory of multi-file definition members from discovery (schemaVersion 1). Empty by default. When set, inventory root must equal spec-path. Cannot be combined with spec-url. Not a directory mode — companions are listed explicitly; file content is never embedded. Forwarded to bootstrap only when spec-url is empty. | no |  |
 | `breaking-change-mode` | OpenAPI breaking-change comparison mode passed through to bootstrap (off, pr-native, baseline-only, or previous-spec). | no | `off` |
 | `breaking-baseline-spec-path` | Repo-root-relative baseline OpenAPI spec path used by bootstrap baseline-only mode and pr-native fallback. | no |  |
 | `breaking-rules-path` | Repo-root-relative openapi-changes rules file passed through to bootstrap. Missing files are ignored. | no | `changes-rules.yaml` |

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -56,8 +56,8 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.9.9`
-- `postman-cs/postman-repo-sync-action@v2.1.7`
+- `postman-cs/postman-bootstrap-action@v2.10.1`
+- `postman-cs/postman-repo-sync-action@v2.1.8`
 - `postman-cs/postman-insights-onboarding-action@v2.1.2` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,14 @@ inputs:
   spec-path:
     description: Repo-root-relative path to the local spec file. Used for repo metadata generation and, when spec-url is not provided, as the spec source for bootstrap (read directly from the checked-out workspace).
     required: false
+  spec-files-json:
+    description: >-
+      Optional content-free JSON inventory of multi-file definition members from discovery
+      (schemaVersion 1). Empty by default. When set, inventory root must equal spec-path.
+      Cannot be combined with spec-url. Not a directory mode — companions are listed explicitly;
+      file content is never embedded. Forwarded to bootstrap only when spec-url is empty.
+    required: false
+    default: ''
   breaking-change-mode:
     description: OpenAPI breaking-change comparison mode passed through to bootstrap (off, pr-native, baseline-only, or previous-spec).
     required: false
@@ -346,6 +354,9 @@ runs:
         # repo metadata) keep working under the bootstrap action's one-of
         # contract.
         spec-path: ${{ inputs.spec-url == '' && inputs.spec-path || '' }}
+        # Same URL precedence for inventory: local path only; blank when
+        # spec-url is non-empty so legacy dual callers remain unchanged.
+        spec-files-json: ${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}
         breaking-change-mode: ${{ inputs.breaking-change-mode }}
         breaking-baseline-spec-path: ${{ inputs.breaking-baseline-spec-path }}
         breaking-rules-path: ${{ inputs.breaking-rules-path }}

--- a/action.yml
+++ b/action.yml
@@ -328,7 +328,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.9.9
+      uses: postman-cs/postman-bootstrap-action@v2.10.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -374,7 +374,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.7
+      uses: postman-cs/postman-repo-sync-action@v2.1.8
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -345,8 +345,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.9');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.7');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.1');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.8');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');
@@ -487,12 +487,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(bootstrapStep?.with?.['spec-files-json']).toBe(
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
-      // Sibling pins stay on the current immutable tags; release lane advances
-      // bootstrap to v2.10.0 after publication.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.9');
+      // Sibling pins stay on the current immutable tags.
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.1');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.1.7');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.1.8');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -199,6 +199,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'workspace-team-id',
         'spec-url',
         'spec-path',
+        'spec-files-json',
         'breaking-change-mode',
         'breaking-baseline-spec-path',
         'breaking-rules-path',
@@ -255,6 +256,28 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(manifest.inputs['project-name']?.required).toBe(true);
       expect(manifest.inputs['spec-url']?.required).toBe(false);
       expect(manifest.inputs['spec-path']?.required).toBe(false);
+    });
+
+    it('places optional content-free spec-files-json immediately after spec-path with empty default', () => {
+      const manifest = loadManifest();
+      const inputNames = Object.keys(manifest.inputs);
+      const inventory = manifest.inputs['spec-files-json'];
+
+      expect(inputNames.indexOf('spec-files-json')).toBe(inputNames.indexOf('spec-path') + 1);
+      expect(inventory?.required).toBe(false);
+      expect(inventory?.default).toBe('');
+      expect(inventory?.description).toMatch(/content-free/i);
+      expect(inventory?.description).toMatch(/root must equal spec-path/i);
+      expect(inventory?.description).toMatch(/not a directory mode/i);
+      expect(inventory?.description).toMatch(/never embedded/i);
+      expect(inventory?.description).not.toMatch(/\bcontent\s*[:=]/i);
+      expect(Object.keys(manifest.outputs)).not.toContain('spec-files-json');
+      for (const [name, output] of Object.entries(manifest.outputs)) {
+        expect(output.description, `output "${name}" must not claim embedded source content`).not.toMatch(
+          /source content|file content|embedded content/i
+        );
+        expect(output.value).not.toMatch(/spec-files-json/);
+      }
     });
 
     it('keeps integration-backend internal with no visible manifest default', () => {
@@ -443,6 +466,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.with?.['spec-path']).toBe(
         '${{ inputs.spec-path }}'
       );
+      expect(repoSyncStep?.with?.['spec-files-json']).toBeUndefined();
       expect(repoSyncStep?.with?.['releases-json']).toBeUndefined();
       expect(repoSyncStep?.with?.['generate-ci-workflow']).toBe(
         '${{ inputs.generate-ci-workflow }}'
@@ -450,6 +474,28 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.with?.['ci-workflow-path']).toBe(
         '${{ inputs.ci-workflow-path }}'
       );
+    });
+
+    it('forwards local spec-path and spec-files-json to bootstrap only when spec-url is empty', () => {
+      const manifest = loadManifest();
+      const bootstrapStep = manifest.runs.steps.find((step) => step.id === 'bootstrap');
+
+      expect(bootstrapStep?.with?.['spec-url']).toBe('${{ inputs.spec-url }}');
+      expect(bootstrapStep?.with?.['spec-path']).toBe(
+        "${{ inputs.spec-url == '' && inputs.spec-path || '' }}"
+      );
+      expect(bootstrapStep?.with?.['spec-files-json']).toBe(
+        "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
+      );
+      // Sibling pins stay on the current immutable tags; release lane advances
+      // bootstrap to v2.10.0 after publication.
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.9.9');
+      expect(
+        manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
+      ).toBe('postman-cs/postman-repo-sync-action@v2.1.7');
+      expect(
+        manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
+      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');
     });
 
     it('surfaces final outputs from phase steps', () => {


### PR DESCRIPTION
## Summary

The composite onboarding action can now accept the content-free multi-file definition inventory emitted by AWS, GCP, and Azure discovery and forward it to bootstrap. Existing single-file callers remain unchanged because the new input defaults to empty.

## What changed

- Add the optional `spec-files-json` composite input and document its schema and exclusivity with `spec-url`.
- Forward the inventory to bootstrap only for local definition sources.
- Reject ambiguous `spec-files-json` plus `spec-url` invocations before any wrapped action runs.
- Cover forwarding, omission, and source-conflict behavior in the composite contract suite.
- Pin bootstrap `v2.10.1` and repo-sync `v2.1.8` after their successful publication.
- Release the composite package as `2.1.0`.

## Validation

- `npm test` (100 tests)
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `node scripts/render-action-tables.mjs --check`
- `actionlint`
- `npx commitlint --from origin/main --to HEAD`
