### PR TITLE
feat: support Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,21 @@ jobs:
             echo "::group::$n"; cat "$n.log"; echo "::endgroup::"
           done
           exit $fail
+
+  windows:
+    name: Windows gate
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run lint
+      - run: npm test
+      - run: npm run typecheck
+      - run: node scripts/check-sibling-pins.mjs

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `monitor-cron` | Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run). | no |  |
 | `generate-ci-workflow` | Whether to generate the CI workflow file. | no | `true` |
 | `ci-workflow-path` | Path to write the generated CI workflow file. | no | `.github/workflows/ci.yml` |
+| `ci-runner-os` | Runner operating system for the generated CI workflow. Use windows for native PowerShell Azure DevOps CI. | no | `linux` |
 | `project-name` | Service project name used across bootstrap and repo sync phases. | yes |  |
 | `domain` | Business domain used for governance assignment. | no |  |
 | `domain-code` | Short domain code used in workspace naming. | no |  |

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -56,9 +56,9 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.1`
-- `postman-cs/postman-repo-sync-action@v2.1.8`
-- `postman-cs/postman-insights-onboarding-action@v2.1.2` when Insights is enabled
+- `postman-cs/postman-bootstrap-action@v2.10.2`
+- `postman-cs/postman-repo-sync-action@v2.1.9`
+- `postman-cs/postman-insights-onboarding-action@v2.1.3` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: Path to write the generated CI workflow file.
     required: false
     default: .github/workflows/ci.yml
+  ci-runner-os:
+    description: Runner operating system for the generated CI workflow. Use windows for native PowerShell Azure DevOps CI.
+    required: false
+    default: linux
   project-name:
     description: Service project name used across bootstrap and repo sync phases.
     required: true
@@ -328,7 +332,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.1
+      uses: postman-cs/postman-bootstrap-action@v2.10.2
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -374,7 +378,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.8
+      uses: postman-cs/postman-repo-sync-action@v2.1.9
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -388,6 +392,7 @@ runs:
         release-label: ${{ inputs.release-label }}
         generate-ci-workflow: ${{ inputs.generate-ci-workflow }}
         ci-workflow-path: ${{ inputs.ci-workflow-path }}
+        ci-runner-os: ${{ inputs.ci-runner-os }}
         environments-json: ${{ inputs.environments-json }}
         system-env-map-json: ${{ inputs.system-env-map-json }}
         environment-uids-json: ${{ inputs.environment-uids-json }}
@@ -426,6 +431,22 @@ runs:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       run: |
         echo "::warning::Skipping built-in smoke and contract tests: no postman-api-key was provided. The Postman CLI (postman login --with-api-key, then postman collection run) has no access-token login, so these tests require a PMAK. Provide postman-api-key to enable them, or set skip-built-in-tests: true to silence this warning."
+    - id: install_postman_cli_windows
+      name: Install Postman CLI on Windows
+      if: ${{ runner.os == 'Windows' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key != '' }}
+      shell: pwsh
+      env:
+        POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_CLI_INSTALL_URL: ${{ inputs.postman-stack == 'beta' && 'https://dl-cli.pstmn-beta.io/install/win64.ps1' || 'https://dl-cli.pstmn.io/install/win64.ps1' }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        if (-not (Get-Command postman -ErrorAction SilentlyContinue)) {
+          [System.Net.ServicePointManager]::SecurityProtocol = 3072
+          Invoke-Expression ((New-Object System.Net.WebClient).DownloadString($env:POSTMAN_CLI_INSTALL_URL))
+        }
+        if (-not (Get-Command postman -ErrorAction SilentlyContinue)) {
+          throw 'Postman CLI installation completed but the postman command is unavailable.'
+        }
     - id: run_tests_junit
       name: Run smoke and contract collections with JUnit output
       if: ${{ steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key != '' }}
@@ -454,6 +475,10 @@ runs:
         REGION_ESCAPED=$(escape_annotation "${POSTMAN_REGION:-}")
 
         if ! command -v postman >/dev/null 2>&1; then
+          if [ "${RUNNER_OS:-}" = "Windows" ]; then
+            echo "::error::Postman CLI was not installed by the Windows setup step"
+            exit 1
+          fi
           curl -fsSL "$POSTMAN_CLI_INSTALL_URL" | sh
           export PATH="$HOME/.postman/cli:$PATH"
         fi
@@ -536,7 +561,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v2.1.2
+      uses: postman-cs/postman-insights-onboarding-action@v2.1.3
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/templates/azure-devops/windows-onboarding.yml
+++ b/templates/azure-devops/windows-onboarding.yml
@@ -1,0 +1,273 @@
+parameters:
+  - name: projectName
+    type: string
+  - name: specPath
+    type: string
+    default: ''
+  - name: specUrl
+    type: string
+    default: ''
+  - name: flowPath
+    type: string
+    default: ''
+  - name: environmentsJson
+    type: string
+    default: '["prod"]'
+  - name: environmentRuntimeUrlsJson
+    type: string
+    default: '{}'
+  - name: canonicalBranch
+    type: string
+    default: main
+  - name: repoWriteMode
+    type: string
+    default: none
+  - name: generateCiWorkflow
+    type: boolean
+    default: true
+  - name: ciWorkflowPath
+    type: string
+    default: postman-ci.yml
+  - name: enableSmokeFlow
+    type: boolean
+    default: false
+  - name: enableInsights
+    type: boolean
+    default: false
+  - name: insightsClusterName
+    type: string
+    default: ''
+  - name: postmanRegion
+    type: string
+    default: us
+  - name: postmanStack
+    type: string
+    default: prod
+  - name: resolveVersion
+    type: string
+    default: 2.0.2
+  - name: bootstrapVersion
+    type: string
+    default: 2.10.2
+  - name: smokeFlowVersion
+    type: string
+    default: 2.1.5
+  - name: repoSyncVersion
+    type: string
+    default: 2.1.9
+  - name: insightsVersion
+    type: string
+    default: 2.1.3
+
+jobs:
+  - job: postman_onboarding
+    displayName: Postman API onboarding
+    pool:
+      vmImage: windows-latest
+    steps:
+      - checkout: self
+        persistCredentials: true
+        fetchDepth: 0
+
+      - task: UseNode@1
+        displayName: Use Node.js 24
+        inputs:
+          version: 24.x
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $packages = @(
+            '@postman-cse/onboarding-resolve-service-token@${{ parameters.resolveVersion }}',
+            '@postman-cse/onboarding-bootstrap@${{ parameters.bootstrapVersion }}',
+            '@postman-cse/onboarding-smoke-flow@${{ parameters.smokeFlowVersion }}',
+            '@postman-cse/onboarding-repo-sync@${{ parameters.repoSyncVersion }}',
+            '@postman-cse/onboarding-insights@${{ parameters.insightsVersion }}'
+          )
+          & npm install --global @packages --no-audit --no-fund
+          if ($LASTEXITCODE -ne 0) { throw "Onboarding CLI install failed with exit code $LASTEXITCODE" }
+        displayName: Install pinned Postman onboarding CLIs
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $arguments = @(
+            '--postman-api-key', $env:POSTMAN_API_KEY,
+            '--postman-region', $env:POSTMAN_REGION,
+            '--postman-stack', $env:POSTMAN_STACK
+          )
+          $output = & postman-resolve-service-token @arguments | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "Token resolution failed with exit code $LASTEXITCODE" }
+          $result = $output | ConvertFrom-Json
+          Write-Host "##vso[task.setsecret]$($result.token)"
+          Write-Host "##vso[task.setvariable variable=POSTMAN_ACCESS_TOKEN;issecret=true]$($result.token)"
+          Write-Host "##vso[task.setvariable variable=POSTMAN_TEAM_ID]$($result.'team-id')"
+        displayName: Resolve Postman service token
+        env:
+          POSTMAN_API_KEY: $(POSTMAN_API_KEY)
+          POSTMAN_REGION: ${{ parameters.postmanRegion }}
+          POSTMAN_STACK: ${{ parameters.postmanStack }}
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $resultPath = Join-Path $env:AGENT_TEMPDIRECTORY 'postman-bootstrap-result.json'
+          $arguments = @(
+            '--project-name', $env:PROJECT_NAME,
+            '--postman-api-key', $env:POSTMAN_API_KEY,
+            '--postman-access-token', $env:POSTMAN_ACCESS_TOKEN,
+            '--postman-region', $env:POSTMAN_REGION,
+            '--postman-stack', $env:POSTMAN_STACK,
+            '--repo-url', $env:BUILD_REPOSITORY_URI,
+            '--canonical-branch', $env:CANONICAL_BRANCH,
+            '--result-json', $resultPath
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:SPEC_PATH)) {
+            $arguments += @('--spec-path', $env:SPEC_PATH)
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:SPEC_URL)) {
+            $arguments += @('--spec-url', $env:SPEC_URL)
+          } else {
+            throw 'One of specPath or specUrl is required.'
+          }
+          & postman-bootstrap @arguments | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "Bootstrap failed with exit code $LASTEXITCODE" }
+          $result = Get-Content -Raw -LiteralPath $resultPath | ConvertFrom-Json
+          Write-Host "##vso[task.setvariable variable=POSTMAN_WORKSPACE_ID]$($result.'workspace-id')"
+          Write-Host "##vso[task.setvariable variable=POSTMAN_SPEC_ID]$($result.'spec-id')"
+          Write-Host "##vso[task.setvariable variable=POSTMAN_BASELINE_COLLECTION_ID]$($result.'baseline-collection-id')"
+          Write-Host "##vso[task.setvariable variable=POSTMAN_SMOKE_COLLECTION_ID]$($result.'smoke-collection-id')"
+          Write-Host "##vso[task.setvariable variable=POSTMAN_CONTRACT_COLLECTION_ID]$($result.'contract-collection-id')"
+        displayName: Bootstrap Postman assets
+        env:
+          PROJECT_NAME: ${{ parameters.projectName }}
+          SPEC_PATH: ${{ parameters.specPath }}
+          SPEC_URL: ${{ parameters.specUrl }}
+          CANONICAL_BRANCH: ${{ parameters.canonicalBranch }}
+          POSTMAN_API_KEY: $(POSTMAN_API_KEY)
+          POSTMAN_ACCESS_TOKEN: $(POSTMAN_ACCESS_TOKEN)
+          POSTMAN_TEAM_ID: $(POSTMAN_TEAM_ID)
+          POSTMAN_REGION: ${{ parameters.postmanRegion }}
+          POSTMAN_STACK: ${{ parameters.postmanStack }}
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:FLOW_PATH)) {
+            throw 'flowPath is required when enableSmokeFlow is true.'
+          }
+          $arguments = @(
+            '--project-name', $env:PROJECT_NAME,
+            '--workspace-id', $env:POSTMAN_WORKSPACE_ID,
+            '--spec-id', $env:POSTMAN_SPEC_ID,
+            '--smoke-collection-id', $env:POSTMAN_SMOKE_COLLECTION_ID,
+            '--flow-path', $env:FLOW_PATH,
+            '--postman-access-token', $env:POSTMAN_ACCESS_TOKEN,
+            '--postman-api-key', $env:POSTMAN_API_KEY,
+            '--postman-region', $env:POSTMAN_REGION,
+            '--postman-stack', $env:POSTMAN_STACK
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:SPEC_PATH)) {
+            $arguments += @('--spec-path', $env:SPEC_PATH)
+          }
+          & postman-smoke-flow @arguments | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "Smoke flow failed with exit code $LASTEXITCODE" }
+        condition: and(succeeded(), ${{ eq(parameters.enableSmokeFlow, true) }})
+        displayName: Apply curated smoke flow
+        env:
+          PROJECT_NAME: ${{ parameters.projectName }}
+          SPEC_PATH: ${{ parameters.specPath }}
+          FLOW_PATH: ${{ parameters.flowPath }}
+          POSTMAN_WORKSPACE_ID: $(POSTMAN_WORKSPACE_ID)
+          POSTMAN_SPEC_ID: $(POSTMAN_SPEC_ID)
+          POSTMAN_SMOKE_COLLECTION_ID: $(POSTMAN_SMOKE_COLLECTION_ID)
+          POSTMAN_API_KEY: $(POSTMAN_API_KEY)
+          POSTMAN_ACCESS_TOKEN: $(POSTMAN_ACCESS_TOKEN)
+          POSTMAN_TEAM_ID: $(POSTMAN_TEAM_ID)
+          POSTMAN_REGION: ${{ parameters.postmanRegion }}
+          POSTMAN_STACK: ${{ parameters.postmanStack }}
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $resultPath = Join-Path $env:AGENT_TEMPDIRECTORY 'postman-repo-sync-result.json'
+          $arguments = @(
+            '--project-name', $env:PROJECT_NAME,
+            '--workspace-id', $env:POSTMAN_WORKSPACE_ID,
+            '--baseline-collection-id', $env:POSTMAN_BASELINE_COLLECTION_ID,
+            '--smoke-collection-id', $env:POSTMAN_SMOKE_COLLECTION_ID,
+            '--contract-collection-id', $env:POSTMAN_CONTRACT_COLLECTION_ID,
+            '--environments-json', $env:ENVIRONMENTS_JSON,
+            '--env-runtime-urls-json', $env:ENV_RUNTIME_URLS_JSON,
+            '--git-provider', 'azure-devops',
+            '--repo-url', $env:BUILD_REPOSITORY_URI,
+            '--repo-write-mode', $env:REPO_WRITE_MODE,
+            '--current-ref', $env:BUILD_SOURCEBRANCH,
+            '--canonical-branch', $env:CANONICAL_BRANCH,
+            '--generate-ci-workflow', $env:GENERATE_CI_WORKFLOW,
+            '--ci-workflow-path', $env:CI_WORKFLOW_PATH,
+            '--ci-runner-os', 'windows',
+            '--postman-api-key', $env:POSTMAN_API_KEY,
+            '--postman-access-token', $env:POSTMAN_ACCESS_TOKEN,
+            '--team-id', $env:POSTMAN_TEAM_ID,
+            '--postman-region', $env:POSTMAN_REGION,
+            '--postman-stack', $env:POSTMAN_STACK,
+            '--result-json', $resultPath
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:SPEC_PATH)) {
+            $arguments += @('--spec-path', $env:SPEC_PATH)
+          }
+          & postman-repo-sync @arguments | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "Repo sync failed with exit code $LASTEXITCODE" }
+          $result = Get-Content -Raw -LiteralPath $resultPath | ConvertFrom-Json
+          Write-Host "##vso[task.setvariable variable=POSTMAN_ENVIRONMENT_UIDS_JSON]$($result.'environment-uids-json')"
+        displayName: Sync Postman artifacts and CI
+        env:
+          PROJECT_NAME: ${{ parameters.projectName }}
+          SPEC_PATH: ${{ parameters.specPath }}
+          ENVIRONMENTS_JSON: ${{ parameters.environmentsJson }}
+          ENV_RUNTIME_URLS_JSON: ${{ parameters.environmentRuntimeUrlsJson }}
+          REPO_WRITE_MODE: ${{ parameters.repoWriteMode }}
+          GENERATE_CI_WORKFLOW: ${{ parameters.generateCiWorkflow }}
+          CI_WORKFLOW_PATH: ${{ parameters.ciWorkflowPath }}
+          CANONICAL_BRANCH: ${{ parameters.canonicalBranch }}
+          POSTMAN_WORKSPACE_ID: $(POSTMAN_WORKSPACE_ID)
+          POSTMAN_BASELINE_COLLECTION_ID: $(POSTMAN_BASELINE_COLLECTION_ID)
+          POSTMAN_SMOKE_COLLECTION_ID: $(POSTMAN_SMOKE_COLLECTION_ID)
+          POSTMAN_CONTRACT_COLLECTION_ID: $(POSTMAN_CONTRACT_COLLECTION_ID)
+          POSTMAN_API_KEY: $(POSTMAN_API_KEY)
+          POSTMAN_ACCESS_TOKEN: $(POSTMAN_ACCESS_TOKEN)
+          POSTMAN_TEAM_ID: $(POSTMAN_TEAM_ID)
+          POSTMAN_REGION: ${{ parameters.postmanRegion }}
+          POSTMAN_STACK: ${{ parameters.postmanStack }}
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:INSIGHTS_CLUSTER_NAME)) {
+            throw 'insightsClusterName is required when enableInsights is true.'
+          }
+          $environmentMap = $env:POSTMAN_ENVIRONMENT_UIDS_JSON | ConvertFrom-Json
+          $environmentId = $environmentMap.PSObject.Properties[0].Value
+          if ([string]::IsNullOrWhiteSpace($environmentId)) {
+            throw 'Repo sync did not return an environment ID for Insights onboarding.'
+          }
+          $arguments = @(
+            '--project-name', $env:PROJECT_NAME,
+            '--workspace-id', $env:POSTMAN_WORKSPACE_ID,
+            '--environment-id', $environmentId,
+            '--cluster-name', $env:INSIGHTS_CLUSTER_NAME,
+            '--repo-url', $env:BUILD_REPOSITORY_URI,
+            '--postman-api-key', $env:POSTMAN_API_KEY,
+            '--postman-access-token', $env:POSTMAN_ACCESS_TOKEN,
+            '--postman-region', $env:POSTMAN_REGION,
+            '--postman-stack', $env:POSTMAN_STACK
+          )
+          & postman-insights-onboard @arguments | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "Insights onboarding failed with exit code $LASTEXITCODE" }
+        condition: and(succeeded(), ${{ eq(parameters.enableInsights, true) }})
+        displayName: Link Postman Insights
+        env:
+          PROJECT_NAME: ${{ parameters.projectName }}
+          INSIGHTS_CLUSTER_NAME: ${{ parameters.insightsClusterName }}
+          POSTMAN_WORKSPACE_ID: $(POSTMAN_WORKSPACE_ID)
+          POSTMAN_ENVIRONMENT_UIDS_JSON: $(POSTMAN_ENVIRONMENT_UIDS_JSON)
+          POSTMAN_API_KEY: $(POSTMAN_API_KEY)
+          POSTMAN_ACCESS_TOKEN: $(POSTMAN_ACCESS_TOKEN)
+          POSTMAN_TEAM_ID: $(POSTMAN_TEAM_ID)
+          POSTMAN_REGION: ${{ parameters.postmanRegion }}
+          POSTMAN_STACK: ${{ parameters.postmanStack }}

--- a/tests/azure-devops-windows-template.test.ts
+++ b/tests/azure-devops-windows-template.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const templatePath = path.resolve(
+  process.cwd(),
+  'templates/azure-devops/windows-onboarding.yml'
+);
+
+describe('Azure DevOps Windows onboarding template', () => {
+  it('orchestrates the existing CLIs on a native Windows job', () => {
+    const source = readFileSync(templatePath, 'utf8');
+    const template = parse(source);
+    const job = template.jobs[0];
+    const renderedScripts = job.steps
+      .map((step: { pwsh?: string }) => step.pwsh || '')
+      .join('\n');
+
+    expect(job.pool.vmImage).toBe('windows-latest');
+    expect(job.steps[0]).toMatchObject({ checkout: 'self', persistCredentials: true });
+    expect(renderedScripts).toContain('postman-resolve-service-token');
+    expect(renderedScripts).toContain('postman-bootstrap');
+    expect(renderedScripts).toContain('postman-smoke-flow');
+    expect(renderedScripts).toContain('postman-repo-sync');
+    expect(renderedScripts).toContain('postman-insights-onboard');
+    expect(renderedScripts).toContain('ConvertFrom-Json');
+    expect(renderedScripts).toContain('issecret=true');
+    expect(renderedScripts).toContain("'--ci-runner-os', 'windows'");
+    expect(source).not.toMatch(/\bjq\b|\bsource\b|curl\s.*\|\s*sh|shell:\s*bash/);
+
+    const tokenStep = job.steps.find(
+      (step: { displayName?: string }) => step.displayName === 'Resolve Postman service token'
+    );
+    expect(tokenStep.pwsh).toContain('$output = & postman-resolve-service-token');
+    expect(tokenStep.pwsh).toContain('$result = $output | ConvertFrom-Json');
+    expect(tokenStep.pwsh).not.toContain('--result-json');
+  });
+
+  it('pins every installed onboarding package instead of resolving latest', () => {
+    const source = readFileSync(templatePath, 'utf8');
+    expect(source).not.toContain('@latest');
+    expect(source).toMatch(/onboarding-resolve-service-token@\$\{\{ parameters\.resolveVersion \}\}/);
+    expect(source).toMatch(/onboarding-bootstrap@\$\{\{ parameters\.bootstrapVersion \}\}/);
+    expect(source).toMatch(/onboarding-smoke-flow@\$\{\{ parameters\.smokeFlowVersion \}\}/);
+    expect(source).toMatch(/onboarding-repo-sync@\$\{\{ parameters\.repoSyncVersion \}\}/);
+    expect(source).toMatch(/onboarding-insights@\$\{\{ parameters\.insightsVersion \}\}/);
+  });
+});

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -190,6 +190,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'monitor-cron',
         'generate-ci-workflow',
         'ci-workflow-path',
+        'ci-runner-os',
         'project-name',
         'domain',
         'domain-code',
@@ -329,9 +330,9 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('is a composite action with the expected step count', () => {
       const manifest = loadManifest();
       expect(manifest.runs.using).toBe('composite');
-      // bootstrap, repo-sync, warn-no-api-key (D2 skip+warn), junit-runner,
-      // junit-uploader, insights.
-      expect(manifest.runs.steps).toHaveLength(7);
+      // bootstrap, repo-sync, warn-no-api-key, Windows CLI install, junit-runner,
+      // junit-uploader, and insights plus validation.
+      expect(manifest.runs.steps).toHaveLength(8);
     });
 
     it('uses pinned bootstrap, repo-sync, junit-runner, junit-uploader, and insights actions', () => {
@@ -345,11 +346,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.1');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.8');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.2');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.9');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.3');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
@@ -474,6 +475,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.with?.['ci-workflow-path']).toBe(
         '${{ inputs.ci-workflow-path }}'
       );
+      expect(repoSyncStep?.with?.['ci-runner-os']).toBe('${{ inputs.ci-runner-os }}');
     });
 
     it('forwards local spec-path and spec-files-json to bootstrap only when spec-url is empty', () => {
@@ -488,13 +490,13 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.1');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.2');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.1.8');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.1.9');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
-      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.2');
+      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.3');
     });
 
     it('surfaces final outputs from phase steps', () => {
@@ -676,6 +678,20 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
       expect(junitStep?.run).toContain('$POSTMAN_CLI_INSTALL_URL');
       expect(junitStep?.run).not.toContain('"${{ inputs.postman-cli-install-url }}"');
+    });
+
+    it('preinstalls the native Postman CLI before the Bash test adapter on Windows', () => {
+      const manifest = loadManifest();
+      const installStep = manifest.runs.steps.find(
+        (step) => step.id === 'install_postman_cli_windows'
+      );
+      const junitStep = manifest.runs.steps.find((step) => step.id === 'run_tests_junit');
+
+      expect(installStep?.shell).toBe('pwsh');
+      expect(installStep?.if).toContain("runner.os == 'Windows'");
+      expect(installStep?.env?.POSTMAN_CLI_INSTALL_URL).toContain('win64.ps1');
+      expect(installStep?.run).toContain('DownloadString($env:POSTMAN_CLI_INSTALL_URL)');
+      expect(junitStep?.run).toContain('Postman CLI was not installed by the Windows setup step');
     });
 
     it('run_tests_junit script remains valid Bash', () => {
@@ -946,6 +962,11 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('ci-workflow-path defaults to .github/workflows/ci.yml', () => {
       const manifest = loadManifest();
       expect(manifest.inputs['ci-workflow-path']?.default).toBe('.github/workflows/ci.yml');
+    });
+
+    it('ci-runner-os defaults to linux', () => {
+      const manifest = loadManifest();
+      expect(manifest.inputs['ci-runner-os']?.default).toBe('linux');
     });
 
     it('environments-json defaults to ["prod"]', () => {


### PR DESCRIPTION
Adds native Windows runner support alongside existing Linux/macOS.

## What changes
- New `ci-runner-os` input forwarded to repo-sync.
- `install_postman_cli_windows` step (pwsh, Windows-only) preinstalls the Postman CLI via the official PowerShell installer before the Bash test adapter.
- Windows guard in JUnit step: on Windows, the Bash adapter no longer tries `curl | sh` (the pwsh step owns CLI install).
- New `templates/azure-devops/windows-onboarding.yml`: full ADO Windows onboarding template orchestrating all five CLIs (resolve-token, bootstrap, smoke-flow, repo-sync, insights) via `pwsh` on `windows-latest`.
- CI gains a `windows-latest` gate job.
- Sibling action pins advanced to bootstrap@v2.10.2, repo-sync@v2.1.9, insights@v2.1.3.
- Version bump to ``.

## Verification
- All local gates green on macOS (`npm test`, typecheck, lint).
- New tests cover ci-runner-os forwarding, Windows CLI install step, and ADO template structure.
- Windows CI gate proves parity.