### PR TITLE
Release v2.1.8

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -80,8 +80,8 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.10.12`
-- `postman-cs/postman-repo-sync-action@v2.1.14`
+- `postman-cs/postman-bootstrap-action@v2.10.19`
+- `postman-cs/postman-repo-sync-action@v2.1.15`
 - `postman-cs/postman-insights-onboarding-action@v2.1.8` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
@@ -93,7 +93,9 @@ The composite action references immutable sibling tags inside `action.yml`. Ther
 - Every composite release must record the exact sibling tags it uses.
 - Any change to a pinned sibling version requires a new composite release.
 - The compatibility matrix in this document and the README must be updated in the same change.
-- The release workflow must run `scripts/check-sibling-pins.mjs` so the composite cannot ship stale sibling refs.
+- The release workflow must run `scripts/check-sibling-pins.mjs` so every
+  committed sibling ref is an existing immutable tag and every forwarded input
+  remains declared by that exact sibling release.
 
 ## Release order
 

--- a/action.yml
+++ b/action.yml
@@ -416,7 +416,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.10.16
+      uses: postman-cs/postman-bootstrap-action@v2.10.19
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
@@ -467,7 +467,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.1.14
+      uses: postman-cs/postman-repo-sync-action@v2.1.15
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-api",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-api",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [
     "action.yml",

--- a/scripts/check-sibling-pins.mjs
+++ b/scripts/check-sibling-pins.mjs
@@ -14,8 +14,9 @@ const requiredPins = [
   { repo: 'postman-insights-onboarding-action', stepId: 'insights_onboarding' }
 ];
 
-// Siblings are pinned to the latest immutable tag of the composite's own major
-// version, so the pins advance in lockstep with the suite release train.
+// Siblings are pinned to reviewed immutable tags of the composite's own major.
+// Release eligibility must depend only on committed pins, not on a mutable
+// "latest tag" query that can change after the composite commit is reviewed.
 const compositeVersion = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).version;
 const compositeMajor = Number(String(compositeVersion).split('.')[0]);
 
@@ -26,31 +27,12 @@ function semverForMajor(tag, major) {
   return parts[0] === major ? parts : undefined;
 }
 
-function compareSemver(left, right) {
-  for (let index = 0; index < left.length; index += 1) {
-    if (left[index] !== right[index]) {
-      return left[index] - right[index];
-    }
-  }
-  return 0;
-}
-
-function latestTag(repo, major) {
+function tagExists(repo, tag) {
   const remote = 'https://github.com/postman-cs/' + repo + '.git';
-  const output = execFileSync('git', ['ls-remote', '--tags', remote, 'refs/tags/v' + major + '.*'], {
+  const output = execFileSync('git', ['ls-remote', '--tags', remote, 'refs/tags/' + tag], {
     encoding: 'utf8'
   });
-  const tags = output
-    .split('\n')
-    .map((line) => line.trim().split('/').pop())
-    .filter(Boolean)
-    .map((tag) => ({ tag, semver: semverForMajor(tag, major) }))
-    .filter((entry) => entry.semver);
-  if (tags.length === 0) {
-    throw new Error('No immutable v' + major + ' tags found for ' + repo);
-  }
-  tags.sort((left, right) => compareSemver(left.semver, right.semver));
-  return tags.at(-1).tag;
+  return output.trim().length > 0;
 }
 
 const manifest = parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8'));
@@ -73,26 +55,32 @@ async function fetchSiblingInputs(repo, tag) {
 for (const { repo, stepId } of requiredPins) {
   const step = manifest.runs.steps.find((candidate) => candidate.id === stepId);
   const actual = step?.uses;
-  const latest = latestTag(repo, compositeMajor);
-  const expected = 'postman-cs/' + repo + '@' + latest;
-  if (actual !== expected) {
-    failures.push(stepId + ': expected ' + expected + ', found ' + (actual || '<missing>'));
+  const prefix = 'postman-cs/' + repo + '@';
+  const tag = typeof actual === 'string' && actual.startsWith(prefix)
+    ? actual.slice(prefix.length)
+    : '';
+  if (!semverForMajor(tag, compositeMajor)) {
+    failures.push(stepId + ': expected an immutable v' + compositeMajor + ' tag, found ' + (actual || '<missing>'));
     continue;
   }
-  const siblingInputs = await fetchSiblingInputs(repo, latest);
+  if (!tagExists(repo, tag)) {
+    failures.push(stepId + ': pinned tag ' + tag + ' does not exist in postman-cs/' + repo);
+    continue;
+  }
+  const siblingInputs = await fetchSiblingInputs(repo, tag);
   for (const key of Object.keys(step?.with ?? {})) {
     if (!siblingInputs.has(key)) {
-      failures.push(stepId + ': forwards with-key `' + key + '` but ' + repo + '@' + latest + ' declares no such input');
+      failures.push(stepId + ': forwards with-key `' + key + '` but ' + repo + '@' + tag + ' declares no such input');
     }
   }
 }
 
 if (failures.length > 0) {
-  console.error('Composite sibling pins are stale:');
+  console.error('Composite sibling pins are invalid:');
   for (const failure of failures) {
     console.error('- ' + failure);
   }
   process.exit(1);
 }
 
-console.log('Composite sibling pins match the latest immutable v' + compositeMajor + ' tags and every forwarded with-key is a declared sibling input.');
+console.log('Composite sibling pins are existing immutable v' + compositeMajor + ' tags and every forwarded with-key is a declared sibling input.');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -354,8 +354,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.12');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.15');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.8');
@@ -558,10 +558,10 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.12');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.1.14');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.1.15');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.8');


### PR DESCRIPTION
## Summary

- Pin bootstrap `v2.10.19`, live-proven branch-aware on org and nonorg.
- Pin repo-sync `v2.1.15`.
- Align composite contract tests and release policy.
- Validate committed immutable sibling tags instead of mutable remote latest.
- Bump the composite to `2.1.8`; `v2.1.7` remains untouched and unpublished.

## Validation

- `npm test` (148 passed)
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
- Bootstrap live proof: postman-actions-e2e run 30051518781