### PR TITLE
fix(deps): advance the bootstrap pin to v2.13.2

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -80,9 +80,9 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.12.0`
-- `postman-cs/postman-repo-sync-action@v2.5.0`
-- `postman-cs/postman-smoke-flow-action@v3.0.1` when `flow-path` or `flow-mode` is set
+- `postman-cs/postman-bootstrap-action@v2.13.2`
+- `postman-cs/postman-repo-sync-action@v2.6.0`
+- `postman-cs/postman-smoke-flow-action@v3.1.0` when `flow-path` or `flow-mode` is set
 - `postman-cs/postman-insights-onboarding-action@v2.3.0` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -489,7 +489,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.12.0
+      uses: postman-cs/postman-bootstrap-action@v2.13.2
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -369,7 +369,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.12.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.2');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.6.0');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
@@ -608,7 +608,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.12.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.2');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
       ).toBe('postman-cs/postman-repo-sync-action@v2.6.0');


### PR DESCRIPTION
## What

Advances the composite's `postman-bootstrap-action` pin from `v2.12.0` to `v2.13.2`, and records the sibling set that `action.yml` actually carries.

## Why

Bootstrap `v2.13.2` fixes local OpenAPI collection generation for specs whose `pattern` constraints are legal per JSON Schema but illegal under the RegExp `u` flag that `@exodus/schemasafe` compiles with. Previously one such pattern failed the whole validator compile and aborted the run; now only the uncompilable `pattern` is dropped, and generation continues. PayPal's spec is the reproducer: 5 of 8 request bodies failed to compile before, 0 after.

This PR also ships the `postman-smoke-flow-action@v3.1.0` and `postman-repo-sync-action@v2.6.0` pins that landed in `3d5aabc`. That commit typed itself `chore(pins)`, and the release cut treats `chore` as non-shipping, so no tag was cut and `v3.0.1` still runs `smoke-flow@v3.0.1` / `repo-sync@v2.5.0`. A pin advance changes what consumers execute at runtime, so this ships as `fix(deps)` and cuts a release.

`RELEASE_POLICY.md` had drifted to the pre-`3d5aabc` sibling list; it now matches `action.yml`.

## Verification

- `npx vitest run` — 11 files, 169 tests pass
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx eslint .` — clean
- `node scripts/check-sibling-pins.mjs` — every pin is an existing immutable tag of its recorded major, and every forwarded `with:` key is a declared input on the pinned sibling

Upstream: bootstrap `v2.13.2` cut from `postman-cs/postman-bootstrap-action@e4120c4` with CI, SEA binary, and Release workflows green, and release assets published.
