### PR TITLE
fix(deps): advance bootstrap and repo-sync pins

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -80,8 +80,8 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.13.2`
-- `postman-cs/postman-repo-sync-action@v2.6.0`
+- `postman-cs/postman-bootstrap-action@v2.13.6`
+- `postman-cs/postman-repo-sync-action@v2.6.6`
 - `postman-cs/postman-smoke-flow-action@v3.1.0` when `flow-path` or `flow-mode` is set
 - `postman-cs/postman-insights-onboarding-action@v2.3.0` when Insights is enabled
 

--- a/action.yml
+++ b/action.yml
@@ -489,7 +489,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.13.2
+      uses: postman-cs/postman-bootstrap-action@v2.13.6
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
@@ -564,7 +564,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.6.0
+      uses: postman-cs/postman-repo-sync-action@v2.6.6
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -369,8 +369,8 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.2');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.6.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.6');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.6.6');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(smokeFlowStep?.uses).toBe('postman-cs/postman-smoke-flow-action@v3.1.0');
@@ -608,10 +608,10 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.2');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.6');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.6.0');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.6.6');
       expect(
         manifest.runs.steps.find((step) => step.id === 'smoke_flow')?.uses
       ).toBe('postman-cs/postman-smoke-flow-action@v3.1.0');


### PR DESCRIPTION
## Summary
- advance bootstrap to immutable `v2.13.6`
- advance repo-sync to immutable `v2.6.6`
- update the composite contract tests and release policy

Both sibling releases are published to npm and GitHub with green release workflows and rolling-major advancement.

## Validation
- `npm test` (169 tests)
- `npm run lint`
- `npm run typecheck`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`