### PR TITLE
fix(release): verify composite artifacts and Insights credentials

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: Action Version
-      description: "The version tag you are using (e.g., v1.0.0 or v1)."
+      description: "The version tag you are using (e.g., v2.1.2 or v2)."
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gate:
     runs-on: ubuntu-latest
@@ -26,11 +30,9 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Install actionlint
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/393031adb9afb225ee52ae2ccd7a5af5525e03e8/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
           echo "ACTIONLINT_BIN=$RUNNER_TEMP/actionlint" >> "$GITHUB_ENV"
       # Keep at most two checks active on the two-vCPU runner. Failures aggregate
       # under ::group:: logs so one pass still shows every result.
@@ -91,9 +93,35 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm run lint
-      - run: npm test
-      - run: npm run typecheck
-      - run: node scripts/check-sibling-pins.mjs
+      - name: Run Windows gates
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $MAX_PARALLEL_GATES = 2
+          $jobs = @()
+          $results = @{}
+          function Complete-One {
+            $completed = Wait-Job -Job $jobs -Any
+            $results[$completed.Name] = $completed.State
+            Receive-Job -Job $completed -ErrorAction SilentlyContinue | Out-Null
+            Remove-Job -Job $completed
+            $script:jobs = @($jobs | Where-Object Id -ne $completed.Id)
+          }
+          function Start-Gate($name, $executable, $gateArgs) {
+            while ($jobs.Count -ge $MAX_PARALLEL_GATES) { Complete-One }
+            $script:jobs += Start-Job -Name $name -ScriptBlock {
+              param($executable, $gateArgs)
+              & $executable @gateArgs
+              if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }
+            } -ArgumentList $executable, (,$gateArgs)
+          }
+          Start-Gate lint npm @('run', 'lint')
+          Start-Gate test npm @('test')
+          Start-Gate typecheck npm @('run', 'typecheck')
+          Start-Gate sibling-pins node @('scripts/check-sibling-pins.mjs')
+          while ($jobs.Count -gt 0) { Complete-One }
+          $failed = $false
+          foreach ($name in @('lint', 'test', 'typecheck', 'sibling-pins')) {
+            if ($results[$name] -eq 'Completed') { Write-Output "gate:$name=pass" } else { Write-Output "gate:$name=fail"; $failed = $true }
+          }
+          if ($failed) { exit 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
           function Complete-One {
             $completed = Wait-Job -Job $jobs -Any
             $results[$completed.Name] = $completed.State
-            Receive-Job -Job $completed -ErrorAction SilentlyContinue | Out-Null
+            # Continue + 2>&1: keep failed-child text in a per-gate log without aborting aggregation.
+            Receive-Job -Job $completed -ErrorAction Continue 2>&1 | Out-File "$($completed.Name).log"
             Remove-Job -Job $completed
             $script:jobs = @($jobs | Where-Object Id -ne $completed.Id)
           }
@@ -123,5 +124,8 @@ jobs:
           $failed = $false
           foreach ($name in @('lint', 'test', 'typecheck', 'sibling-pins')) {
             if ($results[$name] -eq 'Completed') { Write-Output "gate:$name=pass" } else { Write-Output "gate:$name=fail"; $failed = $true }
+            Write-Output "::group::$name"
+            if (Test-Path -LiteralPath "$name.log") { Get-Content -LiteralPath "$name.log" } else { Write-Output "(no log captured for $name)" }
+            Write-Output '::endgroup::'
           }
           if ($failed) { exit 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,6 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - name: Diagnose Windows release tests
-        shell: pwsh
-        run: |
-          node --check scripts/check-release-alias.mjs
-          node --check scripts/verify-release-artifacts.mjs
-          node -e "Promise.all([import('./scripts/check-release-alias.mjs'), import('./scripts/verify-release-artifacts.mjs')])"
-          npx vitest run tests/release-alias.test.ts --reporter=verbose
-          npx vitest run tests/release-artifact-contract.test.ts --reporter=verbose
       - name: Run Windows gates
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - name: Diagnose Windows release tests
+        shell: pwsh
+        run: |
+          node --check scripts/check-release-alias.mjs
+          node --check scripts/verify-release-artifacts.mjs
+          node -e "Promise.all([import('./scripts/check-release-alias.mjs'), import('./scripts/verify-release-artifacts.mjs')])"
+          npx vitest run tests/release-alias.test.ts --reporter=verbose
+          npx vitest run tests/release-artifact-contract.test.ts --reporter=verbose
       - name: Run Windows gates
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,12 @@ jobs:
         run: |
           node --input-type=module <<'NODE'
           import { createHash } from 'node:crypto';
+          import { execFileSync } from 'node:child_process';
           import { readFileSync } from 'node:fs';
           import { join } from 'node:path';
 
           const directory = 'release';
+          const tarballPath = join(directory, 'release.tgz');
           const manifest = JSON.parse(readFileSync(join(directory, 'release-manifest.json'), 'utf8'));
           if (manifest.schema_version !== 1) throw new Error('unsupported manifest schema');
           for (const key of ['repository', 'commit_sha', 'tag', 'package_name', 'package_version']) {
@@ -143,13 +145,18 @@ jobs:
           if (artifact.path !== 'release.tgz' || typeof artifact.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(artifact.sha256)) {
             throw new Error('manifest artifact is invalid');
           }
-          const actual = createHash('sha256').update(readFileSync(join(directory, 'release.tgz'))).digest('hex');
+          const actual = createHash('sha256').update(readFileSync(tarballPath)).digest('hex');
           if (actual !== artifact.sha256) throw new Error('checksum mismatch for release.tgz');
+          const packageJson = JSON.parse(execFileSync('tar', ['-xOf', tarballPath, 'package/package.json'], { encoding: 'utf8' }));
+          if (packageJson.name !== manifest.package_name) throw new Error('tarball package name does not match manifest');
+          if (packageJson.version !== manifest.package_version) throw new Error('tarball package version does not match manifest');
+          const [major, minor, patch] = String(packageJson.version).split('.');
+          const allowed = [`v${packageJson.version}`];
+          if (patch === '0') allowed.push(`v${major}.${minor}`);
+          if (!allowed.includes(process.env.GITHUB_REF_NAME)) {
+            throw new Error(`tag ${process.env.GITHUB_REF_NAME} does not match package version ${packageJson.version}`);
+          }
           NODE
-      - name: Verify package identity from staged artifacts
-        run: |
-          tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs > "$RUNNER_TEMP/verify-release-artifacts.mjs"
-          node "$RUNNER_TEMP/verify-release-artifacts.mjs" release
       - name: Publish or verify npm package
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,120 +2,206 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  classify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
+      release_kind: ${{ steps.release_tag.outputs.release_kind }}
       npm_publish: ${{ steps.release_tag.outputs.npm_publish }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
-          cache: npm
-          registry-url: 'https://registry.npmjs.org'
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.24'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm test
-      - name: Verify composite sibling pins
-        run: node scripts/check-sibling-pins.mjs
-      - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
-      - name: Run actionlint
-        run: |
-          ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
-          "$ACTIONLINT_BIN"
-      - name: Verify release tag matches package version
+      - name: Classify release tag
         id: release_tag
         run: |
-          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
-            echo "::error::Release workflow must run from a v* tag; got $GITHUB_REF"
-            exit 1
-          fi
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
           PKG_VERSION=$(node -p "require('./package.json').version")
           IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
-          PUBLISH_TAGS=("$PKG_VERSION")
-          if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
-            PUBLISH_TAGS+=("$MAJOR.$MINOR")
+          IMMUTABLE=("v$PKG_VERSION")
+          if [ "$PATCH" = "0" ]; then IMMUTABLE+=("v$MAJOR.$MINOR"); fi
+          if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+            echo "::error::Release workflow must run from an accepted immutable tag; got $GITHUB_REF; expected ${IMMUTABLE[*]} or v$MAJOR"
+            exit 1
           fi
-          for PUBLISH_TAG in "${PUBLISH_TAGS[@]}"; do
-            if [ "$TAG_VERSION" = "$PUBLISH_TAG" ]; then
-              echo "npm_publish=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          if [ "$TAG_VERSION" = "$MAJOR" ]; then
-            echo "npm_publish=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Tag v$TAG_VERSION is the rolling alias for package version $PKG_VERSION; skipping npm publish."
-            exit 0
-          fi
-          if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then
-            EXPECTED="v${PUBLISH_TAGS[0]}, v${PUBLISH_TAGS[1]}, or v$MAJOR"
+          if [[ " ${IMMUTABLE[*]} " == *" $GITHUB_REF_NAME "* ]]; then
+            echo 'release_kind=immutable' >> "$GITHUB_OUTPUT"
+            echo 'npm_publish=true' >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REF_NAME" = "v$MAJOR" ]; then
+            echo 'release_kind=alias' >> "$GITHUB_OUTPUT"
+            echo 'npm_publish=false' >> "$GITHUB_OUTPUT"
+            echo "::notice::$GITHUB_REF_NAME is a rolling alias; no release work will run."
           else
-            EXPECTED="v${PUBLISH_TAGS[0]} or v$MAJOR"
+            echo "::error::Release workflow must run from an accepted immutable tag; got $GITHUB_REF; expected ${IMMUTABLE[*]} or v$MAJOR"
+            exit 1
           fi
-          echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
-          exit 1
+
+  verify-package:
+    needs: classify
+    if: needs.classify.outputs.release_kind == 'immutable'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/393031adb9afb225ee52ae2ccd7a5af5525e03e8/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
+          echo "ACTIONLINT_BIN=$RUNNER_TEMP/actionlint" >> "$GITHUB_ENV"
+      - name: Run gates
+        run: |
+          set -uo pipefail
+          declare -A pid=() result=(); declare -a names=(); MAX_PARALLEL_GATES=2
+          finish_one() { local finished_pid status n; if wait -n -p finished_pid "${pid[@]}"; then status=0; else status=$?; fi; for n in "${!pid[@]}"; do if [ "${pid[$n]}" = "$finished_pid" ]; then result[$n]=$status; unset 'pid[$n]'; return; fi; done; }
+          run() { while [ "${#pid[@]}" -ge "$MAX_PARALLEL_GATES" ]; do finish_one; done; local n=$1; shift; names+=("$n"); ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!; }
+          run lint npm run lint
+          run typecheck npm run typecheck
+          run test npm test
+          run sibling-pins node scripts/check-sibling-pins.mjs
+          run actionlint "$ACTIONLINT_BIN"
+          while [ "${#pid[@]}" -gt 0 ]; do finish_one; done
+          fail=0; for n in "${names[@]}"; do if [ "${result[$n]}" -eq 0 ]; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi; done; for n in "${names[@]}"; do echo "::group::$n"; cat "$n.log"; echo '::endgroup::'; done; exit $fail
+      - name: Package release artifact
+        run: |
+          set -euo pipefail
+          npm pack --pack-destination .
+          mv ./*.tgz release.tgz
+          SHA256=$(shasum -a 256 release.tgz | awk '{print $1}')
+          SHA256="$SHA256" node -e "const fs=require('fs');const p=require('./package.json');fs.writeFileSync('release-manifest.json',JSON.stringify({schema_version:1,repository:process.env.GITHUB_REPOSITORY,commit_sha:process.env.GITHUB_SHA,tag:process.env.GITHUB_REF_NAME,package_name:p.name,package_version:p.version,artifacts:[{path:'release.tgz',sha256:process.env.SHA256}]},null,2))"
+          node scripts/verify-release-artifacts.mjs .
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            release.tgz
+            release-manifest.json
+          if-no-files-found: error
+
+  publish:
+    needs: [classify, verify-package]
+    if: needs.classify.outputs.release_kind == 'immutable'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v7
+        with:
+          name: release-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release
+      - name: Verify release artifact envelope
+        run: |
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { readFileSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const directory = 'release';
+          const manifest = JSON.parse(readFileSync(join(directory, 'release-manifest.json'), 'utf8'));
+          if (manifest.schema_version !== 1) throw new Error('unsupported manifest schema');
+          for (const key of ['repository', 'commit_sha', 'tag', 'package_name', 'package_version']) {
+            if (typeof manifest[key] !== 'string' || manifest[key].length === 0) {
+              throw new Error(`manifest ${key} must be a non-empty string`);
+            }
+          }
+          for (const [key, expected] of Object.entries({
+            repository: process.env.GITHUB_REPOSITORY,
+            commit_sha: process.env.GITHUB_SHA,
+            tag: process.env.GITHUB_REF_NAME
+          })) {
+            if (manifest[key] !== expected) throw new Error(`${key} does not match this release`);
+          }
+          if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== 1) {
+            throw new Error('manifest artifact allowlist is invalid');
+          }
+          const artifact = manifest.artifacts[0];
+          if (artifact.path !== 'release.tgz' || typeof artifact.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(artifact.sha256)) {
+            throw new Error('manifest artifact is invalid');
+          }
+          const actual = createHash('sha256').update(readFileSync(join(directory, 'release.tgz'))).digest('hex');
+          if (actual !== artifact.sha256) throw new Error('checksum mismatch for release.tgz');
+          NODE
+      - name: Verify package identity from staged artifacts
+        run: |
+          tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs > "$RUNNER_TEMP/verify-release-artifacts.mjs"
+          node "$RUNNER_TEMP/verify-release-artifacts.mjs" release
+      - name: Publish or verify npm package
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name")
+          PKG_VERSION=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          SRI="sha512-$(openssl dgst -sha512 -binary release/release.tgz | openssl base64 -A)"
+          if EXISTING=$(npm view "$PKG_NAME@$PKG_VERSION" dist.integrity 2>/dev/null); then
+            [ "$EXISTING" = "$SRI" ] || { echo '::error::Published npm integrity differs from staged tarball'; exit 1; }
+          else
+            npm publish ./release/release.tgz --provenance --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
-      - uses: actions/setup-node@v7
-        if: steps.release_tag.outputs.npm_publish == 'true'
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Check npm package version
-        id: npm_package
-        if: steps.release_tag.outputs.npm_publish == 'true'
-        run: |
-          PKG_NAME=$(node -p "require('./package.json').name")
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
-            echo "already_published=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::$PKG_NAME@$PKG_VERSION is already published; skipping npm publish."
-          else
-            echo "already_published=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Publish to npm
-        if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Attach npm tarball to release
-        run: |
-          npm pack
-          mv ./*.tgz release.tgz
-      - name: Upload tarball
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: release.tgz
+          files: |
+            release/release.tgz
+            release/release-manifest.json
 
   advance-major-alias:
-    needs: release
-    if: ${{ needs.release.outputs.npm_publish == 'true' }}
+    needs: [classify, publish]
+    if: needs.classify.outputs.release_kind == 'immutable'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
-      - name: Force-move rolling major alias tag
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+      - name: Advance rolling major alias
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          MAJOR="v${VERSION%%.*}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          COMMIT="$(git rev-parse "HEAD^{commit}")"
-          git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$COMMIT"
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"; MAJOR="v${VERSION%%.*}"
+          set +e
+          ROWS=$(git ls-remote --tags origin "refs/tags/$MAJOR" "refs/tags/$MAJOR^{}" "refs/tags/$MAJOR.*")
+          LS_STATUS=$?
+          set -e
+          [ "$LS_STATUS" -eq 0 ] || exit "$LS_STATUS"
+          set +e
+          CURRENT=$(printf '%s\n' "$ROWS" | node scripts/check-release-alias.mjs "$MAJOR" "$GITHUB_REF_NAME")
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -eq 10 ]; then
+            echo "::notice::Keeping newer $MAJOR alias at v$CURRENT"
+            exit 0
+          fi
+          [ "$STATUS" -eq 0 ] || exit "$STATUS"
+          git config user.name 'github-actions[bot]'; git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$GITHUB_SHA"
           git push origin "$MAJOR" --force

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Run `postman-resolve-service-token-action` first and pass its `token` and `team-
 | Credential or permission | Where it appears | Required for | Source and permissions | Expiration behavior |
 | --- | --- | --- | --- | --- |
 | Service-account PMAK | `POSTMAN_API_KEY`, or `POSTMAN_SERVICE_ACCOUNT_API_KEY` in AWS examples | Access-token minting and the Postman CLI logins inside the wrapped actions (bootstrap spec lint, repo-sync generated-CI collection run) | GitHub secret backed by a [Postman service account](https://learning.postman.com/docs/administration/service-accounts/) API key | Long-lived until rotated in Postman and updated in CI |
-| Generated access token | `steps.postman-token.outputs.token`, passed as `postman-access-token` | Every Postman asset operation in the wrapped actions, routed through the access-token gateway (workspace, spec, collection, environment, mock, monitor, tagging, identity) | Minted by `postman-resolve-service-token-action` from the service-account PMAK | Fresh per workflow run; avoid storing unless a scheduled refresh workflow intentionally writes `POSTMAN_ACCESS_TOKEN` |
+| Generated access token | `steps.postman-token.outputs.token`, passed as `postman-access-token` | Every Postman asset operation in bootstrap and repo sync, routed through the access-token gateway (workspace, spec, collection, environment, mock, monitor, tagging, identity) | Minted by `postman-resolve-service-token-action` from the service-account PMAK | Fresh per workflow run; avoid storing unless a scheduled refresh workflow intentionally writes `POSTMAN_ACCESS_TOKEN` |
+| Human-user Insights credentials | `insights-postman-api-key`, `insights-postman-access-token` | Optional Insights linking only | A human workspace-admin user's PMAK and session access token, stored as separate GitHub secrets | Required together only when `enable-insights: true`; never substitute the service-account suite credentials |
 | Team ID | `steps.postman-token.outputs.team-id`, passed as `postman-team-id`; direct bootstrap workflows may use `workspace-team-id` | Org-mode integration headers and sub-team workspace creation | Emitted by `postman-resolve-service-token-action`, or stored as a repository/org variable when the sub-team is fixed | Not a secret and does not expire, but update it if the target Postman team changes |
 | GitHub token | `github-token`, `gh-fallback-token`, or `${{ github.token }}` | Artifact commits, repository variables, generated workflow files, and optional secret writes | `GITHUB_TOKEN` needs `contents: write`; generated workflow updates need `actions: write`; repository secret writes need a PAT or GitHub App token with secrets write permission | `GITHUB_TOKEN` is job-scoped; PAT/App token lifetime follows its issuer policy |
 | AWS OIDC | `permissions: id-token: write` plus `aws-actions/configure-aws-credentials` | AWS Spec Discovery before onboarding | GitHub OIDC role assumption with least-privilege read permissions for API Gateway, AppSync, EventBridge, Lambda, or the providers you enable | Temporary AWS credentials for the job; no static AWS key is stored |
@@ -164,7 +165,7 @@ The full pattern, including sync-branch creation and programmatic PR opening, is
 
 ### Insights linking
 
-When `enable-insights: true`, the action chains `postman-cs/postman-insights-onboarding-action@v2` after bootstrap and repo sync, using the workspace from bootstrap plus the first environment from `environments-json`.
+When `enable-insights: true`, the action chains `postman-cs/postman-insights-onboarding-action@v2` after bootstrap and repo sync, using the workspace from bootstrap plus the first environment from `environments-json`. Insights requires a separate human-user PMAK and human-user session access token; do not pass the service-account credentials used by bootstrap and repo sync.
 
 ```yaml
 - uses: actions/checkout@v5
@@ -183,6 +184,8 @@ When `enable-insights: true`, the action chains `postman-cs/postman-insights-onb
     cluster-name: my-cluster
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
     postman-access-token: ${{ steps.postman-token.outputs.token }}
+    insights-postman-api-key: ${{ secrets.POSTMAN_INSIGHTS_USER_API_KEY }}
+    insights-postman-access-token: ${{ secrets.POSTMAN_INSIGHTS_USER_ACCESS_TOKEN }}
     postman-team-id: ${{ steps.postman-token.outputs.team-id }}
 ```
 
@@ -259,7 +262,9 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `env-runtime-urls-json` | JSON map of environment slug to runtime base URL. | no | `{}` |
 | `postman-api-key` | Postman API key (PMAK). Threaded to the wrapped actions to mint and re-mint the access token and to authenticate the Postman CLI logins (bootstrap spec lint, repo-sync generated-CI collection run). Individually optional; at least one of postman-api-key or postman-access-token is required. | no |  |
 | `postman-access-token` | Postman access token (x-access-token). Primary credential threaded to the wrapped actions; every Postman asset operation runs through the access-token gateway. Mint it with postman-resolve-service-token-action. Individually optional; at least one of postman-api-key or postman-access-token is required. | no |  |
-| `credential-preflight` | Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created. | no | `warn` |
+| `insights-postman-api-key` | Human-user Postman API key (PMAK) for Insights. Required with insights-postman-access-token only when enable-insights is true; do not use the service-account suite key. | no |  |
+| `insights-postman-access-token` | Human-user session access token for Insights. Required with insights-postman-api-key only when enable-insights is true; do not use a service-token mint. | no |  |
+| `credential-preflight` | Credential identity preflight policy forwarded to bootstrap and repo sync. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created. | no | `warn` |
 | `postman-team-id` | Explicit Postman team ID override for org-mode integration calls. | no |  |
 | `postman-region` | Postman data residency region for public API and Postman CLI calls. One of us or eu. | no | `us` |
 | `github-token` | GitHub token used for repo variables and generated commits. | no |  |

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Between repo sync and Insights, the action runs the generated smoke and contract
 
 Running outside GitHub Actions (GitLab CI, Bitbucket Pipelines, Azure DevOps)? The bootstrap and repo-sync CLIs cover that: see [docs/non-github-ci.md](docs/non-github-ci.md).
 
-Releases use immutable `v1.x.y` tags with `v1` as the rolling release channel; pin an immutable tag for reproducibility. See [RELEASE_POLICY.md](RELEASE_POLICY.md).
+Releases use immutable `v2.x.y` tags with `v2` as the rolling release channel; pin an immutable tag for reproducibility. See [RELEASE_POLICY.md](RELEASE_POLICY.md).
 
 ## Resources
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -23,7 +23,10 @@ It applies to these repositories:
 
 - Each repository owns its own CI workflow and its own `v*` tag-triggered GitHub release workflow.
 - The composite action references sibling actions through immutable release tags in `action.yml`.
-- The public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier.
+- Immutable release identity is derived from the repository `package.json` version at the tagged commit:
+  exact `vX.Y.Z`, plus `vX.Y` when the patch component is `0`.
+- The current consumer rolling channel for this composite is `v2`.
+- The public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier by themselves.
 
 ## Source of truth
 
@@ -38,16 +41,19 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 ## Tag policy
 
-- Immutable release tags use the public `v1.x.y` pattern.
-- The moving `v1` tag is the rolling release channel.
-- Never rewrite or force-push an existing release tag.
-- Every public tag should have a corresponding GitHub release with generated notes.
+- Immutable release tags are version-derived (`vX.Y.Z`, and `vX.Y` only when patch is `0`).
+  These tags are never rewritten or force-pushed.
+- The moving `v2` tag is the current rolling consumer channel for this composite.
+  Rolling aliases are deliberately movable and may be force-updated forward only;
+  they must never regress to an older immutable version.
+- Immutable release tags have a corresponding GitHub release with generated notes;
+  a direct rolling-alias invocation is a successful no-op.
 
 ## Consumer guidance
 
-- Use `@v1` in quick-start examples when the goal is a short marketplace install path.
-- Recommend immutable tags such as `@v1.x.y` for reproducible production workflows.
-- Treat `@v1` as a convenience channel; pin an immutable `@v1.x.y` tag or commit SHA when you need a reproducible reference.
+- Use `@v2` in quick-start examples when the goal is a short marketplace install path.
+- Recommend immutable tags such as `@v2.x.y` for reproducible production workflows.
+- Treat `@v2` as a convenience channel; pin an immutable `@v2.x.y` tag or commit SHA when you need a reproducible reference.
 - For security-sensitive environments, document that SHA pinning is the strongest option.
 
 ## Composite dependency policy
@@ -56,7 +62,7 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.5`
+- `postman-cs/postman-bootstrap-action@v2.10.7`
 - `postman-cs/postman-repo-sync-action@v2.1.10`
 - `postman-cs/postman-insights-onboarding-action@v2.1.4` when Insights is enabled
 
@@ -84,37 +90,22 @@ Release from the bottom up:
 6. Update `README.md`, this file, and any compatibility notes affected by the release.
 7. Release `postman-api-onboarding-action` last.
 
-## Live E2E Release Gate
+## Verification and live monitors
 
-Phase 1 of the live release gate covers only the actions currently exercised by
-`postman-cs/postman-actions-e2e` as released CLI artifacts:
+Pull requests and immutable releases run deterministic repository-local checks.
+The composite release verifies immutable sibling pins before packaging. Its
+release workflow classifies a tag before installing dependencies, validates and
+packs in an unprivileged job, then publishes only checksummed staged artifacts in
+the privileged job. Trusted envelope verification establishes artifact identity
+and checksums before any packaged verifier code is extracted. npm publication
+(or SRI identity verification on retry) precedes the GitHub Release; the rolling
+`v2` alias advances only after that work and never regresses to an older
+immutable version.
 
-- `postman-resolve-service-token-action`
-- `postman-bootstrap-action`
-- `postman-repo-sync-action`
-- `postman-smoke-flow-action`
-
-For those repos, pull requests targeting `main` must pass the central live e2e
-gate before approval or merge. The PR workflow dispatches
-`postman-cs/postman-actions-e2e` with the PR head SHA pinned for the changed
-action and waits for the correlated run to succeed. Branches must live in the
-target repository so GitHub can provide the central e2e dispatch secret; forked
-PRs cannot satisfy the required merge gate until moved to an in-repo branch.
-
-For those repos, immutable publishing tags must pass the central live e2e gate
-before any GitHub release, npm package, or release tarball is published. The
-release workflow validates locally, dispatches the central e2e workflow with the
-exact action tag pinned, waits for the correlated workflow run to conclude
-successfully, and only then publishes. The release log must include the e2e run
-URL, correlation id, and conclusion.
-
-The rolling `v1` alias validates locally but skips npm publish
-and the live e2e gate.
-
-The composite action, Insights onboarding, and AWS spec discovery are not
-directly live-e2e-gated in Phase 1. Do not describe releases in those repos as
-live-e2e-gated until the harness adds real coverage for the released artifact and
-the repo's release workflow blocks on that gate.
+Live sandbox E2E is not a PR or publication gate. The `onboarding-e2e` harness
+runs a nightly `full` monitor and receives asynchronous post-release `smoke`
+monitor dispatches for covered actions. Monitor failures remain observable but do
+not block merge, npm publication, GitHub Release creation, or rolling aliases.
 
 ## Compatibility matrix
 
@@ -122,7 +113,7 @@ This matrix describes the current release model.
 
 | Composite reference used by consumers | Composite repository content | Lower-level dependency references | Result |
 | --- | --- | --- | --- |
-| `postman-api-onboarding-action@v1` | Rolling composite alias | Immutable sibling tags in the current composite content | Rolling composite channel with pinned siblings per composite revision |
+| `postman-api-onboarding-action@v2` | Rolling composite alias | Immutable sibling tags in the current composite content | Rolling composite channel with pinned siblings per composite revision |
 | Immutable composite release | Immutable composite repo tag | Immutable sibling tags | Fully reproducible |
 
 ## Marketplace documentation surface
@@ -144,10 +135,10 @@ Before pushing a new release tag:
 4. Confirm `README.md` and `RELEASE_POLICY.md` still match the actual composite wiring.
 5. Confirm `SUPPORT.md` and `SECURITY.md` still match the current support and vulnerability-reporting paths.
 6. If lower-level actions changed behavior, verify whether the composite repo needs a coordinated release.
-7. For a live-e2e-gated repo, confirm `E2E_DISPATCH_TOKEN` is configured and the
-   release workflow records a successful central e2e run before publish.
-8. Push the immutable release tag.
-9. Confirm that the matching GitHub release was published with generated notes.
+7. Push the immutable release tag.
+8. Confirm npm publication or matching SRI retry identity, then the matching
+   GitHub release and rolling alias update.
+9. Review asynchronous post-release monitor results when the action is covered.
 
 ## What changes the policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Only the latest `v1.x.y` release (tracked by the rolling `v1` alias) receives security fixes. Older tags remain published for reproducibility and are never retroactively modified.
+Only the latest `v2.x.y` release (tracked by the rolling `v2` alias) receives security fixes. Older tags remain published for reproducibility and are never retroactively modified.
 
 ## Credential Handling
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,11 +11,13 @@ This composite action accepts credentials and forwards them to the lower-level o
 | Credential | Purpose | Guidance |
 | --- | --- | --- |
 | `postman-api-key` | Standard Postman API operations, including workspace, spec, collection, environment, mock, and monitor management. | Store it as a GitHub secret. Never echo it in caller workflow steps. |
-| `postman-access-token` | Governance, workspace linking, and Insights operations. | Prefer `postman-resolve-service-token-action` and pass its `token` output into this action. |
+| `postman-access-token` | Governance and workspace linking for bootstrap and repo sync. | Prefer `postman-resolve-service-token-action` and pass its `token` output into this action. |
+| `insights-postman-api-key` | Human-user PMAK for optional Insights linking. | Required with `insights-postman-access-token` only when `enable-insights: true`; store as a separate secret and never substitute the suite service-account key. |
+| `insights-postman-access-token` | Human-user session access token for optional Insights linking. | Required with `insights-postman-api-key` only when `enable-insights: true`; store as a separate secret and never use a minted service token. |
 | `postman-team-id` | Explicit team context for org-mode integration calls. | Prefer `postman-resolve-service-token-action` and pass its `team-id` output into this action. |
 | `postman-region` | Data residency region for Postman API and Postman CLI calls. | Use `us` or `eu`; keep the same region on service-token and onboarding steps. |
 
-The Postman CLI credential store created by `postman login` is a legacy fallback for `postman-access-token`. Service-token minting remains the primary CI path. Do not use copied web-session credentials in shared workflows.
+Service-token minting remains the primary CI path for bootstrap and repo sync. Insights is the exception: it requires a dedicated human-user PMAK and session access token for the same workspace-admin identity. Do not reuse copied web-session credentials for suite operations.
 
 ## Reporting a Vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,7 +15,7 @@ Use this repository for issues with the composite Postman API Onboarding action:
 
 Include the details that let maintainers reproduce the workflow without exposing secrets:
 
-- Action reference used, such as `postman-cs/postman-api-onboarding-action@v1` or an immutable `v1.x.y` tag.
+- Action reference used, such as `postman-cs/postman-api-onboarding-action@v2` or an immutable `v2.x.y` tag.
 - Whether the workflow used `postman-resolve-service-token-action` for `postman-access-token` and `postman-team-id`.
 - `postman-region` and whether `org-mode` was enabled.
 - Redacted workflow YAML for the failing steps.
@@ -26,4 +26,4 @@ Never paste Postman API keys, access tokens, service-token outputs, GitHub token
 
 ## Version Guidance
 
-Use `@v1` for the shortest marketplace install path. Use an immutable `@v1.x.y` tag or a commit SHA when reproducibility matters. See [RELEASE_POLICY.md](RELEASE_POLICY.md) for release sequencing and tag policy.
+Use `@v2` for the shortest marketplace install path. Use an immutable `@v2.x.y` tag or a commit SHA when reproducibility matters. See [RELEASE_POLICY.md](RELEASE_POLICY.md) for release sequencing and tag policy.

--- a/action.yml
+++ b/action.yml
@@ -141,8 +141,14 @@ inputs:
   postman-access-token:
     description: Postman access token (x-access-token). Primary credential threaded to the wrapped actions; every Postman asset operation runs through the access-token gateway. Mint it with postman-resolve-service-token-action. Individually optional; at least one of postman-api-key or postman-access-token is required.
     required: false
+  insights-postman-api-key:
+    description: Human-user Postman API key (PMAK) for Insights. Required with insights-postman-access-token only when enable-insights is true; do not use the service-account suite key.
+    required: false
+  insights-postman-access-token:
+    description: Human-user session access token for Insights. Required with insights-postman-api-key only when enable-insights is true; do not use a service-token mint.
+    required: false
   credential-preflight:
-    description: "Credential identity preflight policy forwarded to bootstrap, repo sync, and insights. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created."
+    description: "Credential identity preflight policy forwarded to bootstrap and repo sync. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created."
     required: false
     default: warn
   postman-team-id:
@@ -293,6 +299,9 @@ runs:
         REPO_WRITE_MODE: ${{ inputs.repo-write-mode }}
         POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
         POSTMAN_ACCESS_TOKEN: ${{ inputs.postman-access-token }}
+        ENABLE_INSIGHTS: ${{ inputs.enable-insights }}
+        INSIGHTS_POSTMAN_API_KEY: ${{ inputs.insights-postman-api-key }}
+        INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ inputs.insights-postman-access-token }}
       run: |
         case "$POSTMAN_STACK" in
           prod|beta) ;;
@@ -328,6 +337,10 @@ runs:
         esac
         if [ -z "$POSTMAN_API_KEY" ] && [ -z "$POSTMAN_ACCESS_TOKEN" ]; then
           echo "::error::Attempted onboarding credential validation failed: neither postman-api-key nor postman-access-token was supplied. Provide one of those inputs and rerun."
+          exit 1
+        fi
+        if [ "$ENABLE_INSIGHTS" = "true" ] && { [ -z "$INSIGHTS_POSTMAN_API_KEY" ] || [ -z "$INSIGHTS_POSTMAN_ACCESS_TOKEN" ]; }; then
+          echo "::error::Attempted Insights credential validation failed: both insights-postman-api-key and insights-postman-access-token are required when enable-insights=true. Provide human-user credentials and rerun."
           exit 1
         fi
     - id: bootstrap
@@ -570,8 +583,8 @@ runs:
         environment-id: ${{ fromJSON(steps.repo_sync.outputs.environment-uids-json)[fromJSON(inputs.environments-json)[0]] }}
         system-environment-id: ${{ fromJSON(inputs.system-env-map-json)[fromJSON(inputs.environments-json)[0]] }}
         cluster-name: ${{ inputs.cluster-name }}
-        postman-api-key: ${{ inputs.postman-api-key }}
-        postman-access-token: ${{ inputs.postman-access-token }}
+        postman-api-key: ${{ inputs.insights-postman-api-key }}
+        postman-access-token: ${{ inputs.insights-postman-access-token }}
         credential-preflight: ${{ inputs.credential-preflight }}
         postman-team-id: ${{ inputs.postman-team-id }}
         github-token: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -345,7 +345,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.5
+      uses: postman-cs/postman-bootstrap-action@v2.10.7
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -4,7 +4,7 @@
 
 The `postman-api-key` is a [Postman API key](https://learning.postman.com/docs/reference/postman-api/authentication/) (PMAK) used for all standard Postman API operations: creating workspaces, uploading specs, generating collections, exporting artifacts, and managing environments.
 
-For CI, use a service-account PMAK. The same key can run the standard Postman API calls and mint the short-lived access token used by integration steps. See the [service accounts documentation](https://learning.postman.com/docs/administration/service-accounts/) for setup and assignment guidance.
+For bootstrap and repo-sync CI operations, use a service-account PMAK. The same key can run the standard Postman API calls and mint the short-lived access token used by integration steps. See the [service accounts documentation](https://learning.postman.com/docs/administration/service-accounts/) for setup and assignment guidance. Insights is an exception: it requires separate human-user credentials described below.
 
 To generate one:
 
@@ -87,6 +87,12 @@ The [roles and permissions](https://learning.postman.com/docs/administration/rol
 
 ## API key auto-creation
 
-`postman-api-key` and `postman-access-token` are individually optional, but at least one is required. Access-token-only runs match the wrapped bootstrap/repo-sync contract: the composite fails in the first validation step when neither credential is present. Built-in Postman CLI smoke/contract tests still need a PMAK (they use `postman login --with-api-key`); without one the composite skips those tests with a warning. `postman-repo-sync-action` and `postman-insights-onboarding-action` can create or rotate a PMAK from `postman-access-token` when they encounter a clear auth failure.
+`postman-api-key` and `postman-access-token` are individually optional, but at least one is required. Access-token-only runs match the wrapped bootstrap/repo-sync contract: the composite fails in the first validation step when neither credential is present. Built-in Postman CLI smoke/contract tests still need a PMAK (they use `postman login --with-api-key`); without one the composite skips those tests with a warning. Repo sync can create or rotate a PMAK from `postman-access-token` when it encounters a clear auth failure.
+
+## Insights credentials
+
+When `enable-insights: true`, provide both `insights-postman-api-key` and `insights-postman-access-token`. They must be a human workspace-admin user's PMAK and session access token for the same identity. Store them as separate CI secrets, such as `POSTMAN_INSIGHTS_USER_API_KEY` and `POSTMAN_INSIGHTS_USER_ACCESS_TOKEN`.
+
+Do not use `postman-resolve-service-token-action` outputs, a service-account PMAK, or the suite `postman-api-key` / `postman-access-token` for Insights. When Insights is disabled, both dedicated inputs may be empty.
 
 For org-wide API key expiration, revocation, and exposed-key handling, see the [managing API keys](https://learning.postman.com/docs/administration/managing-your-team/managing-api-keys/) guide.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -25,12 +25,12 @@ Primary path: mint the token with [postman-resolve-service-token-action](https:/
 
 ```yaml
 - id: postman_token
-  uses: postman-cs/postman-resolve-service-token-action@v1
+  uses: postman-cs/postman-resolve-service-token-action@v2
   with:
     postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
     postman-region: us
 
-- uses: postman-cs/postman-api-onboarding-action@v1
+- uses: postman-cs/postman-api-onboarding-action@v2
   with:
     project-name: core-payments
     spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml

--- a/docs/deferred-tests.md
+++ b/docs/deferred-tests.md
@@ -13,7 +13,7 @@ Caller pattern when `skip-built-in-tests: true`:
 
 ```yaml
 - id: onboard
-  uses: postman-cs/postman-api-onboarding-action@v1
+  uses: postman-cs/postman-api-onboarding-action@v2
   with:
     # ...standard inputs...
     skip-built-in-tests: 'true'

--- a/docs/protected-branch-workflows.md
+++ b/docs/protected-branch-workflows.md
@@ -44,12 +44,12 @@ jobs:
           git switch -c "$BRANCH"
           echo "SYNC_BRANCH=$BRANCH" >> "$GITHUB_ENV"
       - id: postman-token
-        uses: postman-cs/postman-resolve-service-token-action@v1
+        uses: postman-cs/postman-resolve-service-token-action@v2
         with:
           postman-api-key: ${{ secrets.POSTMAN_API_KEY }}
           postman-region: us
       - id: onboard
-        uses: postman-cs/postman-api-onboarding-action@v1
+        uses: postman-cs/postman-api-onboarding-action@v2
         with:
           project-name: core-payments
           spec-url: https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",
-    "README.md"
+    "README.md",
+    "scripts/verify-release-artifacts.mjs"
   ],
   "engines": {
     "node": ">=24"

--- a/scripts/check-release-alias.mjs
+++ b/scripts/check-release-alias.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/* global console, process */
+import { fileURLToPath } from 'node:url';
+
+const MAJOR_ALIAS = /^v(\d+)$/;
+const IMMUTABLE_FULL = /^v(\d+)\.(\d+)\.(\d+)$/;
+const IMMUTABLE_MINOR = /^v(\d+)\.(\d+)$/;
+
+/**
+ * @param {string} version
+ * @returns {[number, number, number]}
+ */
+export function parseSemverParts(version) {
+  const raw = String(version).replace(/^v/, '');
+  const parts = raw.split('.').map((part) => Number(part));
+  if (parts.length === 2) parts.push(0);
+  if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n) || n < 0 || Number.isNaN(n))) {
+    throw new Error(`invalid semver: ${version}`);
+  }
+  return /** @type {[number, number, number]} */ (parts);
+}
+
+/**
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function compareSemver(a, b) {
+  const left = parseSemverParts(a);
+  const right = parseSemverParts(b);
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i] !== right[i]) return left[i] < right[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * @param {string} text
+ * @returns {Map<string, { object: string | null, peeled: string | null }>}
+ */
+export function parseLsRemoteLines(text) {
+  /** @type {Map<string, { object: string | null, peeled: string | null }>} */
+  const tags = new Map();
+  for (const line of String(text ?? '').split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const match = line.match(/^([0-9a-f]{40})\trefs\/tags\/(.+)$/);
+    if (!match) continue;
+    const sha = match[1];
+    const rawName = match[2];
+    const peeled = rawName.endsWith('^{}');
+    const name = peeled ? rawName.slice(0, -3) : rawName;
+    const entry = tags.get(name) ?? { object: null, peeled: null };
+    if (peeled) entry.peeled = sha;
+    else entry.object = sha;
+    tags.set(name, entry);
+  }
+  return tags;
+}
+
+/**
+ * Resolve lightweight (`object`) or annotated (`peeled`) tag targets.
+ * @param {Map<string, { object: string | null, peeled: string | null }>} tags
+ * @param {string} name
+ * @returns {string | null}
+ */
+export function resolveTagCommit(tags, name) {
+  const entry = tags.get(name);
+  if (!entry) return null;
+  return entry.peeled ?? entry.object;
+}
+
+/**
+ * @param {string} tagName
+ * @param {number} majorNum
+ */
+export function isSameMajorImmutableTag(tagName, majorNum) {
+  const full = tagName.match(IMMUTABLE_FULL);
+  if (full) return Number(full[1]) === majorNum;
+  const minor = tagName.match(IMMUTABLE_MINOR);
+  if (!minor || MAJOR_ALIAS.test(tagName)) return false;
+  return Number(minor[1]) === majorNum;
+}
+
+/**
+ * @param {string} tagName
+ * @returns {string}
+ */
+export function versionFromImmutableTag(tagName) {
+  const full = tagName.match(IMMUTABLE_FULL);
+  if (full) return `${full[1]}.${full[2]}.${full[3]}`;
+  const minor = tagName.match(IMMUTABLE_MINOR);
+  if (minor && !MAJOR_ALIAS.test(tagName)) return `${minor[1]}.${minor[2]}.0`;
+  throw new Error(`not an immutable tag: ${tagName}`);
+}
+
+/**
+ * @param {string} majorAlias
+ * @param {string} candidateTag
+ * @returns {{ majorNum: number, candidateVersion: string }}
+ */
+export function parseAliasArgs(majorAlias, candidateTag) {
+  const majorMatch = String(majorAlias ?? '').match(MAJOR_ALIAS);
+  if (!majorMatch) throw new Error(`malformed major alias: ${majorAlias}`);
+  const majorNum = Number(majorMatch[1]);
+  const full = String(candidateTag ?? '').match(IMMUTABLE_FULL);
+  if (full) {
+    if (Number(full[1]) !== majorNum) throw new Error(`mismatched major: ${candidateTag} vs ${majorAlias}`);
+    return { majorNum, candidateVersion: `${full[1]}.${full[2]}.${full[3]}` };
+  }
+  const minor = String(candidateTag ?? '').match(IMMUTABLE_MINOR);
+  if (minor && !MAJOR_ALIAS.test(candidateTag)) {
+    if (Number(minor[1]) !== majorNum) throw new Error(`mismatched major: ${candidateTag} vs ${majorAlias}`);
+    return { majorNum, candidateVersion: `${minor[1]}.${minor[2]}.0` };
+  }
+  throw new Error(`malformed candidate immutable tag: ${candidateTag}`);
+}
+
+/**
+ * @param {{ majorAlias: string, candidateTag: string, lsRemoteText: string }} input
+ * @returns {{ status: number, reason: string, currentVersion?: string }}
+ */
+export function decideAliasAdvance({ majorAlias, candidateTag, lsRemoteText }) {
+  const { majorNum, candidateVersion } = parseAliasArgs(majorAlias, candidateTag);
+  const tags = parseLsRemoteLines(lsRemoteText);
+  const aliasCommit = resolveTagCommit(tags, majorAlias);
+  if (!aliasCommit) return { status: 0, reason: 'absent' };
+
+  /** @type {string[]} */
+  const versions = [];
+  for (const name of tags.keys()) {
+    if (!isSameMajorImmutableTag(name, majorNum)) continue;
+    if (resolveTagCommit(tags, name) !== aliasCommit) continue;
+    versions.push(versionFromImmutableTag(name));
+  }
+  const unique = [...new Set(versions)];
+  if (unique.length === 0) {
+    throw new Error(`existing alias ${majorAlias} cannot be safely resolved to a same-major immutable tag`);
+  }
+  unique.sort(compareSemver);
+  const currentVersion = unique[unique.length - 1];
+  if (compareSemver(currentVersion, candidateVersion) > 0) {
+    return { status: 10, reason: 'newer', currentVersion };
+  }
+  return { status: 0, reason: compareSemver(currentVersion, candidateVersion) === 0 ? 'same' : 'older', currentVersion };
+}
+
+async function readStdin() {
+  let text = '';
+  for await (const chunk of process.stdin) {
+    text += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+  }
+  return text;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [majorAlias, candidateTag] = process.argv.slice(2);
+  if (!majorAlias || !candidateTag) {
+    console.error('usage: node scripts/check-release-alias.mjs <majorAlias> <candidateImmutableTag>');
+    process.exit(2);
+  }
+  try {
+    const lsRemoteText = await readStdin();
+    const result = decideAliasAdvance({ majorAlias, candidateTag, lsRemoteText });
+    if (result.status === 10 && result.currentVersion) process.stdout.write(result.currentVersion);
+    process.exit(result.status);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/check-release-alias.mjs
+++ b/scripts/check-release-alias.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /* global console, process */
 import { fileURLToPath } from 'node:url';
 

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /* global console, process */
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/* global console, process */
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+const REQUIRED_FIELDS = ['repository', 'commit_sha', 'tag', 'package_name', 'package_version'];
+
+/**
+ * @param {string | Buffer} fileOrBytes
+ * @returns {string}
+ */
+export function sha256(fileOrBytes) {
+  const bytes = typeof fileOrBytes === 'string' ? readFileSync(fileOrBytes) : fileOrBytes;
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * @param {string | Buffer} fileOrBytes
+ * @returns {string}
+ */
+export function computeNpmSri(fileOrBytes) {
+  const bytes = typeof fileOrBytes === 'string' ? readFileSync(fileOrBytes) : fileOrBytes;
+  return `sha512-${createHash('sha512').update(bytes).digest('base64')}`;
+}
+
+/**
+ * @param {string} expected
+ * @param {string} actual
+ */
+export function assertNpmSriMatch(expected, actual) {
+  if (String(expected ?? '').trim() !== String(actual ?? '').trim()) {
+    throw new Error('Published npm integrity differs from staged tarball');
+  }
+}
+
+/**
+ * @param {string} tag
+ * @param {string} packageVersion
+ */
+export function validateTagVersion(tag, packageVersion) {
+  if (typeof tag !== 'string' || typeof packageVersion !== 'string') {
+    throw new Error('tag and package version must be strings');
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(packageVersion)) {
+    throw new Error(`invalid package version ${packageVersion}`);
+  }
+  const [major, minor, patch] = packageVersion.split('.');
+  const allowed = [`v${packageVersion}`];
+  if (patch === '0') allowed.push(`v${major}.${minor}`);
+  if (!allowed.includes(tag)) {
+    throw new Error(`tag ${tag} does not match package version ${packageVersion}`);
+  }
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ */
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`manifest ${label} must be a non-empty string`);
+  }
+}
+
+/**
+ * @param {unknown} manifest
+ * @param {{ repository: string, commitSha: string, tag: string }} expected
+ */
+export function validateManifest(manifest, expected) {
+  if (!manifest || typeof manifest !== 'object') throw new Error('unsupported manifest schema');
+  const body = /** @type {Record<string, unknown>} */ (manifest);
+  if (body.schema_version !== 1) throw new Error('unsupported manifest schema');
+  for (const key of REQUIRED_FIELDS) assertNonEmptyString(body[key], key);
+  for (const [key, value] of Object.entries({
+    repository: expected.repository,
+    commit_sha: expected.commitSha,
+    tag: expected.tag
+  })) {
+    if (body[key] !== value) throw new Error(`${key} does not match this release`);
+  }
+  if (!Array.isArray(body.artifacts) || body.artifacts.length !== 1) {
+    throw new Error('manifest artifact allowlist is invalid');
+  }
+  const artifact = /** @type {Record<string, unknown>} */ (body.artifacts[0] ?? {});
+  if (artifact.path !== 'release.tgz' || typeof artifact.sha256 !== 'string' || !SHA256_HEX.test(artifact.sha256)) {
+    throw new Error('manifest artifact is invalid');
+  }
+  return body;
+}
+
+/**
+ * @param {string} tarball
+ * @returns {{ name: string, version: string }}
+ */
+function packageJson(tarball) {
+  return JSON.parse(execFileSync('tar', ['-xOf', tarball, 'package/package.json'], { encoding: 'utf8' }));
+}
+
+/**
+ * @param {string} directory
+ * @param {{ repository: string, commitSha: string, tag: string }} expected
+ */
+export function verifyReleaseArtifacts(directory, expected) {
+  const manifestPath = path.join(directory, 'release-manifest.json');
+  if (!existsSync(manifestPath)) throw new Error('Release artifact verification failed: missing release-manifest.json');
+  let manifest;
+  try {
+    manifest = validateManifest(JSON.parse(readFileSync(manifestPath, 'utf8')), expected);
+  } catch (error) {
+    throw new Error(`Release artifact verification failed: ${error instanceof Error ? error.message : String(error)}`, {
+      cause: error
+    });
+  }
+  const artifact = /** @type {{ path: string, sha256: string }} */ (/** @type {unknown[]} */ (manifest.artifacts)[0]);
+  const tarball = path.join(directory, artifact.path);
+  if (!existsSync(tarball)) {
+    throw new Error(`Release artifact verification failed: missing artifact ${artifact.path}`);
+  }
+  if (sha256(tarball) !== artifact.sha256) {
+    throw new Error(`Release artifact verification failed: checksum mismatch for ${artifact.path}`);
+  }
+  const pkg = packageJson(tarball);
+  if (pkg.name !== manifest.package_name) {
+    throw new Error('Release artifact verification failed: package name does not match manifest');
+  }
+  if (pkg.version !== manifest.package_version) {
+    throw new Error('Release artifact verification failed: package version does not match manifest');
+  }
+  try {
+    validateTagVersion(expected.tag, pkg.version);
+  } catch (error) {
+    throw new Error(`Release artifact verification failed: ${error instanceof Error ? error.message : String(error)}`, {
+      cause: error
+    });
+  }
+  return manifest;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const directory = path.resolve(process.argv[2] ?? '.');
+    verifyReleaseArtifacts(directory, {
+      repository: process.env.GITHUB_REPOSITORY ?? '',
+      commitSha: process.env.GITHUB_SHA ?? '',
+      tag: process.env.GITHUB_REF_NAME ?? ''
+    });
+    console.log('Release artifacts match the manifest and invocation identity.');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/templates/azure-devops/windows-onboarding.yml
+++ b/templates/azure-devops/windows-onboarding.yml
@@ -241,6 +241,9 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($env:INSIGHTS_CLUSTER_NAME)) {
             throw 'insightsClusterName is required when enableInsights is true.'
           }
+          if ([string]::IsNullOrWhiteSpace($env:INSIGHTS_POSTMAN_API_KEY) -or [string]::IsNullOrWhiteSpace($env:INSIGHTS_POSTMAN_ACCESS_TOKEN)) {
+            throw 'INSIGHTS_POSTMAN_API_KEY and INSIGHTS_POSTMAN_ACCESS_TOKEN are required human-user credentials when enableInsights is true.'
+          }
           $environmentMap = $env:POSTMAN_ENVIRONMENT_UIDS_JSON | ConvertFrom-Json
           $environmentId = $environmentMap.PSObject.Properties[0].Value
           if ([string]::IsNullOrWhiteSpace($environmentId)) {
@@ -252,8 +255,8 @@ jobs:
             '--environment-id', $environmentId,
             '--cluster-name', $env:INSIGHTS_CLUSTER_NAME,
             '--repo-url', $env:BUILD_REPOSITORY_URI,
-            '--postman-api-key', $env:POSTMAN_API_KEY,
-            '--postman-access-token', $env:POSTMAN_ACCESS_TOKEN,
+            '--postman-api-key', $env:INSIGHTS_POSTMAN_API_KEY,
+            '--postman-access-token', $env:INSIGHTS_POSTMAN_ACCESS_TOKEN,
             '--postman-region', $env:POSTMAN_REGION,
             '--postman-stack', $env:POSTMAN_STACK
           )
@@ -266,8 +269,8 @@ jobs:
           INSIGHTS_CLUSTER_NAME: ${{ parameters.insightsClusterName }}
           POSTMAN_WORKSPACE_ID: $(POSTMAN_WORKSPACE_ID)
           POSTMAN_ENVIRONMENT_UIDS_JSON: $(POSTMAN_ENVIRONMENT_UIDS_JSON)
-          POSTMAN_API_KEY: $(POSTMAN_API_KEY)
-          POSTMAN_ACCESS_TOKEN: $(POSTMAN_ACCESS_TOKEN)
+          INSIGHTS_POSTMAN_API_KEY: $(INSIGHTS_POSTMAN_API_KEY)
+          INSIGHTS_POSTMAN_ACCESS_TOKEN: $(INSIGHTS_POSTMAN_ACCESS_TOKEN)
           POSTMAN_TEAM_ID: $(POSTMAN_TEAM_ID)
           POSTMAN_REGION: ${{ parameters.postmanRegion }}
           POSTMAN_STACK: ${{ parameters.postmanStack }}

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -10,7 +10,7 @@ const ACTIONLINT_DOWNLOADER_COMMIT = '393031adb9afb225ee52ae2ccd7a5af5525e03e8';
 const ACTIONLINT_VERSION = '1.7.11';
 const ACTIONLINT_DOWNLOADER_URL = `https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_DOWNLOADER_COMMIT}/scripts/download-actionlint.bash`;
 
-const ciWorkflowText = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+const ciWorkflowText = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8').replace(/\r\n/g, '\n');
 const ciWorkflow = parse(ciWorkflowText) as {
   concurrency?: { group?: string; 'cancel-in-progress'?: string | boolean };
   jobs?: Record<string, WorkflowJob>;
@@ -158,6 +158,13 @@ describe('CI workflow contract', () => {
     expect(runGates).toContain("Start-Gate sibling-pins node @('scripts/check-sibling-pins.mjs')");
     expect(runGates.match(/Start-Gate [a-zA-Z0-9_-]+ /g) ?? []).toHaveLength(4);
 
+    // Receive-Job must retain failed-child text in per-gate logs; Out-Null hid Windows npm test failures.
+    expect(runGates).toContain('Receive-Job -Job $completed -ErrorAction Continue 2>&1 | Out-File "$($completed.Name).log"');
+    expect(runGates).not.toContain('Out-Null');
+    expect(runGates).toContain('Write-Output "::group::$name"');
+    expect(runGates).toContain('Get-Content -LiteralPath "$name.log"');
+    expect(runGates).toContain("Write-Output '::endgroup::'");
+
     expect(runGates).toContain("foreach ($name in @('lint', 'test', 'typecheck', 'sibling-pins'))");
     expect(runGates).toContain("if ($results[$name] -eq 'Completed') { Write-Output \"gate:$name=pass\" } else { Write-Output \"gate:$name=fail\"; $failed = $true }");
     expect(runGates).toContain('if ($failed) { exit 1 }');
@@ -171,6 +178,9 @@ describe('CI workflow contract', () => {
       const script = extractWindowsRunGatesBody(ciWorkflowText);
       expect(script).toContain('& $executable @gateArgs');
       expect(script).toContain('if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }');
+      expect(script).toContain('Receive-Job -Job $completed -ErrorAction Continue 2>&1 | Out-File');
+      expect(script).toContain('::group::$name');
+      expect(script).not.toContain('Out-Null');
       expect(script).not.toContain('Invoke-Expression');
 
       const mutated = script
@@ -209,6 +219,9 @@ describe('CI workflow contract', () => {
 
         expect(result.status, output).not.toBe(0);
         expect(output).toContain('gate:test=fail');
+        expect(output).toContain('::group::test');
+        expect(output).toContain('::endgroup::');
+        expect(output).toMatch(/gate failed with exit code 7|exit code 7/i);
         expect(output).not.toContain('gate:lint=');
         expect(output).not.toContain('gate:typecheck=');
         expect(output).not.toContain('gate:sibling-pins=');

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -172,6 +172,13 @@ describe('CI workflow contract', () => {
     expect(runGates).not.toContain('commitlint');
   });
 
+  it('keeps imported release helpers free of Windows-incompatible shebangs', () => {
+    for (const helper of ['check-release-alias.mjs', 'verify-release-artifacts.mjs']) {
+      const source = readFileSync(join(process.cwd(), 'scripts', helper), 'utf8');
+      expect(source, helper).not.toMatch(/^#!/u);
+    }
+  });
+
   it(
     'executes the Windows gate runner and fails aggregate status when a native gate exits nonzero',
     () => {

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,18 +1,221 @@
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
-const ciWorkflow = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+const ACTIONLINT_DOWNLOADER_COMMIT = '393031adb9afb225ee52ae2ccd7a5af5525e03e8';
+const ACTIONLINT_VERSION = '1.7.11';
+const ACTIONLINT_DOWNLOADER_URL = `https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_DOWNLOADER_COMMIT}/scripts/download-actionlint.bash`;
 
-describe('PR CI sibling-pin freshness', () => {
-  it('runs check-sibling-pins.mjs as a normal PR gate', () => {
-    expect(ciWorkflow).toContain('node scripts/check-sibling-pins.mjs');
-    expect(ciWorkflow).toMatch(/run\s+sibling-pins\s+node scripts\/check-sibling-pins\.mjs/);
+const ciWorkflowText = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+const ciWorkflow = parse(ciWorkflowText) as {
+  concurrency?: { group?: string; 'cancel-in-progress'?: string | boolean };
+  jobs?: Record<string, WorkflowJob>;
+};
+
+type WorkflowStep = {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  run?: string;
+  shell?: string;
+};
+
+type WorkflowJob = {
+  name?: string;
+  'runs-on'?: string;
+  steps?: WorkflowStep[];
+};
+
+/** Extract one top-level job block: `  <id>:` through the next job header or EOF. */
+function jobText(source: string, jobId: string): string {
+  const jobsBody = source.match(/^jobs:\n([\s\S]*)$/m)?.[1] ?? '';
+  const header = `  ${jobId}:\n`;
+  const start = jobsBody.indexOf(header);
+  if (start < 0) return '';
+  const rest = jobsBody.slice(start + header.length);
+  const nextJob = rest.search(/^ {2}[a-zA-Z0-9_-]+:\n/m);
+  return header + (nextJob < 0 ? rest : rest.slice(0, nextJob));
+}
+
+function namedStep(source: string, name: string): string {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n?$)`));
+  return match?.[0] ?? '';
+}
+
+/** Ordered gate names launched via `run <name> ...` (excludes the `run()` helper definition). */
+function linuxQueuedGates(runGates: string): string[] {
+  return [...runGates.matchAll(/^\s+run ([a-zA-Z0-9_-]+)\s+/gm)].map((m) => m[1]!);
+}
+
+/** Exact Windows `Run Windows gates` PowerShell body under `run: |`, with YAML indent stripped. */
+function extractWindowsRunGatesBody(source: string): string {
+  const windows = jobText(source, 'windows');
+  const match = windows.match(
+    /^ {6}- name: Run Windows gates\n {8}shell: pwsh\n {8}run: \|\n([\s\S]*)$/m,
+  );
+  if (!match?.[1]) {
+    throw new Error('Windows Run Windows gates pwsh body not found');
+  }
+  return match[1]
+    .replace(/\n$/, '')
+    .split('\n')
+    .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
+    .join('\n');
+}
+
+function findStep(job: WorkflowJob | undefined, name: string): WorkflowStep | undefined {
+  return job?.steps?.find((step) => step.name === name);
+}
+
+const linux = jobText(ciWorkflowText, 'gate');
+const windows = jobText(ciWorkflowText, 'windows');
+const linuxJob = ciWorkflow.jobs?.gate;
+const windowsJob = ciWorkflow.jobs?.windows;
+
+describe('CI workflow contract', () => {
+  it('supersedes only older pull-request runs', () => {
+    expect(ciWorkflow.concurrency?.group).toBe(
+      'ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}',
+    );
+    expect(ciWorkflow.concurrency?.['cancel-in-progress']).toBe(
+      "${{ github.event_name == 'pull_request' }}",
+    );
   });
 
-  it('caps the single-runner gate queue at two concurrent checks', () => {
-    expect(ciWorkflow).toContain('MAX_PARALLEL_GATES=2');
-    expect(ciWorkflow).toContain('wait -n -p finished_pid');
+  it('keeps Linux full-history checkout and the exact bounded Linux gate set', () => {
+    const checkout = linuxJob?.steps?.find((step) => step.uses?.startsWith('actions/checkout@'));
+    expect(checkout?.with?.['fetch-depth']).toBe(0);
+    expect(linux).toContain('fetch-depth: 0');
+
+    const runGates = namedStep(linux, 'Run gates');
+    expect(runGates).toContain('MAX_PARALLEL_GATES=2');
+    expect(runGates).toContain('while [ "${#pid[@]}" -ge "$MAX_PARALLEL_GATES" ]; do finish_one; done');
+    expect(runGates).toContain('while [ "${#pid[@]}" -gt 0 ]; do finish_one; done');
+    expect(runGates).toContain('wait -n -p finished_pid');
+
+    expect(linuxQueuedGates(runGates)).toEqual([
+      'lint',
+      'typecheck',
+      'test',
+      'sibling-pins',
+      'actionlint',
+      'commitlint',
+    ]);
+    expect(runGates).toContain('run lint          npm run lint');
+    expect(runGates).toContain('run typecheck     npm run typecheck');
+    expect(runGates).toContain('run test          npm test');
+    expect(runGates).toContain('run sibling-pins  node scripts/check-sibling-pins.mjs');
+    expect(runGates).toContain('run actionlint    "$ACTIONLINT_BIN"');
+    expect(runGates).toContain('if [ "${{ github.event_name }}" = "pull_request" ]; then');
+    expect(runGates).toContain('run commitlint npx commitlint \\');
+    expect(runGates).toContain('--from "${{ github.event.pull_request.base.sha }}"');
+    expect(runGates).toContain('--to "${{ github.event.pull_request.head.sha }}"');
+    expect(runGates).toContain('gate:$n=pass');
+    expect(runGates).toContain('gate:$n=fail');
+    expect(runGates).toContain('exit $fail');
   });
+
+  it('pins actionlint 1.7.11 via the immutable downloader commit into $RUNNER_TEMP without Go', () => {
+    const install = namedStep(linux, 'Install actionlint');
+    const installStep = findStep(linuxJob, 'Install actionlint');
+    expect(installStep?.run).toContain(ACTIONLINT_DOWNLOADER_URL);
+    expect(installStep?.run).toContain(`) ${ACTIONLINT_VERSION} "$RUNNER_TEMP"`);
+    expect(install).toContain(
+      `bash <(curl -sSfL ${ACTIONLINT_DOWNLOADER_URL}) ${ACTIONLINT_VERSION} "$RUNNER_TEMP"`,
+    );
+    expect(install).toContain('ACTIONLINT_BIN=$RUNNER_TEMP/actionlint');
+    expect(install).not.toMatch(/\/main\/scripts\/download-actionlint\.bash/);
+    expect(ciWorkflowText).not.toContain('actions/setup-go');
+    expect(ciWorkflowText).not.toContain('go install github.com/rhysd/actionlint');
+    expect(ciWorkflowText).not.toMatch(/\bgo install\b/);
+  });
+
+  it('keeps the required Windows job with exact four gates, cap two, and native exit fail-through', () => {
+    expect(windowsJob?.name).toBe('Windows gate');
+    expect(windowsJob?.['runs-on']).toBe('windows-latest');
+    expect(windows).toContain('runs-on: windows-latest');
+    expect(windows).not.toMatch(/^\s*fetch-depth:\s*/m);
+
+    const runGates = namedStep(windows, 'Run Windows gates');
+    expect(runGates).toContain('shell: pwsh');
+    expect(runGates).toContain('$MAX_PARALLEL_GATES = 2');
+    expect(runGates).toContain('while ($jobs.Count -ge $MAX_PARALLEL_GATES) { Complete-One }');
+    expect(runGates).toContain('while ($jobs.Count -gt 0) { Complete-One }');
+    expect(runGates).toContain('Start-Job');
+    expect(runGates).toContain('function Start-Gate($name, $executable, $gateArgs)');
+    expect(runGates).toContain('& $executable @gateArgs');
+    expect(runGates).toContain('if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }');
+    expect(runGates).not.toContain('Invoke-Expression');
+
+    expect(runGates).toContain("Start-Gate lint npm @('run', 'lint')");
+    expect(runGates).toContain("Start-Gate test npm @('test')");
+    expect(runGates).toContain("Start-Gate typecheck npm @('run', 'typecheck')");
+    expect(runGates).toContain("Start-Gate sibling-pins node @('scripts/check-sibling-pins.mjs')");
+    expect(runGates.match(/Start-Gate [a-zA-Z0-9_-]+ /g) ?? []).toHaveLength(4);
+
+    expect(runGates).toContain("foreach ($name in @('lint', 'test', 'typecheck', 'sibling-pins'))");
+    expect(runGates).toContain("if ($results[$name] -eq 'Completed') { Write-Output \"gate:$name=pass\" } else { Write-Output \"gate:$name=fail\"; $failed = $true }");
+    expect(runGates).toContain('if ($failed) { exit 1 }');
+    expect(runGates).not.toContain('actionlint');
+    expect(runGates).not.toContain('commitlint');
+  });
+
+  it(
+    'executes the Windows gate runner and fails aggregate status when a native gate exits nonzero',
+    () => {
+      const script = extractWindowsRunGatesBody(ciWorkflowText);
+      expect(script).toContain('& $executable @gateArgs');
+      expect(script).toContain('if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }');
+      expect(script).not.toContain('Invoke-Expression');
+
+      const mutated = script
+        .replace(/^[ \t]*Start-Gate lint .+\n/mu, '')
+        .replace(/Start-Gate test .+/u, "Start-Gate test node @('-e', 'process.exit(7)')")
+        .replace(/^[ \t]*Start-Gate typecheck .+\n/mu, '')
+        .replace(/^[ \t]*Start-Gate sibling-pins .+\n/mu, '')
+        .replace(
+          /foreach \(\$name in @\('lint', 'test', 'typecheck', 'sibling-pins'\)\)/u,
+          "foreach ($name in @('test'))",
+        );
+
+      expect(mutated).toContain("Start-Gate test node @('-e', 'process.exit(7)')");
+      expect(mutated).toContain("foreach ($name in @('test'))");
+      expect(mutated).not.toContain("Start-Gate test npm @('test')");
+      expect(mutated).not.toMatch(/^[ \t]*Start-Gate lint /mu);
+      expect(mutated).not.toMatch(/^[ \t]*Start-Gate typecheck /mu);
+      expect(mutated).not.toMatch(/^[ \t]*Start-Gate sibling-pins /mu);
+      expect(mutated.match(/^[ \t]*Start-Gate /gmu) ?? []).toHaveLength(1);
+
+      const probe = spawnSync('pwsh', ['-NoProfile', '-Command', 'exit 0'], { encoding: 'utf8' });
+      const probeError = probe.error as NodeJS.ErrnoException | undefined;
+      if (probeError?.code === 'ENOENT') {
+        return;
+      }
+      expect(probeError, `${probe.stderr ?? ''}`).toBeUndefined();
+
+      const fixture = mkdtempSync(join(tmpdir(), 'api-ci-windows-gates-'));
+      try {
+        writeFileSync(join(fixture, 'run-gates.ps1'), `${mutated}\n`);
+        const result = spawnSync('pwsh', ['-NoProfile', '-File', 'run-gates.ps1'], {
+          cwd: fixture,
+          encoding: 'utf8',
+        });
+        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+        expect(result.status, output).not.toBe(0);
+        expect(output).toContain('gate:test=fail');
+        expect(output).not.toContain('gate:lint=');
+        expect(output).not.toContain('gate:typecheck=');
+        expect(output).not.toContain('gate:sibling-pins=');
+      } finally {
+        rmSync(fixture, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
 });

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -231,6 +231,8 @@ describe('postman-api-onboarding-action composite contract', () => {
         'env-runtime-urls-json',
         'postman-api-key',
         'postman-access-token',
+        'insights-postman-api-key',
+        'insights-postman-access-token',
         'credential-preflight',
         'postman-team-id',
         'postman-region',
@@ -561,13 +563,16 @@ describe('postman-api-onboarding-action composite contract', () => {
       }
     });
 
-    it('passes postman-api-key and postman-access-token to bootstrap, repo-sync, and insights', () => {
+    it('isolates dedicated human-user Insights credentials from suite credentials', () => {
       const manifest = loadManifest();
-      for (const stepId of ['bootstrap', 'repo_sync', 'insights_onboarding'] as const) {
+      for (const stepId of ['bootstrap', 'repo_sync'] as const) {
         const step = manifest.runs.steps.find((s) => s.id === stepId);
         expect(step?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
         expect(step?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
       }
+      const insights = manifest.runs.steps.find((step) => step.id === 'insights_onboarding');
+      expect(insights?.with?.['postman-api-key']).toBe('${{ inputs.insights-postman-api-key }}');
+      expect(insights?.with?.['postman-access-token']).toBe('${{ inputs.insights-postman-access-token }}');
     });
 
     it('credential-preflight defaults to warn and is optional', () => {

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -50,9 +50,11 @@ type ActionManifest = {
 
 type WorkflowManifest = {
   jobs: {
-    release: {
+    classify: {
       steps: Step[];
     };
+    'verify-package': { if: string };
+    publish: { if: string; steps: Step[] };
   };
 };
 
@@ -122,38 +124,21 @@ describe('postman-api-onboarding-action composite contract', () => {
 
     it('publishes immutable release tags while skipping npm for the rolling alias', () => {
       const workflow = loadReleaseWorkflow();
-      const steps = workflow.jobs.release.steps;
-      const verifyStep = steps.find((step) => step.name === 'Verify release tag matches package version');
-      const releaseStep = steps.find((step) => step.name === 'Publish GitHub release');
-      const npmSetupStep = steps.find(
-        (step) =>
-          step.uses?.startsWith('actions/setup-node@') &&
-          step.with?.['registry-url'] &&
-          step.if === "steps.release_tag.outputs.npm_publish == 'true'"
-      );
-      const npmPackageStep = steps.find((step) => step.name === 'Check npm package version');
-      const publishStep = steps.find((step) => step.name === 'Publish to npm');
-      const attachStep = steps.find((step) => step.name === 'Attach npm tarball to release');
-      const uploadStep = steps.find((step) => step.name === 'Upload tarball');
+      const classifier = workflow.jobs.classify.steps.find((step) => step.name === 'Classify release tag');
+      const verify = workflow.jobs['verify-package'];
+      const publish = workflow.jobs.publish;
 
-      expect(verifyStep?.id).toBe('release_tag');
-      expect(verifyStep?.run).toContain('PUBLISH_TAGS=("$PKG_VERSION")');
-      expect(verifyStep?.run).toContain('PUBLISH_TAGS+=("$MAJOR.$MINOR")');
-      expect(verifyStep?.run).toContain('if [ "$TAG_VERSION" = "$MAJOR" ]; then');
-      expect(verifyStep?.run).not.toContain('if [ "$TAG_VERSION" = "0" ]; then');
-      expect(verifyStep?.run).toContain('or v$MAJOR');
-      expect(verifyStep?.run).toContain('npm_publish=true');
-      expect(verifyStep?.run).toContain('npm_publish=false');
-      expect(verifyStep?.run).toContain('skipping npm publish');
-      expect(verifyStep?.run).not.toContain('ALIAS_TAGS');
-      expect(verifyStep?.run).not.toContain('publish_tag');
-      expect(releaseStep?.if).toBeUndefined();
-      expect(npmSetupStep?.if).toBe("steps.release_tag.outputs.npm_publish == 'true'");
-      expect(npmPackageStep?.id).toBe('npm_package');
-      expect(npmPackageStep?.run).toContain('npm view "$PKG_NAME@$PKG_VERSION" version');
-      expect(publishStep?.if).toBe("steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'");
-      expect(attachStep?.if).toBeUndefined();
-      expect(uploadStep?.if).toBeUndefined();
+      expect(classifier?.id).toBe('release_tag');
+      expect(classifier?.run).toContain('IMMUTABLE=("v$PKG_VERSION")');
+      expect(classifier?.run).toContain('IMMUTABLE+=("v$MAJOR.$MINOR")');
+      expect(classifier?.run).toContain("release_kind=immutable");
+      expect(classifier?.run).toContain("release_kind=alias");
+      expect(verify.if).toBe("needs.classify.outputs.release_kind == 'immutable'");
+      expect(publish.if).toBe("needs.classify.outputs.release_kind == 'immutable'");
+      const publishStep = publish.steps.find((step) => step.name === 'Publish or verify npm package');
+      const releaseStep = publish.steps.find((step) => step.name === 'Publish GitHub release');
+      expect(publishStep?.run).toContain('npm publish ./release/release.tgz --provenance --access public');
+      expect(releaseStep?.uses).toContain('softprops/action-gh-release');
     });
 
     it('README documents all inputs from action.yml', () => {
@@ -365,7 +350,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.5');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.7');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.10');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
@@ -509,7 +494,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.5');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.7');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
       ).toBe('postman-cs/postman-repo-sync-action@v2.1.10');

--- a/tests/release-alias.test.ts
+++ b/tests/release-alias.test.ts
@@ -1,0 +1,98 @@
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareSemver,
+  decideAliasAdvance,
+  parseAliasArgs,
+  parseLsRemoteLines,
+  resolveTagCommit
+} from '../scripts/check-release-alias.mjs';
+
+const helper = join(process.cwd(), 'scripts/check-release-alias.mjs');
+const commitA = 'a'.repeat(40);
+const commitB = 'b'.repeat(40);
+const tagObject = 'c'.repeat(40);
+
+function runHelper(major: string, candidate: string, stdin: string) {
+  return spawnSync(process.execPath, [helper, major, candidate], {
+    input: stdin,
+    encoding: 'utf8'
+  });
+}
+
+describe('check-release-alias parser and decision', () => {
+  it('advances when the alias is absent', () => {
+    const decision = decideAliasAdvance({
+      majorAlias: 'v2',
+      candidateTag: 'v2.1.2',
+      lsRemoteText: `${commitA}\trefs/tags/v2.1.2\n`
+    });
+    expect(decision).toEqual({ status: 0, reason: 'absent' });
+    const cli = runHelper('v2', 'v2.1.2', `${commitA}\trefs/tags/v2.1.2\n`);
+    expect(cli.status).toBe(0);
+  });
+
+  it('resolves lightweight aliases and advances for same or older targets', () => {
+    const same = [
+      `${commitA}\trefs/tags/v2`,
+      `${commitA}\trefs/tags/v2.1.2`
+    ].join('\n');
+    expect(decideAliasAdvance({ majorAlias: 'v2', candidateTag: 'v2.1.2', lsRemoteText: same }).reason).toBe('same');
+    expect(runHelper('v2', 'v2.1.2', same).status).toBe(0);
+
+    const older = [
+      `${commitA}\trefs/tags/v2`,
+      `${commitA}\trefs/tags/v2.1.1`
+    ].join('\n');
+    expect(decideAliasAdvance({ majorAlias: 'v2', candidateTag: 'v2.1.2', lsRemoteText: older }).reason).toBe('older');
+    expect(runHelper('v2', 'v2.1.2', older).status).toBe(0);
+  });
+
+  it('resolves annotated aliases via peeled refs and refuses regression', () => {
+    const newer = [
+      `${tagObject}\trefs/tags/v2`,
+      `${commitB}\trefs/tags/v2^{}`,
+      `${tagObject}\trefs/tags/v2.1.3`,
+      `${commitB}\trefs/tags/v2.1.3^{}`,
+      `${commitA}\trefs/tags/v2.1.2`
+    ].join('\n');
+    const decision = decideAliasAdvance({ majorAlias: 'v2', candidateTag: 'v2.1.2', lsRemoteText: newer });
+    expect(decision).toEqual({ status: 10, reason: 'newer', currentVersion: '2.1.3' });
+    const cli = runHelper('v2', 'v2.1.2', newer);
+    expect(cli.status).toBe(10);
+    expect(cli.stdout).toBe('2.1.3');
+    expect(resolveTagCommit(parseLsRemoteLines(newer), 'v2')).toBe(commitB);
+  });
+
+  it('accepts zero-patch minor immutable tags when mapping the alias commit', () => {
+    const rows = [
+      `${commitA}\trefs/tags/v2`,
+      `${commitA}\trefs/tags/v2.2`
+    ].join('\n');
+    const decision = decideAliasAdvance({ majorAlias: 'v2', candidateTag: 'v2.2', lsRemoteText: rows });
+    expect(decision.status).toBe(0);
+    expect(decision.currentVersion).toBe('2.2.0');
+    expect(compareSemver('2.2', '2.2.0')).toBe(0);
+  });
+
+  it('rejects malformed and mismatched-major inputs', () => {
+    expect(() => parseAliasArgs('2', 'v2.1.2')).toThrow(/malformed major alias/);
+    expect(() => parseAliasArgs('v2', 'v3.0.0')).toThrow(/mismatched major/);
+    expect(() => parseAliasArgs('v2', 'main')).toThrow(/malformed candidate/);
+    expect(runHelper('v2', 'v3.0.0', '').status).not.toBe(0);
+    expect(runHelper('v2', 'not-a-tag', '').status).not.toBe(0);
+  });
+
+  it('fails when an existing alias cannot be resolved to a same-major immutable tag', () => {
+    const unresolved = `${commitA}\trefs/tags/v2\n${commitB}\trefs/tags/v2.1.2\n`;
+    expect(() => decideAliasAdvance({
+      majorAlias: 'v2',
+      candidateTag: 'v2.1.2',
+      lsRemoteText: unresolved
+    })).toThrow(/cannot be safely resolved/);
+    expect(runHelper('v2', 'v2.1.2', unresolved).status).not.toBe(0);
+  });
+});

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -1,5 +1,15 @@
 import { createHash } from 'node:crypto';
-import { cpSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -37,6 +47,12 @@ const cleanupRoots: string[] = [];
 const packedByVersion = new Map<string, string>();
 let npmPackCount = 0;
 
+const TRAP_VERIFIER = `import { writeFileSync } from 'node:fs';
+if (process.env.OIDC_MARKER) {
+  writeFileSync(process.env.OIDC_MARKER, 'package-code-executed');
+}
+`;
+
 function track(directory: string): string {
   cleanupRoots.push(directory);
   return directory;
@@ -47,14 +63,16 @@ function ensurePacked(packageVersion: string): string {
   if (cached) return cached;
   const root = track(mkdtempSync(join(tmpdir(), `release-pack-${packageVersion}-`)));
   const source = join(root, 'src');
-  mkdirSync(source, { recursive: true });
+  mkdirSync(join(source, 'scripts'), { recursive: true });
   writeFileSync(
     join(source, 'package.json'),
     `${JSON.stringify({
       name: '@postman-cse/onboarding-api',
-      version: packageVersion
+      version: packageVersion,
+      files: ['scripts/verify-release-artifacts.mjs']
     }, null, 2)}\n`
   );
+  writeFileSync(join(source, 'scripts/verify-release-artifacts.mjs'), TRAP_VERIFIER);
   execFileSync('npm', ['pack', '--pack-destination', root], { cwd: source, stdio: 'ignore' });
   npmPackCount += 1;
   const packed = readdirSync(root).find((name) => name.endsWith('.tgz'));
@@ -137,25 +155,29 @@ describe('release workflow artifact handoff', () => {
     expect(JSON.stringify(publish)).not.toContain('npm run build');
     expect(JSON.stringify(publish)).not.toContain('"npm test"');
     expect(JSON.stringify(publish)).not.toMatch(/npm pack(?:\\s|$|")/);
+    expect(JSON.stringify(publish)).not.toContain('package/scripts/verify-release-artifacts.mjs');
     const tokenSteps = (publish?.steps ?? []).filter((step) => JSON.stringify(step).includes('NODE_AUTH_TOKEN'));
     expect(tokenSteps).toHaveLength(1);
     expect(tokenSteps[0]?.name).toBe('Publish or verify npm package');
     expect(tokenSteps[0]?.env?.NODE_AUTH_TOKEN).toBe('${{ secrets.NPM_TOKEN }}');
   });
 
-  it('executes the trusted envelope verifier successfully and fails on tampered bytes before tar extract', () => {
+  it('executes the trusted inline verifier on a real tarball without running package code under OIDC env', () => {
     const publish = releaseWorkflow.jobs.publish;
     const envelope = stepByName(publish, 'Verify release artifact envelope');
     expect(envelope.run).toBeTruthy();
-    expect(envelope.run).not.toContain('tar -xOf');
+    expect(envelope.run).toContain("execFileSync('tar', ['-xOf', tarballPath, 'package/package.json']");
+    expect(envelope.run).not.toContain('package/scripts/verify-release-artifacts.mjs');
     expect(envelope.run).not.toContain('NODE_AUTH_TOKEN');
 
     const directory = track(mkdtempSync(join(tmpdir(), 'release-envelope-')));
     mkdirSync(join(directory, 'release'), { recursive: true });
     const tarballPath = join(directory, 'release', 'release.tgz');
-    const bytes = Buffer.from('trusted-release-bytes');
-    writeFileSync(tarballPath, bytes);
-    const digest = createHash('sha256').update(bytes).digest('hex');
+    cpSync(ensurePacked('2.1.2'), tarballPath);
+    const trapMember = execFileSync('tar', ['-xOf', tarballPath, 'package/scripts/verify-release-artifacts.mjs'], {
+      encoding: 'utf8'
+    });
+    expect(trapMember).toContain('OIDC_MARKER');
     writeFileSync(
       join(directory, 'release', 'release-manifest.json'),
       JSON.stringify({
@@ -165,25 +187,30 @@ describe('release workflow artifact handoff', () => {
         tag: 'v2.1.2',
         package_name: '@postman-cse/onboarding-api',
         package_version: '2.1.2',
-        artifacts: [{ path: 'release.tgz', sha256: digest }]
+        artifacts: [{ path: 'release.tgz', sha256: sha256(tarballPath) }]
       })
     );
+    const marker = join(directory, 'oidc-marker');
     const scriptPath = join(directory, 'envelope.sh');
     writeFileSync(scriptPath, String(envelope.run));
     const env = {
       ...process.env,
       GITHUB_REPOSITORY: 'postman-cs/postman-api-onboarding-action',
       GITHUB_SHA: 'a'.repeat(40),
-      GITHUB_REF_NAME: 'v2.1.2'
+      GITHUB_REF_NAME: 'v2.1.2',
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.invalid/oidc',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
+      OIDC_MARKER: marker
     };
     const ok = spawnSync('bash', [scriptPath], { cwd: directory, encoding: 'utf8', env });
     expect(ok.status, ok.stderr || ok.stdout).toBe(0);
+    expect(existsSync(marker)).toBe(false);
 
-    writeFileSync(tarballPath, Buffer.from('tampered-release-bytes'));
+    writeFileSync(tarballPath, Buffer.from(`tampered-${createHash('sha256').update('x').digest('hex')}`));
     const bad = spawnSync('bash', [scriptPath], { cwd: directory, encoding: 'utf8', env });
     expect(bad.status).not.toBe(0);
     expect(`${bad.stdout}${bad.stderr}`).toMatch(/checksum mismatch|does not match/i);
-    expect(String(envelope.run)).not.toContain('tar -xOf');
+    expect(existsSync(marker)).toBe(false);
   });
 });
 

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -25,6 +25,23 @@ import {
   verifyReleaseArtifacts
 } from '../scripts/verify-release-artifacts.mjs';
 
+function bashPath(filePath: string): string {
+  if (process.platform !== 'win32') return filePath;
+  return filePath.replace(/^([A-Za-z]):[\\/]/, (_, drive: string) => `/${drive.toLowerCase()}/`).replace(/\\/g, '/');
+}
+
+function bashExecutable(): string {
+  if (process.platform !== 'win32') return 'bash';
+  const candidates = [
+    process.env.GIT_INSTALL_ROOT && join(process.env.GIT_INSTALL_ROOT, 'bin', 'bash.exe'),
+    process.env.ProgramFiles && join(process.env.ProgramFiles, 'Git', 'bin', 'bash.exe'),
+    'C:\\Program Files\\Git\\bin\\bash.exe'
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  const executable = candidates.find((candidate) => existsSync(candidate));
+  if (!executable) throw new Error('Git Bash is required to execute release envelope scripts on Windows');
+  return executable;
+}
+
 type WorkflowStep = {
   name?: string;
   uses?: string;
@@ -202,12 +219,12 @@ describe('release workflow artifact handoff', () => {
       ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
       OIDC_MARKER: marker
     };
-    const ok = spawnSync('bash', [scriptPath], { cwd: directory, encoding: 'utf8', env });
+    const ok = spawnSync(bashExecutable(), [bashPath(scriptPath)], { cwd: directory, encoding: 'utf8', env });
     expect(ok.status, ok.stderr || ok.stdout).toBe(0);
     expect(existsSync(marker)).toBe(false);
 
     writeFileSync(tarballPath, Buffer.from(`tampered-${createHash('sha256').update('x').digest('hex')}`));
-    const bad = spawnSync('bash', [scriptPath], { cwd: directory, encoding: 'utf8', env });
+    const bad = spawnSync(bashExecutable(), [bashPath(scriptPath)], { cwd: directory, encoding: 'utf8', env });
     expect(bad.status).not.toBe(0);
     expect(`${bad.stdout}${bad.stderr}`).toMatch(/checksum mismatch|does not match/i);
     expect(existsSync(marker)).toBe(false);

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -1,0 +1,280 @@
+import { createHash } from 'node:crypto';
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import {
+  assertNpmSriMatch,
+  computeNpmSri,
+  sha256,
+  validateTagVersion,
+  verifyReleaseArtifacts
+} from '../scripts/verify-release-artifacts.mjs';
+
+type WorkflowStep = {
+  name?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+};
+
+const releaseWorkflowText = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8');
+const releaseWorkflow = parse(releaseWorkflowText) as {
+  jobs: Record<string, WorkflowJob>;
+};
+
+const cleanupRoots: string[] = [];
+const packedByVersion = new Map<string, string>();
+let npmPackCount = 0;
+
+function track(directory: string): string {
+  cleanupRoots.push(directory);
+  return directory;
+}
+
+function ensurePacked(packageVersion: string): string {
+  const cached = packedByVersion.get(packageVersion);
+  if (cached) return cached;
+  const root = track(mkdtempSync(join(tmpdir(), `release-pack-${packageVersion}-`)));
+  const source = join(root, 'src');
+  mkdirSync(source, { recursive: true });
+  writeFileSync(
+    join(source, 'package.json'),
+    `${JSON.stringify({
+      name: '@postman-cse/onboarding-api',
+      version: packageVersion
+    }, null, 2)}\n`
+  );
+  execFileSync('npm', ['pack', '--pack-destination', root], { cwd: source, stdio: 'ignore' });
+  npmPackCount += 1;
+  const packed = readdirSync(root).find((name) => name.endsWith('.tgz'));
+  if (!packed) throw new Error(`npm pack did not produce a tarball for ${packageVersion}`);
+  const releaseTarball = join(root, 'release.tgz');
+  renameSync(join(root, packed), releaseTarball);
+  packedByVersion.set(packageVersion, releaseTarball);
+  return releaseTarball;
+}
+
+function caseFixture(options?: { packageVersion?: string; tag?: string }): string {
+  const packageVersion = options?.packageVersion ?? '2.1.2';
+  const tag = options?.tag ?? `v${packageVersion}`;
+  const directory = track(mkdtempSync(join(tmpdir(), 'release-artifact-case-')));
+  const releaseTarball = join(directory, 'release.tgz');
+  cpSync(ensurePacked(packageVersion), releaseTarball);
+  writeFileSync(
+    join(directory, 'release-manifest.json'),
+    JSON.stringify({
+      schema_version: 1,
+      repository: 'postman-cs/postman-api-onboarding-action',
+      commit_sha: 'a'.repeat(40),
+      tag,
+      package_name: '@postman-cse/onboarding-api',
+      package_version: packageVersion,
+      artifacts: [{ path: 'release.tgz', sha256: sha256(releaseTarball) }]
+    })
+  );
+  return directory;
+}
+
+function expected(tag = 'v2.1.2') {
+  return {
+    repository: 'postman-cs/postman-api-onboarding-action',
+    commitSha: 'a'.repeat(40),
+    tag
+  };
+}
+
+function stepByName(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((entry) => entry.name === name);
+  if (!step) throw new Error(`missing step ${name}`);
+  return step;
+}
+
+beforeAll(() => {
+  ensurePacked('2.1.2');
+  ensurePacked('2.2.0');
+  expect(npmPackCount).toBe(2);
+});
+
+afterAll(() => {
+  for (const directory of cleanupRoots.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('release workflow artifact handoff', () => {
+  it('parses verify-package and publish permissions, allowlist, and artifact handoff', () => {
+    const verify = releaseWorkflow.jobs['verify-package'];
+    const publish = releaseWorkflow.jobs.publish;
+    expect(verify?.permissions).toEqual({ contents: 'read' });
+    expect(JSON.stringify(verify)).not.toMatch(/NPM_TOKEN|NODE_AUTH_TOKEN/);
+
+    const upload = verify?.steps?.find((step) => step.uses?.startsWith('actions/upload-artifact@'));
+    expect(upload?.with?.name).toBe('release-artifacts-${{ github.run_id }}-${{ github.run_attempt }}');
+    expect(upload?.with?.['if-no-files-found']).toBe('error');
+    const uploadPaths = String(upload?.with?.path ?? '')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    expect(uploadPaths).toEqual(['release.tgz', 'release-manifest.json']);
+
+    expect(publish?.permissions).toEqual({ contents: 'write', 'id-token': 'write' });
+    const setupNode = publish?.steps?.find((step) => step.uses?.startsWith('actions/setup-node@'));
+    expect(setupNode?.with).toBeTruthy();
+    expect(setupNode?.with).not.toHaveProperty('cache');
+    const download = publish?.steps?.find((step) => step.uses?.startsWith('actions/download-artifact@'));
+    expect(download?.with?.name).toBe(upload?.with?.name);
+    expect(JSON.stringify(publish)).not.toContain('actions/checkout');
+    expect(JSON.stringify(publish)).not.toContain('npm ci');
+    expect(JSON.stringify(publish)).not.toContain('npm run build');
+    expect(JSON.stringify(publish)).not.toContain('"npm test"');
+    expect(JSON.stringify(publish)).not.toMatch(/npm pack(?:\\s|$|")/);
+    const tokenSteps = (publish?.steps ?? []).filter((step) => JSON.stringify(step).includes('NODE_AUTH_TOKEN'));
+    expect(tokenSteps).toHaveLength(1);
+    expect(tokenSteps[0]?.name).toBe('Publish or verify npm package');
+    expect(tokenSteps[0]?.env?.NODE_AUTH_TOKEN).toBe('${{ secrets.NPM_TOKEN }}');
+  });
+
+  it('executes the trusted envelope verifier successfully and fails on tampered bytes before tar extract', () => {
+    const publish = releaseWorkflow.jobs.publish;
+    const envelope = stepByName(publish, 'Verify release artifact envelope');
+    expect(envelope.run).toBeTruthy();
+    expect(envelope.run).not.toContain('tar -xOf');
+    expect(envelope.run).not.toContain('NODE_AUTH_TOKEN');
+
+    const directory = track(mkdtempSync(join(tmpdir(), 'release-envelope-')));
+    mkdirSync(join(directory, 'release'), { recursive: true });
+    const tarballPath = join(directory, 'release', 'release.tgz');
+    const bytes = Buffer.from('trusted-release-bytes');
+    writeFileSync(tarballPath, bytes);
+    const digest = createHash('sha256').update(bytes).digest('hex');
+    writeFileSync(
+      join(directory, 'release', 'release-manifest.json'),
+      JSON.stringify({
+        schema_version: 1,
+        repository: 'postman-cs/postman-api-onboarding-action',
+        commit_sha: 'a'.repeat(40),
+        tag: 'v2.1.2',
+        package_name: '@postman-cse/onboarding-api',
+        package_version: '2.1.2',
+        artifacts: [{ path: 'release.tgz', sha256: digest }]
+      })
+    );
+    const scriptPath = join(directory, 'envelope.sh');
+    writeFileSync(scriptPath, String(envelope.run));
+    const env = {
+      ...process.env,
+      GITHUB_REPOSITORY: 'postman-cs/postman-api-onboarding-action',
+      GITHUB_SHA: 'a'.repeat(40),
+      GITHUB_REF_NAME: 'v2.1.2'
+    };
+    const ok = spawnSync('bash', [scriptPath], { cwd: directory, encoding: 'utf8', env });
+    expect(ok.status, ok.stderr || ok.stdout).toBe(0);
+
+    writeFileSync(tarballPath, Buffer.from('tampered-release-bytes'));
+    const bad = spawnSync('bash', [scriptPath], { cwd: directory, encoding: 'utf8', env });
+    expect(bad.status).not.toBe(0);
+    expect(`${bad.stdout}${bad.stderr}`).toMatch(/checksum mismatch|does not match/i);
+    expect(String(envelope.run)).not.toContain('tar -xOf');
+  });
+});
+
+describe('release artifact verifier', () => {
+  it('accepts a manifest bound to the expected package and release identity', () => {
+    const directory = caseFixture();
+    expect(() => verifyReleaseArtifacts(directory, expected())).not.toThrow();
+  });
+
+  it.each([
+    ['repository', { repository: 'wrong/repo', commitSha: 'a'.repeat(40), tag: 'v2.1.2' }],
+    ['commitSha', { repository: 'postman-cs/postman-api-onboarding-action', commitSha: 'b'.repeat(40), tag: 'v2.1.2' }],
+    ['tag', { repository: 'postman-cs/postman-api-onboarding-action', commitSha: 'a'.repeat(40), tag: 'v2.1.1' }]
+  ] as const)('rejects a mismatched %s', (_label, next) => {
+    const directory = caseFixture();
+    expect(() => verifyReleaseArtifacts(directory, next)).toThrow();
+  });
+
+  it('rejects a mismatched package name', () => {
+    const directory = caseFixture();
+    const manifestPath = join(directory, 'release-manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.package_name = '@postman-cse/wrong';
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/package name/);
+  });
+
+  it('rejects a mismatched package version', () => {
+    const directory = caseFixture();
+    const manifestPath = join(directory, 'release-manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.package_version = '9.9.9';
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/package version/);
+  });
+
+  it('rejects a checksum mismatch', () => {
+    const directory = caseFixture();
+    const manifestPath = join(directory, 'release-manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.artifacts[0].sha256 = '0'.repeat(64);
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/checksum/);
+  });
+
+  it('rejects malformed and uppercase checksums', () => {
+    const directory = caseFixture();
+    const manifestPath = join(directory, 'release-manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const digest = manifest.artifacts[0].sha256 as string;
+    manifest.artifacts[0].sha256 = digest.toUpperCase();
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/artifact is invalid/);
+    manifest.artifacts[0].sha256 = 'not-a-digest';
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/artifact is invalid/);
+  });
+
+  it('rejects missing and extra manifest artifacts', () => {
+    const directory = caseFixture();
+    const manifestPath = join(directory, 'release-manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    const digest = manifest.artifacts[0].sha256 as string;
+    manifest.artifacts = [];
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/allowlist/);
+    manifest.artifacts = [
+      { path: 'release.tgz', sha256: digest },
+      { path: 'extra.tgz', sha256: digest }
+    ];
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/allowlist/);
+  });
+
+  it('accepts a zero-patch minor tag and rejects non-zero-patch minor tags', () => {
+    expect(() => validateTagVersion('v2.2', '2.2.0')).not.toThrow();
+    expect(() => validateTagVersion('v2.1', '2.1.2')).toThrow(/does not match/);
+    const directory = caseFixture({ packageVersion: '2.2.0', tag: 'v2.2' });
+    expect(() => verifyReleaseArtifacts(directory, expected('v2.2'))).not.toThrow();
+  });
+
+  it('rejects an npm SRI identity mismatch', () => {
+    const directory = caseFixture();
+    const actual = computeNpmSri(join(directory, 'release.tgz'));
+    expect(() => assertNpmSriMatch(actual, actual)).not.toThrow();
+    expect(() => assertNpmSriMatch(actual, 'sha512-wrong')).toThrow(/integrity differs/);
+  });
+
+  it('packs each required version at most once', () => {
+    expect(npmPackCount).toBeLessThanOrEqual(2);
+    expect(packedByVersion.has('2.1.2')).toBe(true);
+    expect(packedByVersion.has('2.2.0')).toBe(true);
+  });
+});

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -42,6 +42,10 @@ function bashExecutable(): string {
   return executable;
 }
 
+function npmExecutable(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
 type WorkflowStep = {
   name?: string;
   uses?: string;
@@ -90,7 +94,7 @@ function ensurePacked(packageVersion: string): string {
     }, null, 2)}\n`
   );
   writeFileSync(join(source, 'scripts/verify-release-artifacts.mjs'), TRAP_VERIFIER);
-  execFileSync('npm', ['pack', '--pack-destination', root], { cwd: source, stdio: 'ignore' });
+  execFileSync(npmExecutable(), ['pack', '--pack-destination', root], { cwd: source, stdio: 'ignore' });
   npmPackCount += 1;
   const packed = readdirSync(root).find((name) => name.endsWith('.tgz'));
   if (!packed) throw new Error(`npm pack did not produce a tarball for ${packageVersion}`);
@@ -146,6 +150,11 @@ afterAll(() => {
 });
 
 describe('release workflow artifact handoff', () => {
+  it('selects the Windows npm command shim', () => {
+    expect(npmExecutable('win32')).toBe('npm.cmd');
+    expect(npmExecutable('darwin')).toBe('npm');
+  });
+
   it('parses verify-package and publish permissions, allowlist, and artifact handoff', () => {
     const verify = releaseWorkflow.jobs['verify-package'];
     const publish = releaseWorkflow.jobs.publish;

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -42,8 +42,9 @@ function bashExecutable(): string {
   return executable;
 }
 
-function npmExecutable(platform: NodeJS.Platform = process.platform): string {
-  return platform === 'win32' ? 'npm.cmd' : 'npm';
+function npmCliPath(npmExecPath: string | undefined): string {
+  if (!npmExecPath) throw new Error('npm_execpath is required to create release fixtures');
+  return npmExecPath;
 }
 
 type WorkflowStep = {
@@ -94,7 +95,10 @@ function ensurePacked(packageVersion: string): string {
     }, null, 2)}\n`
   );
   writeFileSync(join(source, 'scripts/verify-release-artifacts.mjs'), TRAP_VERIFIER);
-  execFileSync(npmExecutable(), ['pack', '--pack-destination', root], { cwd: source, stdio: 'ignore' });
+  execFileSync(process.execPath, [npmCliPath(process.env.npm_execpath), 'pack', '--pack-destination', root], {
+    cwd: source,
+    stdio: 'ignore'
+  });
   npmPackCount += 1;
   const packed = readdirSync(root).find((name) => name.endsWith('.tgz'));
   if (!packed) throw new Error(`npm pack did not produce a tarball for ${packageVersion}`);
@@ -150,9 +154,9 @@ afterAll(() => {
 });
 
 describe('release workflow artifact handoff', () => {
-  it('selects the Windows npm command shim', () => {
-    expect(npmExecutable('win32')).toBe('npm.cmd');
-    expect(npmExecutable('darwin')).toBe('npm');
+  it('executes npm through its JavaScript CLI without a platform shell shim', () => {
+    expect(npmCliPath('/npm/bin/npm-cli.js')).toBe('/npm/bin/npm-cli.js');
+    expect(() => npmCliPath(undefined)).toThrow(/npm_execpath/);
   });
 
   it('parses verify-package and publish permissions, allowlist, and artifact handoff', () => {

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,9 +1,16 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
 const releaseWorkflow = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8').replace(/\r\n/g, '\n');
+const releasePolicy = readFileSync(join(process.cwd(), 'RELEASE_POLICY.md'), 'utf8');
+
+function job(name: string): string {
+  return releaseWorkflow.match(new RegExp(`  ${name}:\\n[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:|$)`))?.[0] ?? '';
+}
 
 function namedStep(name: string): string {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -11,50 +18,216 @@ function namedStep(name: string): string {
   return match?.[0] ?? '';
 }
 
-function npmRegistrySetupStep(): string {
-  return releaseWorkflow
-    .match(/ {6}- uses: actions\/setup-node@v\d+\n(?: {8}[^\n]+\n| {10}[^\n]+\n)*/g)
-    ?.find((step) => step.includes("registry-url: 'https://registry.npmjs.org'") && step.includes("if: steps.release_tag.outputs.npm_publish == 'true'")) ?? '';
+function classifierScript(): string {
+  const match = releaseWorkflow.match(/ {6}- name: Classify release tag\n(?:.*\n)*? {8}run: \|\n([\s\S]*?)(?=\n\n {2}[a-z]|\n {2}[a-z])/);
+  expect(match?.[1]).toBeTruthy();
+  return (match?.[1] ?? '')
+    .split('\n')
+    .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
+    .join('\n');
+}
+
+function runClassifier(options: { ref: string; refName: string; packageVersion: string }) {
+  const directory = mkdtempSync(join(tmpdir(), 'release-classify-'));
+  const output = join(directory, 'github-output');
+  writeFileSync(join(directory, 'package.json'), JSON.stringify({ version: options.packageVersion }));
+  writeFileSync(output, '');
+  writeFileSync(join(directory, 'classify.sh'), classifierScript());
+  const result = spawnSync('bash', [join(directory, 'classify.sh')], {
+    cwd: directory,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GITHUB_REF: options.ref,
+      GITHUB_REF_NAME: options.refName,
+      GITHUB_OUTPUT: output
+    }
+  });
+  const githubOutput = readFileSync(output, 'utf8');
+  rmSync(directory, { recursive: true, force: true });
+  return { status: result.status ?? 1, stdout: result.stdout, stderr: result.stderr, githubOutput };
+}
+
+function runGatesBody(): string {
+  const step = namedStep('Run gates');
+  const match = step.match(/ {8}run: \|\n([\s\S]*)$/);
+  expect(match?.[1]).toBeTruthy();
+  return (match?.[1] ?? '')
+    .split('\n')
+    .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
+    .join('\n');
+}
+
+function launchedGates(body: string): Array<{ name: string; command: string }> {
+  return [...body.matchAll(/^run (\S+) (.+)$/gm)].map((match) => ({
+    name: match[1] ?? '',
+    command: match[2] ?? ''
+  }));
 }
 
 describe('release workflow publishing contract', () => {
-  it('verifies composite sibling pins before publishing', () => {
-    expect(namedStep('Verify composite sibling pins')).toContain('node scripts/check-sibling-pins.mjs');
-    expect(releaseWorkflow.indexOf('npm test')).toBeLessThan(releaseWorkflow.indexOf('node scripts/check-sibling-pins.mjs'));
-    expect(releaseWorkflow.indexOf('node scripts/check-sibling-pins.mjs')).toBeLessThan(
-      releaseWorkflow.indexOf('Verify release tag matches package version')
+  it('keeps existing classifier forms and executes immutable, alias, invalid, mismatched, and zero-patch cases', () => {
+    expect(releaseWorkflow).toContain('IMMUTABLE=("v$PKG_VERSION")');
+    expect(releaseWorkflow).toContain('IMMUTABLE+=("v$MAJOR.$MINOR")');
+    expect(releaseWorkflow).toContain('elif [ "$GITHUB_REF_NAME" = "v$MAJOR" ]; then');
+    expect(releaseWorkflow).toContain("echo 'release_kind=immutable'");
+    expect(releaseWorkflow).toContain("echo 'release_kind=alias'");
+    expect(releaseWorkflow).toContain("echo 'npm_publish=true'");
+    expect(releaseWorkflow).toContain("echo 'npm_publish=false'");
+    expect(releaseWorkflow).toContain('npm_publish: ${{ steps.release_tag.outputs.npm_publish }}');
+    expect(releaseWorkflow).toContain('no release work will run');
+    expect(releaseWorkflow).not.toContain('ALIAS_TAGS');
+    expect(releaseWorkflow).not.toContain('publish_tag');
+    expect(releaseWorkflow).not.toContain('needs.classify.outputs.npm_publish');
+
+    const immutable = runClassifier({ ref: 'refs/tags/v2.1.2', refName: 'v2.1.2', packageVersion: '2.1.2' });
+    expect(immutable.status).toBe(0);
+    expect(immutable.githubOutput).toContain('release_kind=immutable');
+    expect(immutable.githubOutput).toContain('npm_publish=true');
+
+    const alias = runClassifier({ ref: 'refs/tags/v2', refName: 'v2', packageVersion: '2.1.2' });
+    expect(alias.status).toBe(0);
+    expect(alias.githubOutput).toContain('release_kind=alias');
+    expect(alias.githubOutput).toContain('npm_publish=false');
+    expect(`${alias.stdout}${alias.stderr}`).toMatch(/rolling alias|no release work will run/i);
+
+    const branch = runClassifier({ ref: 'refs/heads/main', refName: 'main', packageVersion: '2.1.2' });
+    expect(branch.status).not.toBe(0);
+    expect(`${branch.stdout}${branch.stderr}`).toContain('::error::');
+    expect(branch.githubOutput).not.toContain('release_kind=');
+    expect(branch.githubOutput).not.toContain('npm_publish=');
+
+    const mismatched = runClassifier({ ref: 'refs/tags/v2.1.1', refName: 'v2.1.1', packageVersion: '2.1.2' });
+    expect(mismatched.status).not.toBe(0);
+    expect(mismatched.githubOutput).not.toContain('release_kind=');
+    expect(mismatched.githubOutput).not.toContain('npm_publish=');
+
+    const zeroPatch = runClassifier({ ref: 'refs/tags/v2.2', refName: 'v2.2', packageVersion: '2.2.0' });
+    expect(zeroPatch.status).toBe(0);
+    expect(zeroPatch.githubOutput).toContain('release_kind=immutable');
+    expect(zeroPatch.githubOutput).toContain('npm_publish=true');
+  });
+
+  it('classifies before dependency installation and guards every downstream job on immutable', () => {
+    expect(releaseWorkflow.indexOf('Classify release tag')).toBeLessThan(releaseWorkflow.indexOf('npm ci'));
+    for (const name of ['verify-package', 'publish', 'advance-major-alias']) {
+      const body = job(name);
+      expect(body).toContain('needs:');
+      expect(body).toContain("if: needs.classify.outputs.release_kind == 'immutable'");
+      expect(body).not.toContain('npm_publish');
+    }
+    expect(job('verify-package')).toContain('needs: classify');
+    expect(job('publish')).toContain('needs: [classify, verify-package]');
+    expect(job('advance-major-alias')).toContain('needs: [classify, publish]');
+  });
+
+  it('verifies composite sibling pins before packaging', () => {
+    expect(releaseWorkflow).toContain('node scripts/check-sibling-pins.mjs');
+    expect(releaseWorkflow.indexOf('npm ci')).toBeLessThan(releaseWorkflow.indexOf('node scripts/check-sibling-pins.mjs'));
+    expect(releaseWorkflow.indexOf('node scripts/check-sibling-pins.mjs')).toBeLessThan(releaseWorkflow.indexOf('npm pack'));
+  });
+
+  it('queues exactly the five composite gates with MAX_PARALLEL_GATES=2 and failure aggregation', () => {
+    const body = runGatesBody();
+    expect(launchedGates(body)).toEqual([
+      { name: 'lint', command: 'npm run lint' },
+      { name: 'typecheck', command: 'npm run typecheck' },
+      { name: 'test', command: 'npm test' },
+      { name: 'sibling-pins', command: 'node scripts/check-sibling-pins.mjs' },
+      { name: 'actionlint', command: '"$ACTIONLINT_BIN"' }
+    ]);
+    expect(body).toContain('MAX_PARALLEL_GATES=2');
+    expect(body).toContain('wait -n');
+    expect(body).toContain('gate:$n=pass');
+    expect(body).toContain('gate:$n=fail');
+    expect(body).toContain('exit $fail');
+    expect(body).not.toMatch(/\bbundle\b/);
+    expect(body).not.toMatch(/\bbuild\b/);
+    expect(body).not.toContain('verify:dist');
+    expect(body).not.toContain('check:dist');
+    expect(body).not.toContain('rm -rf dist');
+    expect(body).not.toContain('npm run dist');
+
+    const verify = job('verify-package');
+    expect(verify).toContain('contents: read');
+    expect(verify).toContain('fetch-depth: 1');
+    expect(verify).toContain(
+      'https://raw.githubusercontent.com/rhysd/actionlint/393031adb9afb225ee52ae2ccd7a5af5525e03e8/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"'
+    );
+    expect(verify).toContain('ACTIONLINT_BIN=$RUNNER_TEMP/actionlint');
+    expect(verify).toContain('node scripts/verify-release-artifacts.mjs .');
+    expect(verify).toContain('if-no-files-found: error');
+    expect(verify).toContain('release-artifacts-${{ github.run_id }}-${{ github.run_attempt }}');
+    expect(verify).not.toContain('actions/setup-go');
+    expect(verify).not.toContain('go install github.com/rhysd/actionlint');
+    expect(releaseWorkflow).not.toContain('rhysd/actionlint/main/scripts/download-actionlint.bash');
+  });
+
+  it('uses artifact-only publish with trusted envelope verification before any tarball code', () => {
+    const publish = job('publish');
+    expect(publish).toMatch(/permissions:\n\s+contents: write\n\s+id-token: write/);
+    expect(publish).not.toContain('actions/checkout');
+    expect(publish).not.toContain('cache:');
+    expect(publish).not.toContain('npm ci');
+    expect(publish).not.toContain('npm run build');
+    expect(publish).not.toContain('npm test');
+    expect(publish).not.toMatch(/npm pack(?:\s|$)/);
+    expect(publish).toContain('name: Verify release artifact envelope');
+    expect(publish).toContain('name: Verify package identity from staged artifacts');
+    const envelope = namedStep('Verify release artifact envelope');
+    const identity = namedStep('Verify package identity from staged artifacts');
+    const npm = namedStep('Publish or verify npm package');
+    expect(envelope).toContain("artifact.path !== 'release.tgz'");
+    expect(envelope).toContain('/^[a-f0-9]{64}$/');
+    expect(envelope).not.toContain('tar -xOf');
+    expect(envelope).not.toContain('NPM_TOKEN');
+    expect(envelope).not.toContain('NODE_AUTH_TOKEN');
+    expect(identity).toContain('tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs');
+    expect(identity).not.toContain('NPM_TOKEN');
+    expect(identity).not.toContain('NODE_AUTH_TOKEN');
+    expect(npm).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
+    expect(publish.indexOf('Verify release artifact envelope')).toBeLessThan(
+      publish.indexOf('tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs')
+    );
+    expect(publish.indexOf('tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs')).toBeLessThan(
+      publish.indexOf('NODE_AUTH_TOKEN')
     );
   });
 
-  it('keeps v1 as the only rolling alias and v1.x as a zero-patch publish tag', () => {
-    expect(releaseWorkflow).toContain('PUBLISH_TAGS=("$PKG_VERSION")');
-    expect(releaseWorkflow).toContain('PUBLISH_TAGS+=("$MAJOR.$MINOR")');
-    expect(releaseWorkflow).toContain('if [ "$TAG_VERSION" = "$MAJOR" ]; then');
-    expect(releaseWorkflow).not.toContain('if [ "$TAG_VERSION" = "0" ]; then');
-    expect(releaseWorkflow).toContain('or v$MAJOR');
-    expect(releaseWorkflow).toContain('echo "npm_publish=true" >> "$GITHUB_OUTPUT"');
-    expect(releaseWorkflow).toContain('echo "npm_publish=false" >> "$GITHUB_OUTPUT"');
-    expect(releaseWorkflow).toContain('skipping npm publish');
-    expect(releaseWorkflow).not.toContain('ALIAS_TAGS');
-    expect(releaseWorkflow).not.toContain('publish_tag');
+  it('publishes or verifies npm before GitHub Release and attaches staged artifacts', () => {
+    const publish = job('publish');
+    const npmPublish = publish.indexOf('npm publish ./release/release.tgz --provenance --access public');
+    const githubRelease = publish.indexOf('softprops/action-gh-release');
+    expect(npmPublish).toBeGreaterThanOrEqual(0);
+    expect(githubRelease).toBeGreaterThanOrEqual(0);
+    expect(npmPublish).toBeLessThan(githubRelease);
+    expect(publish).toContain('Published npm integrity differs from staged tarball');
+    expect(publish).toContain('release/release.tgz');
+    expect(publish).toContain('release/release-manifest.json');
+    expect(releaseWorkflow).toContain('group: release-${{ github.repository }}');
+    expect(releaseWorkflow).toContain('cancel-in-progress: false');
   });
 
-  it('keeps GitHub release artifacts while making npm publication idempotent', () => {
-    expect(namedStep('Publish GitHub release')).not.toMatch(/\n\s+if:/);
-    expect(npmRegistrySetupStep()).toContain("if: steps.release_tag.outputs.npm_publish == 'true'");
-    expect(namedStep('Check npm package version')).toContain('id: npm_package');
-    expect(namedStep('Check npm package version')).toContain('npm view "$PKG_NAME@$PKG_VERSION" version');
-    expect(namedStep('Check npm package version')).toContain('already_published=true');
-    expect(namedStep('Publish to npm')).toContain("if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'");
-    expect(namedStep('Attach npm tarball to release')).not.toMatch(/\n\s+if:/);
-    expect(namedStep('Upload tarball')).not.toMatch(/\n\s+if:/);
+  it('compares the rolling alias with check-release-alias before push', () => {
+    const alias = namedStep('Advance rolling major alias');
+    expect(alias).toContain('git ls-remote --tags origin');
+    expect(alias).toContain('node scripts/check-release-alias.mjs');
+    expect(alias).toContain('STATUS=$?');
+    expect(alias).toContain('[ "$STATUS" -eq 10 ]');
+    expect(alias).toContain('Keeping newer $MAJOR alias at v$CURRENT');
+    expect(alias).toContain('git push origin "$MAJOR" --force');
+    expect(alias.indexOf('check-release-alias.mjs')).toBeLessThan(alias.indexOf('git tag -fa'));
+    expect(alias.indexOf('check-release-alias.mjs')).toBeLessThan(alias.indexOf('git push origin "$MAJOR" --force'));
+    expect(alias).not.toContain('fetch-depth: 0');
+    expect(job('advance-major-alias')).toContain('fetch-depth: 1');
   });
 
-  it('advances the rolling major alias after an immutable release publishes', () => {
-    expect(releaseWorkflow).toContain('advance-major-alias:');
-    expect(releaseWorkflow).toContain("needs: release");
-    expect(releaseWorkflow).toContain("if: ${{ needs.release.outputs.npm_publish == 'true' }}");
-    expect(namedStep('Force-move rolling major alias tag')).toContain('git tag -fa "$MAJOR"');
-    expect(namedStep('Force-move rolling major alias tag')).toContain('git push origin "$MAJOR" --force');
+  it('documents live E2E as an asynchronous monitor and the current v2 release policy', () => {
+    expect(releasePolicy).toContain('nightly `full` monitor');
+    expect(releasePolicy).toContain('asynchronous post-release `smoke`');
+    expect(releasePolicy).toContain('not a PR or publication gate');
+    expect(releasePolicy).toContain('v2');
+    expect(releasePolicy).toContain('rolling');
+    expect(releasePolicy).not.toMatch(/\bv1\b/);
   });
 });

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -18,26 +18,32 @@ function namedStep(name: string): string {
   return match?.[0] ?? '';
 }
 
+let cachedClassifierScript: string | undefined;
+
 function classifierScript(): string {
+  if (cachedClassifierScript !== undefined) return cachedClassifierScript;
   const match = releaseWorkflow.match(/ {6}- name: Classify release tag\n(?:.*\n)*? {8}run: \|\n([\s\S]*?)(?=\n\n {2}[a-z]|\n {2}[a-z])/);
   expect(match?.[1]).toBeTruthy();
-  return (match?.[1] ?? '')
+  cachedClassifierScript = (match?.[1] ?? '')
     .split('\n')
     .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
     .join('\n');
+  return cachedClassifierScript;
 }
 
 function runClassifier(options: { ref: string; refName: string; packageVersion: string }) {
   const directory = mkdtempSync(join(tmpdir(), 'release-classify-'));
   const output = join(directory, 'github-output');
+  const scriptPath = join(directory, 'classify.sh');
   writeFileSync(join(directory, 'package.json'), JSON.stringify({ version: options.packageVersion }));
   writeFileSync(output, '');
-  writeFileSync(join(directory, 'classify.sh'), classifierScript());
-  const result = spawnSync('bash', [join(directory, 'classify.sh')], {
+  writeFileSync(scriptPath, classifierScript());
+  // Lean env: avoid copying a large process.env into five nested bash→node spawns.
+  const result = spawnSync('bash', [scriptPath], {
     cwd: directory,
     encoding: 'utf8',
     env: {
-      ...process.env,
+      PATH: process.env.PATH ?? '',
       GITHUB_REF: options.ref,
       GITHUB_REF_NAME: options.refName,
       GITHUB_OUTPUT: output
@@ -66,7 +72,7 @@ function launchedGates(body: string): Array<{ name: string; command: string }> {
 }
 
 describe('release workflow publishing contract', () => {
-  it('keeps existing classifier forms and executes immutable, alias, invalid, mismatched, and zero-patch cases', () => {
+  it('keeps existing classifier forms for immutable, alias, and npm_publish outputs', () => {
     expect(releaseWorkflow).toContain('IMMUTABLE=("v$PKG_VERSION")');
     expect(releaseWorkflow).toContain('IMMUTABLE+=("v$MAJOR.$MINOR")');
     expect(releaseWorkflow).toContain('elif [ "$GITHUB_REF_NAME" = "v$MAJOR" ]; then');
@@ -79,33 +85,84 @@ describe('release workflow publishing contract', () => {
     expect(releaseWorkflow).not.toContain('ALIAS_TAGS');
     expect(releaseWorkflow).not.toContain('publish_tag');
     expect(releaseWorkflow).not.toContain('needs.classify.outputs.npm_publish');
+  });
 
-    const immutable = runClassifier({ ref: 'refs/tags/v2.1.2', refName: 'v2.1.2', packageVersion: '2.1.2' });
-    expect(immutable.status).toBe(0);
-    expect(immutable.githubOutput).toContain('release_kind=immutable');
-    expect(immutable.githubOutput).toContain('npm_publish=true');
-
-    const alias = runClassifier({ ref: 'refs/tags/v2', refName: 'v2', packageVersion: '2.1.2' });
-    expect(alias.status).toBe(0);
-    expect(alias.githubOutput).toContain('release_kind=alias');
-    expect(alias.githubOutput).toContain('npm_publish=false');
-    expect(`${alias.stdout}${alias.stderr}`).toMatch(/rolling alias|no release work will run/i);
-
-    const branch = runClassifier({ ref: 'refs/heads/main', refName: 'main', packageVersion: '2.1.2' });
-    expect(branch.status).not.toBe(0);
-    expect(`${branch.stdout}${branch.stderr}`).toContain('::error::');
-    expect(branch.githubOutput).not.toContain('release_kind=');
-    expect(branch.githubOutput).not.toContain('npm_publish=');
-
-    const mismatched = runClassifier({ ref: 'refs/tags/v2.1.1', refName: 'v2.1.1', packageVersion: '2.1.2' });
-    expect(mismatched.status).not.toBe(0);
-    expect(mismatched.githubOutput).not.toContain('release_kind=');
-    expect(mismatched.githubOutput).not.toContain('npm_publish=');
-
-    const zeroPatch = runClassifier({ ref: 'refs/tags/v2.2', refName: 'v2.2', packageVersion: '2.2.0' });
-    expect(zeroPatch.status).toBe(0);
-    expect(zeroPatch.githubOutput).toContain('release_kind=immutable');
-    expect(zeroPatch.githubOutput).toContain('npm_publish=true');
+  it.each([
+    {
+      label: 'immutable',
+      ref: 'refs/tags/v2.1.2',
+      refName: 'v2.1.2',
+      packageVersion: '2.1.2',
+      status: 0,
+      githubOutput: ['release_kind=immutable', 'npm_publish=true'],
+      diagIncludes: [] as string[],
+      diagExcludesOutput: [] as string[]
+    },
+    {
+      label: 'alias',
+      ref: 'refs/tags/v2',
+      refName: 'v2',
+      packageVersion: '2.1.2',
+      status: 0,
+      githubOutput: ['release_kind=alias', 'npm_publish=false'],
+      diagIncludes: ['rolling alias|no release work will run'],
+      diagExcludesOutput: [] as string[]
+    },
+    {
+      label: 'non-tag branch',
+      ref: 'refs/heads/main',
+      refName: 'main',
+      packageVersion: '2.1.2',
+      status: 1,
+      githubOutput: [],
+      diagIncludes: ['::error::', 'refs/heads/main', 'v2.1.2', 'v2'],
+      diagExcludesOutput: ['release_kind=', 'npm_publish=']
+    },
+    {
+      label: 'mismatched tag',
+      ref: 'refs/tags/v2.1.1',
+      refName: 'v2.1.1',
+      packageVersion: '2.1.2',
+      status: 1,
+      githubOutput: [],
+      diagIncludes: ['::error::', 'refs/tags/v2.1.1', 'v2.1.2', 'v2'],
+      diagExcludesOutput: ['release_kind=', 'npm_publish=']
+    },
+    {
+      label: 'zero-patch minor',
+      ref: 'refs/tags/v2.2',
+      refName: 'v2.2',
+      packageVersion: '2.2.0',
+      status: 0,
+      githubOutput: ['release_kind=immutable', 'npm_publish=true'],
+      diagIncludes: [] as string[],
+      diagExcludesOutput: [] as string[]
+    }
+  ])('executes classifier for $label', (testcase) => {
+    const result = runClassifier({
+      ref: testcase.ref,
+      refName: testcase.refName,
+      packageVersion: testcase.packageVersion
+    });
+    if (testcase.status === 0) {
+      expect(result.status).toBe(0);
+    } else {
+      expect(result.status).not.toBe(0);
+    }
+    for (const fragment of testcase.githubOutput) {
+      expect(result.githubOutput).toContain(fragment);
+    }
+    for (const fragment of testcase.diagExcludesOutput) {
+      expect(result.githubOutput).not.toContain(fragment);
+    }
+    const diag = `${result.stdout}${result.stderr}`;
+    for (const fragment of testcase.diagIncludes) {
+      if (fragment.includes('|')) {
+        expect(diag).toMatch(new RegExp(fragment, 'i'));
+      } else {
+        expect(diag).toContain(fragment);
+      }
+    }
   });
 
   it('classifies before dependency installation and guards every downstream job on immutable', () => {
@@ -158,12 +215,13 @@ describe('release workflow publishing contract', () => {
     expect(verify).toContain('node scripts/verify-release-artifacts.mjs .');
     expect(verify).toContain('if-no-files-found: error');
     expect(verify).toContain('release-artifacts-${{ github.run_id }}-${{ github.run_attempt }}');
-    expect(verify).not.toContain('actions/setup-go');
-    expect(verify).not.toContain('go install github.com/rhysd/actionlint');
     expect(releaseWorkflow).not.toContain('rhysd/actionlint/main/scripts/download-actionlint.bash');
+    expect(releaseWorkflow).not.toContain('actions/setup-go');
+    expect(releaseWorkflow).not.toContain('go install github.com/rhysd/actionlint');
+    expect(releaseWorkflow).not.toContain('go install');
   });
 
-  it('uses artifact-only publish with trusted envelope verification before any tarball code', () => {
+  it('uses one trusted inline publish verifier before NODE_AUTH_TOKEN without executing package code', () => {
     const publish = job('publish');
     expect(publish).toMatch(/permissions:\n\s+contents: write\n\s+id-token: write/);
     expect(publish).not.toContain('actions/checkout');
@@ -173,23 +231,21 @@ describe('release workflow publishing contract', () => {
     expect(publish).not.toContain('npm test');
     expect(publish).not.toMatch(/npm pack(?:\s|$)/);
     expect(publish).toContain('name: Verify release artifact envelope');
-    expect(publish).toContain('name: Verify package identity from staged artifacts');
+    expect(publish).not.toContain('Verify package identity from staged artifacts');
+    expect(publish).not.toContain('package/scripts/verify-release-artifacts.mjs');
+    expect(publish).not.toContain('RUNNER_TEMP/verify-release-artifacts.mjs');
+    expect(publish).not.toContain('$RUNNER_TEMP/verify-release-artifacts.mjs');
     const envelope = namedStep('Verify release artifact envelope');
-    const identity = namedStep('Verify package identity from staged artifacts');
     const npm = namedStep('Publish or verify npm package');
     expect(envelope).toContain("artifact.path !== 'release.tgz'");
     expect(envelope).toContain('/^[a-f0-9]{64}$/');
-    expect(envelope).not.toContain('tar -xOf');
+    expect(envelope).toContain("execFileSync('tar', ['-xOf', tarballPath, 'package/package.json']");
+    expect(envelope).not.toContain('package/scripts/verify-release-artifacts.mjs');
     expect(envelope).not.toContain('NPM_TOKEN');
     expect(envelope).not.toContain('NODE_AUTH_TOKEN');
-    expect(identity).toContain('tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs');
-    expect(identity).not.toContain('NPM_TOKEN');
-    expect(identity).not.toContain('NODE_AUTH_TOKEN');
     expect(npm).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
-    expect(publish.indexOf('Verify release artifact envelope')).toBeLessThan(
-      publish.indexOf('tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs')
-    );
-    expect(publish.indexOf('tar -xOf release/release.tgz package/scripts/verify-release-artifacts.mjs')).toBeLessThan(
+    expect(publish.indexOf('Verify release artifact envelope')).toBeLessThan(publish.indexOf('NODE_AUTH_TOKEN'));
+    expect(publish.indexOf("execFileSync('tar', ['-xOf', tarballPath, 'package/package.json']")).toBeLessThan(
       publish.indexOf('NODE_AUTH_TOKEN')
     );
   });

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -6,7 +6,40 @@ import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 
 const releaseWorkflow = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8').replace(/\r\n/g, '\n');
-const releasePolicy = readFileSync(join(process.cwd(), 'RELEASE_POLICY.md'), 'utf8');
+const releasePolicy = readFileSync(join(process.cwd(), 'RELEASE_POLICY.md'), 'utf8').replace(/\r\n/g, '\n');
+
+/** Convert a native path into a Git Bash-safe absolute path on Windows. */
+function bashPath(filePath: string): string {
+  if (process.platform !== 'win32') return filePath;
+  return filePath.replace(/^([A-Za-z]):[\\/]/, (_, drive: string) => `/${drive.toLowerCase()}/`).replace(/\\/g, '/');
+}
+
+function bashExecutable(): string {
+  if (process.platform !== 'win32') return 'bash';
+  const candidates = [
+    process.env.GIT_INSTALL_ROOT && join(process.env.GIT_INSTALL_ROOT, 'bin', 'bash.exe'),
+    process.env.ProgramFiles && join(process.env.ProgramFiles, 'Git', 'bin', 'bash.exe'),
+    'C:\\Program Files\\Git\\bin\\bash.exe'
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  const executable = candidates.find((candidate) => existsSync(candidate));
+  if (!executable) throw new Error('Git Bash is required to execute classifier scripts on Windows');
+  return executable;
+}
+
+/** Minimal env for bash→node classifier runs; keeps Windows process bootstrap vars. */
+function classifierEnv(overrides: Record<string, string>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH ?? '',
+    Path: process.env.Path ?? process.env.PATH ?? '',
+    PATHEXT: process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD',
+    SYSTEMROOT: process.env.SYSTEMROOT ?? process.env.SystemRoot ?? '',
+    SystemRoot: process.env.SystemRoot ?? process.env.SYSTEMROOT ?? '',
+    COMSPEC: process.env.COMSPEC ?? process.env.ComSpec ?? '',
+    ComSpec: process.env.ComSpec ?? process.env.COMSPEC ?? '',
+    ...overrides
+  };
+  return env;
+}
 
 function job(name: string): string {
   return releaseWorkflow.match(new RegExp(`  ${name}:\\n[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:|$)`))?.[0] ?? '';
@@ -38,16 +71,15 @@ function runClassifier(options: { ref: string; refName: string; packageVersion: 
   writeFileSync(join(directory, 'package.json'), JSON.stringify({ version: options.packageVersion }));
   writeFileSync(output, '');
   writeFileSync(scriptPath, classifierScript());
-  // Lean env: avoid copying a large process.env into five nested bash→node spawns.
-  const result = spawnSync('bash', [scriptPath], {
+  // Lean env + bash-safe paths: avoid huge process.env copies while keeping Windows node bootstrap.
+  const result = spawnSync(bashExecutable(), [bashPath(scriptPath)], {
     cwd: directory,
     encoding: 'utf8',
-    env: {
-      PATH: process.env.PATH ?? '',
+    env: classifierEnv({
       GITHUB_REF: options.ref,
       GITHUB_REF_NAME: options.refName,
-      GITHUB_OUTPUT: output
-    }
+      GITHUB_OUTPUT: bashPath(output)
+    })
   });
   const githubOutput = readFileSync(output, 'utf8');
   rmSync(directory, { recursive: true, force: true });
@@ -70,6 +102,30 @@ function launchedGates(body: string): Array<{ name: string; command: string }> {
     command: match[2] ?? ''
   }));
 }
+
+describe('Windows-portable classifier harness', () => {
+  it('converts drive-letter paths for Git Bash and keeps Windows node bootstrap vars', () => {
+    const windowsNative = 'C:\\Users\\runner\\AppData\\Local\\Temp\\out';
+    const gitBashPath = windowsNative
+      .replace(/^([A-Za-z]):[\\/]/, (_, drive: string) => `/${drive.toLowerCase()}/`)
+      .replace(/\\/g, '/');
+    expect(gitBashPath).toBe('/c/Users/runner/AppData/Local/Temp/out');
+    if (process.platform === 'win32') {
+      expect(bashPath(windowsNative)).toBe(gitBashPath);
+    } else {
+      expect(bashPath('/tmp/out')).toBe('/tmp/out');
+    }
+    const env = classifierEnv({ GITHUB_OUTPUT: '/tmp/out', GITHUB_REF_NAME: 'v2.1.2' });
+    expect(env.PATH || env.Path).toBeTruthy();
+    expect(env).toHaveProperty('SYSTEMROOT');
+    expect(env).toHaveProperty('SystemRoot');
+    expect(env).toHaveProperty('PATHEXT');
+    expect(env.GITHUB_OUTPUT).toBe('/tmp/out');
+    expect(env.GITHUB_REF_NAME).toBe('v2.1.2');
+    // Lean copy: do not ship the full parent process environment into bash→node.
+    expect(Object.keys(env).length).toBeLessThan(Object.keys(process.env).length);
+  });
+});
 
 describe('release workflow publishing contract', () => {
   it('keeps existing classifier forms for immutable, alias, and npm_publish outputs', () => {

--- a/tests/validate-inputs.test.ts
+++ b/tests/validate-inputs.test.ts
@@ -43,6 +43,9 @@ function runValidation(env: Record<string, string>): { status: number; stderr: s
         REPO_WRITE_MODE: 'commit-and-push',
         POSTMAN_API_KEY: 'PMAK-test',
         POSTMAN_ACCESS_TOKEN: '',
+        ENABLE_INSIGHTS: 'false',
+        INSIGHTS_POSTMAN_API_KEY: '',
+        INSIGHTS_POSTMAN_ACCESS_TOKEN: '',
         ...env
       },
       encoding: 'utf8',
@@ -90,7 +93,41 @@ describe('composite first-step input validation', () => {
     expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
     expect(validateStep?.env?.POSTMAN_API_KEY).toBe('${{ inputs.postman-api-key }}');
     expect(validateStep?.env?.POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.postman-access-token }}');
+    expect(validateStep?.env?.ENABLE_INSIGHTS).toBe('${{ inputs.enable-insights }}');
+    expect(validateStep?.env?.INSIGHTS_POSTMAN_API_KEY).toBe('${{ inputs.insights-postman-api-key }}');
+    expect(validateStep?.env?.INSIGHTS_POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.insights-postman-access-token }}');
     expect(steps.findIndex((step) => step.id === 'bootstrap')).toBeGreaterThan(0);
+  });
+
+  it.each([
+    {
+      label: 'Insights disabled without dedicated credentials',
+      env: { ENABLE_INSIGHTS: 'false', INSIGHTS_POSTMAN_API_KEY: '', INSIGHTS_POSTMAN_ACCESS_TOKEN: '' },
+      status: 0
+    },
+    {
+      label: 'Insights enabled with both dedicated credentials',
+      env: { ENABLE_INSIGHTS: 'true', INSIGHTS_POSTMAN_API_KEY: 'PMAK-user', INSIGHTS_POSTMAN_ACCESS_TOKEN: 'user-token' },
+      status: 0
+    },
+    {
+      label: 'Insights enabled without dedicated API key',
+      env: { ENABLE_INSIGHTS: 'true', INSIGHTS_POSTMAN_API_KEY: '', INSIGHTS_POSTMAN_ACCESS_TOKEN: 'user-token' },
+      status: 1
+    },
+    {
+      label: 'Insights enabled without dedicated access token',
+      env: { ENABLE_INSIGHTS: 'true', INSIGHTS_POSTMAN_API_KEY: 'PMAK-user', INSIGHTS_POSTMAN_ACCESS_TOKEN: '' },
+      status: 1
+    }
+  ])('$label validates dedicated Insights credentials before children run', ({ env, status }) => {
+    const result = runValidation(env);
+    expect(result.status).toBe(status);
+    if (status !== 0) {
+      const output = combinedOutput(result);
+      expect(output).toContain('Attempted Insights credential validation failed');
+      expect(output).toContain('both insights-postman-api-key and insights-postman-access-token are required');
+    }
   });
 
   it.each([
@@ -210,9 +247,9 @@ describe('child invocation order and credential forwarding', () => {
     expect(steps.filter((step) => step.id === 'insights_onboarding')).toHaveLength(1);
   });
 
-  it('forwards both credentials completely to bootstrap, repo-sync, and insights', () => {
+  it('forwards suite credentials completely to bootstrap and repo-sync', () => {
     const steps = loadManifest().runs.steps;
-    for (const stepId of ['bootstrap', 'repo_sync', 'insights_onboarding'] as const) {
+    for (const stepId of ['bootstrap', 'repo_sync'] as const) {
       const step = steps.find((candidate) => candidate.id === stepId);
       expect(step?.with?.['postman-api-key'], `${stepId} postman-api-key`).toBe(
         '${{ inputs.postman-api-key }}'
@@ -221,5 +258,13 @@ describe('child invocation order and credential forwarding', () => {
         '${{ inputs.postman-access-token }}'
       );
     }
+  });
+
+  it('forwards only dedicated human-user credentials to Insights', () => {
+    const insights = loadManifest().runs.steps.find((step) => step.id === 'insights_onboarding');
+    expect(insights?.with?.['postman-api-key']).toBe('${{ inputs.insights-postman-api-key }}');
+    expect(insights?.with?.['postman-access-token']).toBe('${{ inputs.insights-postman-access-token }}');
+    expect(insights?.with?.['postman-api-key']).not.toBe('${{ inputs.postman-api-key }}');
+    expect(insights?.with?.['postman-access-token']).not.toBe('${{ inputs.postman-access-token }}');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,9 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": ["node"],
+    "allowJs": true
   },
-  "include": ["tests/**/*.ts", "vitest.config.ts"],
+  "include": ["tests/**/*.ts", "scripts/**/*.mjs", "vitest.config.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

The composite needed an explicit credential boundary for Insights and a release path that never rebuilds or trusts mutable source in the publishing job. It now validates dedicated human-user Insights credentials, forwards them only to the Insights step, and publishes a checksummed package assembled by an unprivileged job.

## What changed

- Adds dedicated Insights PMAK and access-token inputs with validation that prevents service-account credentials from crossing that boundary.
- Aligns the action contract, examples, templates, and support guidance with the current v2 composite wiring.
- Classifies immutable and rolling tags before installation, verifies the staged package envelope, and advances aliases only when they don't regress.
- Keeps the privileged publish job artifact-only and binds package identity to the triggering repository, commit, tag, name, and version.

## Safety

- Insights still requires a human-user PMAK and human-user access token; the composite doesn't mint or refresh them.
- Publishing rejects extra files, checksum drift, tag/version mismatches, and an existing npm version with different bytes.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml`
