### PR TITLE
feat: forward branch-aware composite contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `insights-postman-api-key` | Human-user Postman API key (PMAK) for Insights. Required with insights-postman-access-token only when enable-insights is true; do not use the service-account suite key. | no |  |
 | `insights-postman-access-token` | Human-user session access token for Insights. Required with insights-postman-api-key only when enable-insights is true; do not use a service-token mint. | no |  |
 | `credential-preflight` | Credential identity preflight policy forwarded to bootstrap and repo sync. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created. | no | `warn` |
+| `branch-strategy` | Branch-aware sync strategy. v2 preserves legacy by default; the future v3 major will default to publish-gate after its release gates close. | no | `legacy` |
+| `canonical-branch` | Explicit canonical branch. Defaults to the GitHub event repository default branch for non-legacy strategies. | no |  |
+| `channels` | Comma-separated channel map, for example develop=DEV, staging=STAGE, release/*=RC. | no |  |
+| `preview-ttl` | Sliding preview retention TTL in days, forwarded to repo-sync. | no | `30` |
 | `postman-team-id` | Explicit Postman team ID override for org-mode integration calls. | no |  |
 | `postman-region` | Postman data residency region for public API and Postman CLI calls. One of us or eu. | no | `us` |
 | `github-token` | GitHub token used for repo variables and generated commits. | no |  |
@@ -301,6 +305,8 @@ Tables are generated from `action.yml` by `npm run docs:tables`.
 | `monitor-id` | Smoke monitor ID. |
 | `repo-sync-summary-json` | JSON summary of repo materialization and workspace sync planning. |
 | `commit-sha` | Commit SHA produced by repo-write-mode. |
+| `sync-status` | Branch-aware sync status, including skipped-branch-gate for credential-free gated runs. |
+| `spec-version-url` | Read-only URL for the canonical Spec Hub version finalized by repo-sync. |
 | `bootstrap-outcome` | GitHub Actions runner outcome for the bootstrap step. |
 | `repo-sync-outcome` | GitHub Actions runner outcome for the repo sync step. |
 | `insights-outcome` | GitHub Actions runner outcome for the Insights onboarding step. |

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -26,6 +26,7 @@ It applies to these repositories:
 - Immutable release identity is derived from the repository `package.json` version at the tagged commit:
   exact `vX.Y.Z`, plus `vX.Y` when the patch component is `0`.
 - The current consumer rolling channel for this composite is `v2`.
+- Every v2 release keeps `branch-strategy` defaulted to `legacy`. The next default-flip major is v3.
 - The public release contract is the git tag and GitHub release. Do not treat `package.json` version fields as the authoritative public release identifier by themselves.
 
 ## Source of truth
@@ -58,11 +59,28 @@ Do not duplicate full input and output tables across repositories. Link to the a
 
 ## Composite dependency policy
 
+### Branch-aware v2 contract and v3 rollout
+
+The v2 composite exposes `branch-strategy`, `canonical-branch`, `channels`, and
+`preview-ttl`, resolves one `POSTMAN_BRANCH_DECISION` before every child, and
+surfaces `sync-status` and `spec-version-url`. Gated bootstrap receives empty
+credentials; repo-sync and Insights are skipped. There are no public migration knobs.
+
+The forward-only v3 contract is executable only after every branch-aware E2E
+gate in the PRD passes for org and non-org runs, including zero-mint/zero-write.
+Then release child v3 majors bottom-up; verify their immutable tags, releases,
+and CI; update this composite to major 3, pin those released immutable child
+tags, and flip only `branch-strategy` to `publish-gate`. After Linux, Windows,
+sibling-pin, actionlint, release, and security checks pass and the PR merges,
+create immutable v3 through the release workflow, verify npm/GitHub assets and
+checksums, and advance the new v3 alias forward. Never move v2, rewrite an
+immutable tag, or force-push. Until these prerequisites close, do not publish v3.
+
 ### Current rule
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.9`
+- `postman-cs/postman-bootstrap-action@v2.10.10`
 - `postman-cs/postman-repo-sync-action@v2.1.14`
 - `postman-cs/postman-insights-onboarding-action@v2.1.6` when Insights is enabled
 

--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,20 @@ inputs:
     description: "Credential identity preflight policy forwarded to bootstrap and repo sync. warn (default) logs a note and continues when postman-api-key and postman-access-token resolve to different parent orgs; enforce fails the run on that condition before any workspace is created."
     required: false
     default: warn
+  branch-strategy:
+    description: Branch-aware sync strategy. v2 preserves legacy by default; the future v3 major will default to publish-gate after its release gates close.
+    required: false
+    default: legacy
+  canonical-branch:
+    description: Explicit canonical branch. Defaults to the GitHub event repository default branch for non-legacy strategies.
+    required: false
+  channels:
+    description: Comma-separated channel map, for example develop=DEV, staging=STAGE, release/*=RC.
+    required: false
+  preview-ttl:
+    description: Sliding preview retention TTL in days, forwarded to repo-sync.
+    required: false
+    default: '30'
   postman-team-id:
     description: Explicit Postman team ID override for org-mode integration calls.
     required: false
@@ -258,6 +272,12 @@ outputs:
   commit-sha:
     description: Commit SHA produced by repo-write-mode.
     value: ${{ steps.repo_sync.outputs.commit-sha }}
+  sync-status:
+    description: Branch-aware sync status, including skipped-branch-gate for credential-free gated runs.
+    value: ${{ steps.repo_sync.outputs.sync-status || steps.bootstrap.outputs.sync-status }}
+  spec-version-url:
+    description: Read-only URL for the canonical Spec Hub version finalized by repo-sync.
+    value: ${{ steps.repo_sync.outputs.spec-version-url }}
   bootstrap-outcome:
     description: GitHub Actions runner outcome for the bootstrap step.
     value: ${{ steps.bootstrap.outcome }}
@@ -288,6 +308,56 @@ outputs:
 runs:
   using: composite
   steps:
+    - id: branch_decision
+      name: Resolve immutable branch decision
+      shell: bash
+      env:
+        POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        BRANCH_STRATEGY: ${{ inputs.branch-strategy }}
+        CANONICAL_BRANCH: ${{ inputs.canonical-branch }}
+        CHANNELS: ${{ inputs.channels }}
+      run: |
+        node <<'NODE'
+        const fs = require('node:fs');
+        const clean = (value) => (value || '').trim() || undefined;
+        const strategy = clean(process.env.BRANCH_STRATEGY) || 'legacy';
+        if (!['legacy', 'publish-gate', 'preview'].includes(strategy)) throw new Error('CONTRACT_BRANCH_STRATEGY_INVALID: expected legacy, publish-gate, or preview');
+        let event = {};
+        try { event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); } catch {}
+        const rawRef = clean(process.env.GITHUB_REF) || clean(process.env.GITHUB_REF_NAME);
+        const headBranch = clean(process.env.GITHUB_HEAD_REF) || (rawRef?.startsWith('refs/heads/') ? rawRef.slice(11) : undefined);
+        const defaultBranch = clean(process.env.CANONICAL_BRANCH) || clean(event.repository?.default_branch);
+        const isPrContext = Boolean(clean(process.env.GITHUB_HEAD_REF));
+        const headRepo = event.pull_request?.head?.repo?.full_name;
+        const baseRepo = event.pull_request?.base?.repo?.full_name || event.repository?.full_name;
+        const isForkPr = Boolean(headRepo && baseRepo && headRepo !== baseRepo);
+        let refKind = rawRef?.startsWith('refs/tags/') ? 'tag' : headBranch ? 'branch' : 'unknown';
+        if (headBranch && defaultBranch && headBranch === defaultBranch) refKind = 'default-branch';
+        const identity = { provider: 'github', headBranch, rawRef, defaultBranch, refKind, isPrContext, isForkPr, headSha: clean(process.env.GITHUB_SHA) };
+        const canonicalBranch = clean(process.env.CANONICAL_BRANCH) || defaultBranch;
+        let tier = 'legacy';
+        let reason = 'branch-strategy legacy: branch-blind pre-v2 behavior';
+        let channel;
+        if (strategy !== 'legacy') {
+          if (!canonicalBranch) throw new Error('CONTRACT_DEFAULT_BRANCH_UNRESOLVED: set the canonical-branch input');
+          const rules = (clean(process.env.CHANNELS)?.split(',') || []).filter(Boolean).map((entry) => {
+            const parts = entry.split('=').map((part) => part.trim());
+            if (parts.length !== 2 || !parts[0] || !/^[A-Za-z][A-Za-z0-9_-]{0,15}$/.test(parts[1])) throw new Error(`CONTRACT_CHANNELS_INPUT_INVALID: ${entry}`);
+            return { pattern: parts[0], code: parts[1].toUpperCase() };
+          });
+          if (!rules.some((rule) => rule.pattern === 'release/*')) rules.push({ pattern: 'release/*', code: 'RC' });
+          channel = rules.find((rule) => rule.pattern.endsWith('*') ? headBranch?.startsWith(rule.pattern.slice(0, -1)) : headBranch === rule.pattern);
+          if (refKind === 'tag' || refKind === 'unknown' || !headBranch) { tier = 'gated'; reason = `ref kind ${refKind}: no-op`; }
+          else if (headBranch === canonicalBranch) { tier = 'canonical'; reason = `head branch equals canonical branch ${canonicalBranch}`; }
+          else if (channel) { tier = 'channel'; reason = `branch ${headBranch} matches channel ${channel.pattern}=${channel.code}`; }
+          else if (strategy === 'preview' && !isForkPr) { tier = 'preview'; reason = `branch ${headBranch} under branch-strategy preview`; }
+          else { tier = 'gated'; reason = isForkPr ? 'fork PR: preview-ineligible, gated instead' : `branch ${headBranch} under branch-strategy publish-gate`; }
+        }
+        const decision = { tier, strategy, identity, canonicalBranch, ...(channel && tier === 'channel' ? { channel } : {}), reason };
+        const serialized = JSON.stringify(decision);
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `tier=${tier}\nbranch-decision=${serialized}\n`);
+        fs.appendFileSync(process.env.GITHUB_ENV, `POSTMAN_BRANCH_DECISION=${serialized}\n`);
+        NODE
     - id: validate_postman_stack
       name: Validate Postman stack and region
       shell: bash
@@ -300,6 +370,7 @@ runs:
         POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
         POSTMAN_ACCESS_TOKEN: ${{ inputs.postman-access-token }}
         ENABLE_INSIGHTS: ${{ inputs.enable-insights }}
+        BRANCH_TIER: ${{ steps.branch_decision.outputs.tier }}
         INSIGHTS_POSTMAN_API_KEY: ${{ inputs.insights-postman-api-key }}
         INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ inputs.insights-postman-access-token }}
       run: |
@@ -335,7 +406,7 @@ runs:
             exit 1
             ;;
         esac
-        if [ -z "$POSTMAN_API_KEY" ] && [ -z "$POSTMAN_ACCESS_TOKEN" ]; then
+        if [ "$BRANCH_TIER" != "gated" ] && [ -z "$POSTMAN_API_KEY" ] && [ -z "$POSTMAN_ACCESS_TOKEN" ]; then
           echo "::error::Attempted onboarding credential validation failed: neither postman-api-key nor postman-access-token was supplied. Provide one of those inputs and rerun."
           exit 1
         fi
@@ -345,9 +416,10 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.9
+      uses: postman-cs/postman-bootstrap-action@v2.10.10
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
       with:
         project-name: ${{ inputs.project-name }}
         workspace-id: ${{ inputs.workspace-id }}
@@ -383,17 +455,22 @@ runs:
         governance-mapping-json: ${{ inputs.governance-mapping-json }}
         github-token: ${{ inputs.github-token }}
         gh-fallback-token: ${{ inputs.gh-fallback-token }}
-        postman-api-key: ${{ inputs.postman-api-key }}
-        postman-access-token: ${{ inputs.postman-access-token }}
+        postman-api-key: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
+        postman-access-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}
         credential-preflight: ${{ inputs.credential-preflight }}
+        branch-strategy: ${{ inputs.branch-strategy }}
+        canonical-branch: ${{ inputs.canonical-branch }}
+        channels: ${{ inputs.channels }}
         integration-backend: ${{ inputs.integration-backend }}
         postman-region: ${{ inputs.postman-region }}
         postman-stack: ${{ inputs.postman-stack }}
     - id: repo_sync
       name: Sync Repository and Workspace
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
       uses: postman-cs/postman-repo-sync-action@v2.1.14
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
       with:
         project-name: ${{ inputs.project-name }}
         workspace-id: ${{ steps.bootstrap.outputs.workspace-id }}
@@ -418,6 +495,10 @@ runs:
         postman-api-key: ${{ inputs.postman-api-key }}
         postman-access-token: ${{ inputs.postman-access-token }}
         credential-preflight: ${{ inputs.credential-preflight }}
+        branch-strategy: ${{ inputs.branch-strategy }}
+        canonical-branch: ${{ inputs.canonical-branch }}
+        channels: ${{ inputs.channels }}
+        preview-ttl: ${{ inputs.preview-ttl }}
         github-token: ${{ inputs.github-token }}
         gh-fallback-token: ${{ inputs.gh-fallback-token }}
         org-mode: ${{ inputs.org-mode }}
@@ -573,11 +654,12 @@ runs:
         path: ${{ runner.temp }}/postman-junit/*.xml
         if-no-files-found: ignore
     - id: insights_onboarding
-      if: inputs.enable-insights == 'true'
+      if: inputs.enable-insights == 'true' && steps.branch_decision.outputs.tier != 'gated'
       name: Onboard Postman Insights
       uses: postman-cs/postman-insights-onboarding-action@v2.1.6
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
       with:
         project-name: ${{ inputs.project-name }}
         workspace-id: ${{ steps.bootstrap.outputs.workspace-id }}
@@ -587,6 +669,9 @@ runs:
         postman-api-key: ${{ inputs.insights-postman-api-key }}
         postman-access-token: ${{ inputs.insights-postman-access-token }}
         credential-preflight: ${{ inputs.credential-preflight }}
+        branch-strategy: ${{ inputs.branch-strategy }}
+        canonical-branch: ${{ inputs.canonical-branch }}
+        channels: ${{ inputs.channels }}
         postman-team-id: ${{ inputs.postman-team-id }}
         github-token: ${{ inputs.github-token }}
         postman-region: ${{ inputs.postman-region }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -219,6 +219,10 @@ describe('postman-api-onboarding-action composite contract', () => {
         'insights-postman-api-key',
         'insights-postman-access-token',
         'credential-preflight',
+        'branch-strategy',
+        'canonical-branch',
+        'channels',
+        'preview-ttl',
         'postman-team-id',
         'postman-region',
         'postman-stack',
@@ -317,6 +321,8 @@ describe('postman-api-onboarding-action composite contract', () => {
         'monitor-id',
         'repo-sync-summary-json',
         'commit-sha',
+        'sync-status',
+        'spec-version-url',
         'bootstrap-outcome',
         'repo-sync-outcome',
         'insights-outcome',
@@ -334,9 +340,7 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('is a composite action with the expected step count', () => {
       const manifest = loadManifest();
       expect(manifest.runs.using).toBe('composite');
-      // bootstrap, repo-sync, warn-no-api-key, Windows CLI install, junit-runner,
-      // junit-uploader, and insights plus validation.
-      expect(manifest.runs.steps).toHaveLength(8);
+      expect(manifest.runs.steps).toHaveLength(9);
     });
 
     it('uses pinned bootstrap, repo-sync, junit-runner, junit-uploader, and insights actions', () => {
@@ -350,7 +354,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.9');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.10');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
@@ -379,7 +383,7 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('validates repo-write-mode in the first composite step before any child runs', () => {
       const manifest = loadManifest();
       const steps = manifest.runs.steps;
-      const validateStep = steps[0];
+      const validateStep = steps[1];
 
       expect(validateStep?.id).toBe('validate_postman_stack');
       expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
@@ -390,6 +394,41 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(steps.findIndex((step) => step.uses?.includes('postman-bootstrap-action'))).toBeGreaterThan(
         0
       );
+    });
+
+    it('resolves one branch decision before validation and every child invocation', () => {
+      const manifest = loadManifest();
+      expect(manifest.runs.steps[0]?.id).toBe('branch_decision');
+      for (const id of ['bootstrap', 'repo_sync', 'insights_onboarding']) {
+        expect(manifest.runs.steps.find((step) => step.id === id)?.env?.POSTMAN_BRANCH_DECISION).toBe('${{ steps.branch_decision.outputs.branch-decision }}');
+      }
+    });
+
+    it('keeps v2 legacy and forwards the released branch-aware surface', () => {
+      const manifest = loadManifest();
+      expect(manifest.inputs['branch-strategy']?.default).toBe('legacy');
+      const bootstrap = manifest.runs.steps.find((step) => step.id === 'bootstrap');
+      const repoSync = manifest.runs.steps.find((step) => step.id === 'repo_sync');
+      const insights = manifest.runs.steps.find((step) => step.id === 'insights_onboarding');
+      for (const child of [bootstrap, repoSync, insights]) {
+        expect(child?.with?.['branch-strategy']).toBe('${{ inputs.branch-strategy }}');
+        expect(child?.with?.['canonical-branch']).toBe('${{ inputs.canonical-branch }}');
+        expect(child?.with?.channels).toBe('${{ inputs.channels }}');
+      }
+      expect(repoSync?.with?.['preview-ttl']).toBe('${{ inputs.preview-ttl }}');
+      expect(manifest.outputs['sync-status']?.value).toContain('sync-status');
+      expect(manifest.outputs['spec-version-url']?.value).toBe('${{ steps.repo_sync.outputs.spec-version-url }}');
+    });
+
+    it('runs gated bootstrap without credentials and skips credentialed children', () => {
+      const manifest = loadManifest();
+      const bootstrap = manifest.runs.steps.find((step) => step.id === 'bootstrap');
+      const repoSync = manifest.runs.steps.find((step) => step.id === 'repo_sync');
+      const insights = manifest.runs.steps.find((step) => step.id === 'insights_onboarding');
+      expect(bootstrap?.with?.['postman-api-key']).toContain("tier != 'gated'");
+      expect(bootstrap?.with?.['postman-access-token']).toContain("tier != 'gated'");
+      expect(repoSync?.if).toContain("tier != 'gated'");
+      expect(insights?.if).toContain("tier != 'gated'");
     });
 
     it('invokes bootstrap, repo-sync, and insights exactly once in that order', () => {
@@ -519,7 +558,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.9');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.10');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
       ).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
@@ -575,11 +614,12 @@ describe('postman-api-onboarding-action composite contract', () => {
 
     it('isolates dedicated human-user Insights credentials from suite credentials', () => {
       const manifest = loadManifest();
-      for (const stepId of ['bootstrap', 'repo_sync'] as const) {
-        const step = manifest.runs.steps.find((s) => s.id === stepId);
-        expect(step?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
-        expect(step?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
-      }
+      const bootstrap = manifest.runs.steps.find((s) => s.id === 'bootstrap');
+      const repoSync = manifest.runs.steps.find((s) => s.id === 'repo_sync');
+      expect(bootstrap?.with?.['postman-api-key']).toContain('inputs.postman-api-key');
+      expect(bootstrap?.with?.['postman-access-token']).toContain('inputs.postman-access-token');
+      expect(repoSync?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
+      expect(repoSync?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
       const insights = manifest.runs.steps.find((step) => step.id === 'insights_onboarding');
       expect(insights?.with?.['postman-api-key']).toBe('${{ inputs.insights-postman-api-key }}');
       expect(insights?.with?.['postman-access-token']).toBe('${{ inputs.insights-postman-access-token }}');

--- a/tests/validate-inputs.test.ts
+++ b/tests/validate-inputs.test.ts
@@ -9,6 +9,7 @@ const repoRoot = path.resolve(__dirname, '..');
 
 type Step = {
   id?: string;
+  if?: string;
   run?: string;
   env?: Record<string, string>;
   uses?: string;
@@ -86,9 +87,10 @@ describe('composite first-step input validation', () => {
     expect(manifest.inputs['repo-write-mode']?.default).toBe('commit-and-push');
   });
 
-  it('wires credential and repo-write-mode env into the first validation step before any child', () => {
+  it('resolves branch decision first, then validates before any child', () => {
     const steps = loadManifest().runs.steps;
-    const validateStep = steps[0];
+    expect(steps[0]?.id).toBe('branch_decision');
+    const validateStep = steps[1];
     expect(validateStep?.id).toBe('validate_postman_stack');
     expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
     expect(validateStep?.env?.POSTMAN_API_KEY).toBe('${{ inputs.postman-api-key }}');
@@ -96,6 +98,7 @@ describe('composite first-step input validation', () => {
     expect(validateStep?.env?.ENABLE_INSIGHTS).toBe('${{ inputs.enable-insights }}');
     expect(validateStep?.env?.INSIGHTS_POSTMAN_API_KEY).toBe('${{ inputs.insights-postman-api-key }}');
     expect(validateStep?.env?.INSIGHTS_POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.insights-postman-access-token }}');
+    expect(validateStep?.env?.BRANCH_TIER).toBe('${{ steps.branch_decision.outputs.tier }}');
     expect(steps.findIndex((step) => step.id === 'bootstrap')).toBeGreaterThan(0);
   });
 
@@ -148,6 +151,11 @@ describe('composite first-step input validation', () => {
       expect(output).toContain('neither postman-api-key nor postman-access-token was supplied');
       expect(output).toContain('Provide one of those inputs and rerun');
     }
+  });
+
+  it('permits a gated decision without onboarding credentials', () => {
+    const result = runValidation({ BRANCH_TIER: 'gated', POSTMAN_API_KEY: '', POSTMAN_ACCESS_TOKEN: '' });
+    expect(result.status).toBe(0);
   });
 
   it.each(['none', 'commit-only', 'commit-and-push'])('accepts valid repo-write-mode=%s', (mode) => {
@@ -247,17 +255,15 @@ describe('child invocation order and credential forwarding', () => {
     expect(steps.filter((step) => step.id === 'insights_onboarding')).toHaveLength(1);
   });
 
-  it('forwards suite credentials completely to bootstrap and repo-sync', () => {
+  it('forwards canonical credentials and omits them from gated bootstrap', () => {
     const steps = loadManifest().runs.steps;
-    for (const stepId of ['bootstrap', 'repo_sync'] as const) {
-      const step = steps.find((candidate) => candidate.id === stepId);
-      expect(step?.with?.['postman-api-key'], `${stepId} postman-api-key`).toBe(
-        '${{ inputs.postman-api-key }}'
-      );
-      expect(step?.with?.['postman-access-token'], `${stepId} postman-access-token`).toBe(
-        '${{ inputs.postman-access-token }}'
-      );
-    }
+    const bootstrap = steps.find((candidate) => candidate.id === 'bootstrap');
+    const repoSync = steps.find((candidate) => candidate.id === 'repo_sync');
+    expect(bootstrap?.with?.['postman-api-key']).toBe("${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}");
+    expect(bootstrap?.with?.['postman-access-token']).toBe("${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}");
+    expect(repoSync?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
+    expect(repoSync?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
+    expect(repoSync?.if).toContain("tier != 'gated'");
   });
 
   it('forwards only dedicated human-user credentials to Insights', () => {


### PR DESCRIPTION
## Summary
- resolve and forward one immutable branch decision before child execution
- preserve v2 legacy defaults while documenting the gated v3 rollout
- omit credentials and credentialed children for gated runs

## Validation
- npm test
- npm run typecheck
- npm run lint
- node scripts/check-sibling-pins.mjs
- npm run docs:tables
- node scripts/render-action-tables.mjs --check
- actionlint .github/workflows/*.yml