### PR TITLE
feat: pass mock visibility policy through to repo-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ Set `skip-built-in-tests: 'true'` when the caller workflow must perform post-onb
 | `release-label` | Optional release label for versioned specs and collections. When omitted during versioned sync, derived from GitHub tag or branch metadata. | no |  |
 | `monitor-id` | Existing smoke monitor ID. When set, the action validates and reuses this monitor instead of creating a new one. | no |  |
 | `mock-url` | Existing mock server URL. When set, the action validates and reuses this mock instead of creating a new one. | no |  |
-| `mock-environment-enabled` | Create or update a dedicated manual-validation environment whose baseUrl is the validated public mock URL. This environment is excluded from runtime CI selection. | no | `false` |
+| `mock-visibility` | Required mock access policy. Public is anonymous; private requires a runtime x-api-key supplied by the caller and is never persisted by repo-sync. | no | `public` |
+| `mock-environment-enabled` | Create or update a dedicated manual-validation environment whose baseUrl is the validated mock URL. This environment is excluded from runtime CI selection and never contains a mock credential. | no | `false` |
 | `monitor-cron` | Cron expression for monitor scheduling (e.g. '0 */6 * * *'). When empty, the monitor is created disabled and triggered to run once per workflow invocation (and once on every subsequent run). | no |  |
 | `generate-ci-workflow` | Whether to generate the CI workflow file. | no | `true` |
 | `ci-workflow-path` | Path to write the generated CI workflow file. | no | `.github/workflows/ci.yml` |
@@ -303,6 +304,8 @@ Tables are generated from `action.yml` by `npm run docs:tables`.
 | `breaking-change-summary-json` | JSON summary of the OpenAPI breaking-change check from bootstrap. |
 | `environment-uids-json` | JSON map of environment slug to Postman environment uid. |
 | `mock-url` | Mock server URL. |
+| `mock-visibility` | Authoritatively observed mock visibility: public or private. |
+| `mock-auth-required` | Whether the collection runner must supply postmanPrivateMockApiKey at runtime. |
 | `mock-environment-uid` | Dedicated manual-validation environment UID when mock-environment-enabled succeeds. |
 | `mock-environment-status` | Whether the optional manual-validation mock environment succeeded, was skipped, or failed. |
 | `monitor-id` | Smoke monitor ID. |

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -81,7 +81,7 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 The composite action currently depends on:
 
 - `postman-cs/postman-bootstrap-action@v2.10.19`
-- `postman-cs/postman-repo-sync-action@v2.2.0`
+- `postman-cs/postman-repo-sync-action@v2.3.0`
 - `postman-cs/postman-insights-onboarding-action@v2.2.1` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,12 @@ inputs:
   mock-url:
     description: Existing mock server URL. When set, the action validates and reuses this mock instead of creating a new one.
     required: false
+  mock-visibility:
+    description: Required mock access policy. Public is anonymous; private requires a runtime x-api-key supplied by the caller and is never persisted by repo-sync.
+    required: false
+    default: public
   mock-environment-enabled:
-    description: Create or update a dedicated manual-validation environment whose baseUrl is the validated public mock URL. This environment is excluded from runtime CI selection.
+    description: Create or update a dedicated manual-validation environment whose baseUrl is the validated mock URL. This environment is excluded from runtime CI selection and never contains a mock credential.
     required: false
     default: "false"
   monitor-cron:
@@ -267,6 +271,12 @@ outputs:
   mock-url:
     description: Mock server URL.
     value: ${{ steps.repo_sync.outputs.mock-url }}
+  mock-visibility:
+    description: 'Authoritatively observed mock visibility: public or private.'
+    value: ${{ steps.repo_sync.outputs.mock-visibility }}
+  mock-auth-required:
+    description: Whether the collection runner must supply postmanPrivateMockApiKey at runtime.
+    value: ${{ steps.repo_sync.outputs.mock-auth-required }}
   mock-environment-uid:
     description: Dedicated manual-validation environment UID when mock-environment-enabled succeeds.
     value: ${{ steps.repo_sync.outputs.mock-environment-uid }}
@@ -477,7 +487,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.2.0
+      uses: postman-cs/postman-repo-sync-action@v2.3.0
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
@@ -516,6 +526,7 @@ runs:
         postman-region: ${{ inputs.postman-region }}
         monitor-id: ${{ inputs.monitor-id }}
         mock-url: ${{ inputs.mock-url }}
+        mock-visibility: ${{ inputs.mock-visibility }}
         mock-environment-enabled: ${{ inputs.mock-environment-enabled }}
         monitor-cron: ${{ inputs.monitor-cron }}
         ssl-client-cert: ${{ inputs.ssl-client-cert }}

--- a/templates/azure-devops/windows-onboarding.yml
+++ b/templates/azure-devops/windows-onboarding.yml
@@ -37,6 +37,12 @@ parameters:
   - name: enableMockEnvironment
     type: boolean
     default: false
+  - name: mockVisibility
+    type: string
+    default: public
+    values:
+      - public
+      - private
   - name: insightsClusterName
     type: string
     default: ''
@@ -210,6 +216,7 @@ jobs:
             '--postman-region', $env:POSTMAN_REGION,
             '--postman-stack', $env:POSTMAN_STACK,
             '--mock-environment-enabled', $env:ENABLE_MOCK_ENVIRONMENT,
+            '--mock-visibility', $env:MOCK_VISIBILITY,
             '--result-json', $resultPath
           )
           if (-not [string]::IsNullOrWhiteSpace($env:SPEC_PATH)) {
@@ -229,6 +236,7 @@ jobs:
           ENV_RUNTIME_URLS_JSON: ${{ parameters.environmentRuntimeUrlsJson }}
           REPO_WRITE_MODE: ${{ parameters.repoWriteMode }}
           ENABLE_MOCK_ENVIRONMENT: ${{ parameters.enableMockEnvironment }}
+          MOCK_VISIBILITY: ${{ parameters.mockVisibility }}
           GENERATE_CI_WORKFLOW: ${{ parameters.generateCiWorkflow }}
           CI_WORKFLOW_PATH: ${{ parameters.ciWorkflowPath }}
           CANONICAL_BRANCH: ${{ parameters.canonicalBranch }}

--- a/tests/azure-devops-windows-template.test.ts
+++ b/tests/azure-devops-windows-template.test.ts
@@ -29,6 +29,7 @@ describe('Azure DevOps Windows onboarding template', () => {
     expect(renderedScripts).toContain('issecret=true');
     expect(renderedScripts).toContain("'--ci-runner-os', 'windows'");
     expect(renderedScripts).toContain("'--mock-environment-enabled', $env:ENABLE_MOCK_ENVIRONMENT");
+    expect(renderedScripts).toContain("'--mock-visibility', $env:MOCK_VISIBILITY");
     expect(renderedScripts).toContain('POSTMAN_MOCK_ENVIRONMENT_UID');
     expect(source).not.toMatch(/\bjq\b|\bsource\b|curl\s.*\|\s*sh|shell:\s*bash/);
 

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -189,6 +189,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         'release-label',
         'monitor-id',
         'mock-url',
+        'mock-visibility',
         'mock-environment-enabled',
         'monitor-cron',
         'generate-ci-workflow',
@@ -319,6 +320,8 @@ describe('postman-api-onboarding-action composite contract', () => {
         'breaking-change-summary-json',
         'environment-uids-json',
         'mock-url',
+        'mock-visibility',
+        'mock-auth-required',
         'mock-environment-uid',
         'mock-environment-status',
         'monitor-id',
@@ -358,7 +361,7 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(validateStep?.shell).toBe('bash');
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.2.0');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.3.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');
@@ -564,7 +567,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.2.0');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.3.0');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');


### PR DESCRIPTION
## Why

Repo-sync `v2.3.0` added a `mock-visibility` policy and, for private mocks, a host-conditional runtime credential hook on the smoke and contract collections. The composite still pinned `v2.2.0` and exposed no way to request that policy, so enterprises that prohibit public mock servers could not reach the new path through onboarding.

## What changed

- Pin bumped to `postman-cs/postman-repo-sync-action@v2.3.0`.
- `mock-visibility` input forwarded to repo-sync (default `public`).
- `mock-visibility` and `mock-auth-required` surfaced as composite outputs so callers can wire the `postmanPrivateMockApiKey` runner variable without inspecting Postman.
- Azure DevOps Windows template gains a `mockVisibility` parameter constrained to `public` | `private`, passed through as `MOCK_VISIBILITY` and on to the CLI.

## Validation

`npm test` — 168 passing, 11 files. `npm run typecheck` and `npx eslint .` clean. README tables regenerated from `action.yml`.

Coverage extended in `tests/contract.test.ts` (input/output sets, sibling pin) and `tests/azure-devops-windows-template.test.ts` (CLI argument wiring).

## Compatibility

Default behavior is unchanged. A run that does not set `mock-visibility` still requests a public mock.
