### PR TITLE
feat: reuse bootstrap collection artifacts in the composite

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -62,8 +62,8 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.8`
-- `postman-cs/postman-repo-sync-action@v2.1.13`
+- `postman-cs/postman-bootstrap-action@v2.10.9`
+- `postman-cs/postman-repo-sync-action@v2.1.14`
 - `postman-cs/postman-insights-onboarding-action@v2.1.6` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -400,6 +400,7 @@ runs:
         baseline-collection-id: ${{ steps.bootstrap.outputs.baseline-collection-id }}
         smoke-collection-id: ${{ steps.bootstrap.outputs.smoke-collection-id }}
         contract-collection-id: ${{ steps.bootstrap.outputs.contract-collection-id }}
+        prebuilt-collections-json: ${{ steps.bootstrap.outputs.prebuilt-collections-json }}
         collection-sync-mode: ${{ inputs.collection-sync-mode }}
         spec-sync-mode: ${{ inputs.spec-sync-mode }}
         release-label: ${{ inputs.release-label }}

--- a/action.yml
+++ b/action.yml
@@ -345,7 +345,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.8
+      uses: postman-cs/postman-bootstrap-action@v2.10.9
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -391,7 +391,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.13
+      uses: postman-cs/postman-repo-sync-action@v2.1.14
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -465,6 +465,9 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.with?.['contract-collection-id']).toBe(
         '${{ steps.bootstrap.outputs.contract-collection-id }}'
       );
+      expect(repoSyncStep?.with?.['prebuilt-collections-json']).toBe(
+        '${{ steps.bootstrap.outputs.prebuilt-collections-json }}'
+      );
       expect(repoSyncStep?.with?.['spec-id']).toBe(
         '${{ steps.bootstrap.outputs.spec-id }}'
       );
@@ -473,6 +476,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
       expect(repoSyncStep?.with?.['spec-files-json']).toBeUndefined();
       expect(repoSyncStep?.with?.['releases-json']).toBeUndefined();
+      expect(manifest.inputs['prebuilt-collections-json']).toBeUndefined();
       expect(repoSyncStep?.with?.['generate-ci-workflow']).toBe(
         '${{ inputs.generate-ci-workflow }}'
       );

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -486,6 +486,27 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.with?.['ci-runner-os']).toBe('${{ inputs.ci-runner-os }}');
     });
 
+    it('verifies local OpenAPI prebuilt manifest wiring, output mapping, and absence of mode/cap inputs', () => {
+      const manifest = loadManifest();
+      const repoSyncStep = manifest.runs.steps.find((step) => step.id === 'repo_sync');
+
+      // Bootstrap output passes to repo-sync prebuilt-collections-json input
+      expect(repoSyncStep?.with?.['prebuilt-collections-json']).toBe(
+        '${{ steps.bootstrap.outputs.prebuilt-collections-json }}'
+      );
+
+      // Public collection ID outputs remain bootstrap IDs
+      expect(manifest.outputs['collections-json']?.value).toBe(
+        '${{ steps.bootstrap.outputs.collections-json }}'
+      );
+
+      // No prebuilt collections mode, kill-switch, fallback, or size/count cap inputs exposed
+      const inputNames = Object.keys(manifest.inputs);
+      expect(inputNames).not.toContain('prebuilt-collections-json');
+      expect(inputNames.some((name) => /prebuilt.*(mode|kill|switch|fallback)/i.test(name))).toBe(false);
+      expect(inputNames.some((name) => /prebuilt.*(size|count|cap|limit)/i.test(name))).toBe(false);
+    });
+
     it('forwards local spec-path and spec-files-json to bootstrap only when spec-url is empty', () => {
       const manifest = loadManifest();
       const bootstrapStep = manifest.runs.steps.find((step) => step.id === 'bootstrap');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -350,8 +350,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.8');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.13');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.9');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.6');
@@ -519,10 +519,10 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.8');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.9');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.1.13');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.6');


### PR DESCRIPTION
Depends on new immutable bootstrap and repo-sync releases from postman-cs/postman-bootstrap-action#116 and postman-cs/postman-repo-sync-action#92.

## Summary

The onboarding composite now passes bootstrap's digest-bound prebuilt collection manifest into repo-sync. Repo-sync can therefore reuse the canonical Collection v3 trees produced before cloud import instead of exporting the same collections back from cloud.

The manifest remains internal wiring: callers do not receive a new public input, and bootstrap continues to own the collection IDs exposed by the composite.

## What changed

- Maps `steps.bootstrap.outputs.prebuilt-collections-json` to repo-sync's `prebuilt-collections-json` input.
- Locks the internal-only contract in composite tests while preserving existing IDs, sync controls, and outputs.

## Validation

- `npm test` - 144 tests passed.
- `npm run typecheck`
- `npm run lint`

The immutable child pins will advance after the dependency releases are published and verified.
