### PR TITLE
chore: advance sibling pins; prepare v2.1.5 release

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -80,9 +80,9 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.10`
+- `postman-cs/postman-bootstrap-action@v2.10.11`
 - `postman-cs/postman-repo-sync-action@v2.1.14`
-- `postman-cs/postman-insights-onboarding-action@v2.1.6` when Insights is enabled
+- `postman-cs/postman-insights-onboarding-action@v2.1.7` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -416,7 +416,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.10
+      uses: postman-cs/postman-bootstrap-action@v2.10.11
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
@@ -656,7 +656,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true' && steps.branch_decision.outputs.tier != 'gated'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v2.1.6
+      uses: postman-cs/postman-insights-onboarding-action@v2.1.7
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -354,11 +354,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.10');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.11');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.6');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.7');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
@@ -558,13 +558,13 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.10');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.11');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
       ).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
-      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.6');
+      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.7');
     });
 
     it('surfaces final outputs from phase steps', () => {


### PR DESCRIPTION
## Summary
- pin bootstrap v2.10.11 and Insights v2.1.7
- retain repo-sync v2.1.14
- prepare composite v2.1.5

## Validation
- npm run test