### PR TITLE
fix(deps): advance repo-sync pin to v2.6.8

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -81,7 +81,7 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 The composite action currently depends on:
 
 - `postman-cs/postman-bootstrap-action@v2.13.6`
-- `postman-cs/postman-repo-sync-action@v2.6.7`
+- `postman-cs/postman-repo-sync-action@v2.6.8`
 - `postman-cs/postman-smoke-flow-action@v3.1.0` when `flow-path` or `flow-mode` is set
 - `postman-cs/postman-insights-onboarding-action@v2.3.0` when Insights is enabled
 

--- a/action.yml
+++ b/action.yml
@@ -564,7 +564,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.6.7
+      uses: postman-cs/postman-repo-sync-action@v2.6.8
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -370,7 +370,7 @@ describe('postman-api-onboarding-action composite contract', () => {
 
       expect(validateStep?.shell).toBe('bash');
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.6');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.6.7');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.6.8');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
       expect(smokeFlowStep?.uses).toBe('postman-cs/postman-smoke-flow-action@v3.1.0');
@@ -611,7 +611,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.6');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.6.7');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.6.8');
       expect(
         manifest.runs.steps.find((step) => step.id === 'smoke_flow')?.uses
       ).toBe('postman-cs/postman-smoke-flow-action@v3.1.0');


### PR DESCRIPTION
## Summary
- advance the composite repo-sync action pin from `v2.6.7` to immutable `v2.6.8`
- update both contract assertions and the release-policy pin inventory

`v2.6.8` preserves newer remote history while resolving conflicts within the action-owned generated artifact commit in favor of the current generated bytes.

## Validation
- `npm test` (169 tests)
- `npm run lint`
- `npm run typecheck`
- `actionlint`