### PR TITLE
ci: run Windows suite via node --run test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,4 @@ jobs:
       - name: Install dependencies
         if: steps.windows-node-modules.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
-      - run: npm test
+      - run: node --run test

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -121,7 +121,7 @@ describe('CI workflow contract', () => {
     expect(ciWorkflowText).not.toMatch(/\bgo install\b/);
   });
 
-  it('keeps Windows as an independent exact-cache npm test lane without queue or Linux-owned gates', () => {
+  it('keeps Windows as an independent exact-cache node --run test lane without queue or Linux-owned gates', () => {
     expect(windowsJob?.name).toBe('Windows gate');
     expect(windowsJob?.['runs-on']).toBe('windows-latest');
     expect(windowsJob?.needs).toBeUndefined();
@@ -153,12 +153,12 @@ describe('CI workflow contract', () => {
     expect(windows).toContain("if: steps.windows-node-modules.outputs.cache-hit != 'true'");
     expect(windows).toContain('run: npm ci --prefer-offline --no-audit --no-fund');
 
-    const testSteps = windowsJob?.steps?.filter((step) => step.run === 'npm test') ?? [];
+    const testSteps = windowsJob?.steps?.filter((step) => step.run === 'node --run test') ?? [];
     expect(testSteps).toHaveLength(1);
     expect(testSteps[0]?.if).toBeUndefined();
-    expect(windows).toMatch(/^\s*- run: npm test\s*$/m);
-    expect(windows).not.toContain('npm test --');
-    expect(windows).not.toContain("npm test'");
+    expect(windows).toMatch(/^\s*- run: node --run test\s*$/m);
+    expect(windows).not.toContain('node --run test --');
+    expect(windows).not.toContain("node --run test'");
 
     expect(windows).not.toContain('Run Windows gates');
     expect(windows).not.toContain('Start-Gate');


### PR DESCRIPTION
Restores the Windows gate to node --run test; the PR #82 merge resolution reverted it to npm test. Pins the invocation in the CI workflow contract tests.