### PR TITLE
chore: pin repo-sync v2.4.0

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -81,7 +81,7 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 The composite action currently depends on:
 
 - `postman-cs/postman-bootstrap-action@v2.10.19`
-- `postman-cs/postman-repo-sync-action@v2.3.0`
+- `postman-cs/postman-repo-sync-action@v2.4.0`
 - `postman-cs/postman-insights-onboarding-action@v2.2.1` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -487,7 +487,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.3.0
+      uses: postman-cs/postman-repo-sync-action@v2.4.0
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -361,7 +361,7 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(validateStep?.shell).toBe('bash');
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.3.0');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.4.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');
@@ -567,7 +567,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.10.19');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.3.0');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.4.0');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.2.1');


### PR DESCRIPTION
## Why

Repo-sync `v2.4.0` closes the usability gap in private-mock support. The composite pinned `v2.3.0`, where the request hook existed but nothing ever supplied the `postmanPrivateMockApiKey` variable it reads.

## What v2.4.0 brings to onboarding

- Generated CI forwards the `POSTMAN_API_KEY` secret repo-sync already provisions, across GitHub, Azure DevOps bash, and Azure DevOps Windows. Verified live: the minted service-account key is accepted on the private mock serve path where an anonymous request gets `401`.
- The `<project> - Mock` environment carries `postmanPrivateMockApiKey` as an empty secret-typed variable for manual runs in the app.
- Hook installation emits a notice; a private-mock request with no key logs a warning naming the variable.
- Fixes an upgrade defect that appended the v2 hook beneath a stale v1 block, leaving both live in the collection.

An onboarding run with `mock-visibility: private` picks this up with no further wiring. Public-mock runs are unaffected.

## Validation

`npm test` — 168 passing across 11 files. `npx tsc --noEmit` and `npx eslint .` clean. The contract test pins the sibling version, so it moves with the pin.