### PR TITLE
Release v2.1.7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -416,7 +416,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.12
+      uses: postman-cs/postman-bootstrap-action@v2.10.16
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",


### PR DESCRIPTION
## Summary

- Pin `postman-bootstrap-action` to **@v2.10.16** (branch-aware concurrent preview cleanup/reconcile)
- Bump composite to **2.1.7**

## Evidence

- branch-aware E2E org+nonorg green on bootstrap `@v2.10.16` (run 30042655863)