### PR TITLE
fix(deps): advance bootstrap pin to v2.13.7

### DIFF
--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -80,7 +80,7 @@ immutable tag, or force-push. Until these prerequisites close, do not publish v3
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.13.6`
+- `postman-cs/postman-bootstrap-action@v2.13.7`
 - `postman-cs/postman-repo-sync-action@v2.6.8`
 - `postman-cs/postman-smoke-flow-action@v3.1.0` when `flow-path` or `flow-mode` is set
 - `postman-cs/postman-insights-onboarding-action@v2.3.0` when Insights is enabled

--- a/action.yml
+++ b/action.yml
@@ -489,7 +489,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.13.6
+      uses: postman-cs/postman-bootstrap-action@v2.13.7
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -369,7 +369,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.6');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.7');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.6.8');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
@@ -608,7 +608,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.6');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.13.7');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
       ).toBe('postman-cs/postman-repo-sync-action@v2.6.8');


### PR DESCRIPTION
## Summary
- advance the composite bootstrap action pin from `v2.13.6` to immutable `v2.13.7`
- retain repo-sync `v2.6.8`
- update both contract assertions and the release-policy pin inventory

`v2.13.7` continues bounded inventory polling only when a freshly imported canonical collection identity remains hidden, without adding latency to healthy imports.

## Validation
- `npm test` (169 tests)
- `npm run lint`
- `npm run typecheck`
- `actionlint`