### PR TITLE
fix: consume repo-sync v2.2.0

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -81,7 +81,7 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 The composite action currently depends on:
 
 - `postman-cs/postman-bootstrap-action@v2.10.19`
-- `postman-cs/postman-repo-sync-action@v2.1.15`
+- `postman-cs/postman-repo-sync-action@v2.2.0`
 - `postman-cs/postman-insights-onboarding-action@v2.2.1` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -467,7 +467,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.1.15
+      uses: postman-cs/postman-repo-sync-action@v2.2.0
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -355,7 +355,7 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(validateStep?.shell).toBe('bash');
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.1.15');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.2.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');
@@ -561,7 +561,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.1.15');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.2.0');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');


### PR DESCRIPTION
## Summary

The composite still invoked repo-sync `v2.1.15`, so onboarding runs did not receive the released public-mock callability checks. It now pins immutable repo-sync `v2.2.0`, bringing composite runs onto the validated mock resolver without introducing a floating sibling dependency.

## What changed

- Advances the `repo_sync` step to `postman-cs/postman-repo-sync-action@v2.2.0`.
- Updates the contract assertions and release-policy compatibility record to the same immutable tag.

## Validation

- `npm ci`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run docs:tables`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
- Repo-sync `v2.2.0`: GitHub release, SEA assets, rolling `v2` alias, and npm `latest` are published and resolve to the same immutable release commit.
