### PR TITLE
chore: prepare v2.1.3 release

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -62,9 +62,9 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.7`
-- `postman-cs/postman-repo-sync-action@v2.1.10`
-- `postman-cs/postman-insights-onboarding-action@v2.1.4` when Insights is enabled
+- `postman-cs/postman-bootstrap-action@v2.10.8`
+- `postman-cs/postman-repo-sync-action@v2.1.13`
+- `postman-cs/postman-insights-onboarding-action@v2.1.6` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -345,7 +345,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.7
+      uses: postman-cs/postman-bootstrap-action@v2.10.8
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -391,7 +391,7 @@ runs:
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
-      uses: postman-cs/postman-repo-sync-action@v2.1.10
+      uses: postman-cs/postman-repo-sync-action@v2.1.13
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:
@@ -574,7 +574,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v2.1.4
+      uses: postman-cs/postman-insights-onboarding-action@v2.1.6
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -350,11 +350,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.7');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.10');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.8');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.13');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.4');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.6');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
@@ -494,13 +494,13 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.7');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.8');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.1.10');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.1.13');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
-      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.4');
+      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.6');
     });
 
     it('surfaces final outputs from phase steps', () => {


### PR DESCRIPTION
## Summary

Prepare composite `v2.1.3` with the newly published Windows/Linux parity releases:

- Bootstrap `v2.10.8`
- Repo Sync `v2.1.13`
- Insights `v2.1.6`

The action contract tests and release policy move with the immutable sibling pins.

## Validation

- Composite contract tests verify every pinned sibling ref and the full input/output wiring.
- CI runs lint, typecheck, tests, sibling-pin validation, commitlint, and actionlint before merge.
