### PR TITLE
chore(deps): pin Insights onboarding v2.2.1

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -82,7 +82,7 @@ The composite action currently depends on:
 
 - `postman-cs/postman-bootstrap-action@v2.10.19`
 - `postman-cs/postman-repo-sync-action@v2.1.15`
-- `postman-cs/postman-insights-onboarding-action@v2.1.8` when Insights is enabled
+- `postman-cs/postman-insights-onboarding-action@v2.2.1` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.
 

--- a/action.yml
+++ b/action.yml
@@ -656,7 +656,7 @@ runs:
     - id: insights_onboarding
       if: inputs.enable-insights == 'true' && steps.branch_decision.outputs.tier != 'gated'
       name: Onboard Postman Insights
-      uses: postman-cs/postman-insights-onboarding-action@v2.1.8
+      uses: postman-cs/postman-insights-onboarding-action@v2.2.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -358,7 +358,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.15');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.1.8');
+      expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');
       for (const step of [bootstrapStep, repoSyncStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
       }
@@ -564,7 +564,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       ).toBe('postman-cs/postman-repo-sync-action@v2.1.15');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
-      ).toBe('postman-cs/postman-insights-onboarding-action@v2.1.8');
+      ).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');
     });
 
     it('surfaces final outputs from phase steps', () => {


### PR DESCRIPTION
## Summary

- advance the composite Insights child action to immutable v2.2.1
- update the sibling-pin release policy and contract assertions
- consume the human-session identity normalization shipped in Insights v2.2.1

## Validation

- npm test
- npm run typecheck
- npm run lint
- node scripts/check-sibling-pins.mjs