### PR TITLE
fix(ci): validate sibling pins without local checkouts

### DIFF
--- a/scripts/check-sibling-pins.mjs
+++ b/scripts/check-sibling-pins.mjs
@@ -13,74 +13,497 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 // siblings remain on v2), so each expected major is committed beside its pin.
 // Release eligibility must depend only on committed content, not on a mutable
 // "latest tag" query that can change after the composite commit is reviewed.
-const requiredPins = [
+export const REQUIRED_PINS = [
   { repo: 'postman-bootstrap-action', stepId: 'bootstrap', major: 2 },
   { repo: 'postman-repo-sync-action', stepId: 'repo_sync', major: 2 },
   { repo: 'postman-smoke-flow-action', stepId: 'smoke_flow', major: 3 },
   { repo: 'postman-insights-onboarding-action', stepId: 'insights_onboarding', major: 2 }
 ];
 
-function semverForMajor(tag, major) {
+/** Source files asserted against the exact immutable tags in action.yml. */
+export const SOURCE_CONTRACTS = {
+  'postman-bootstrap-action': ['src/index.ts'],
+  'postman-repo-sync-action': ['src/index.ts', 'src/lib/repo/branch-decision.ts']
+};
+
+export const COLLECTIONS_JSON_KEYS = ['baseline', 'contract', 'smoke'];
+export const BRANCH_DECISION_REQUIRED = ['tier', 'strategy', 'identity', 'reason'];
+export const BRANCH_DECISION_OPTIONAL = ['canonicalBranch', 'channel'];
+export const REPO_SYNC_SUMMARY_KEYS = [
+  'commitSha',
+  'environmentCount',
+  'environmentSyncStatus',
+  'mockEnvironmentStatus',
+  'mockEnvironmentUid',
+  'mockAuthRequired',
+  'mockUrl',
+  'mockVisibility',
+  'monitorId',
+  'pushed',
+  'resolvedCurrentRef',
+  'workspaceLinkStatus'
+];
+export const REPO_SYNC_SUMMARY_GATED_KEYS = ['status', 'reason'];
+
+/** Upper bound for git ls-remote and raw.githubusercontent.com fetches in main(). */
+export const SIBLING_PIN_NETWORK_TIMEOUT_MS = 30_000;
+
+/**
+ * @param {string} repo
+ * @param {string} tag
+ * @param {string} filePath
+ * @returns {string}
+ */
+export function pinnedRawFileUrl(repo, tag, filePath) {
+  return `https://raw.githubusercontent.com/postman-cs/${repo}/${tag}/${filePath}`;
+}
+
+/**
+ * @param {number} [timeoutMs]
+ * @returns {{ encoding: 'utf8', timeout: number }}
+ */
+export function gitTagExistsExecOptions(timeoutMs = SIBLING_PIN_NETWORK_TIMEOUT_MS) {
+  return { encoding: 'utf8', timeout: timeoutMs };
+}
+
+/**
+ * @param {number} [timeoutMs]
+ * @returns {{ signal: AbortSignal }}
+ */
+export function pinnedFileFetchInit(timeoutMs = SIBLING_PIN_NETWORK_TIMEOUT_MS) {
+  return { signal: globalThis.AbortSignal.timeout(timeoutMs) };
+}
+
+/**
+ * @param {string} tag
+ * @param {number} major
+ * @returns {number[] | undefined}
+ */
+export function semverForMajor(tag, major) {
   const match = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
   if (!match) return undefined;
   const parts = match.slice(1).map(Number);
   return parts[0] === major ? parts : undefined;
 }
 
+/**
+ * @param {string} site
+ * @param {string} text
+ * @param {Array<{ step: string, output: string, site: string }>} edges
+ * @param {Set<string>} seen
+ */
+function recordEdges(site, text, edges, seen) {
+  for (const match of String(text ?? '').matchAll(/steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)) {
+    const key = `${match[1]}.${match[2]}@${site}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ step: match[1], output: match[2], site });
+  }
+}
+
+/**
+ * Every steps.<id>.outputs.<name> reference in the composite with its consuming site.
+ * @param {{ outputs?: Record<string, { value?: string }>, runs?: { steps?: Array<{ id?: string, if?: string, with?: Record<string, string>, env?: Record<string, string>, run?: string }> } }} manifest
+ * @returns {Array<{ step: string, output: string, site: string }>}
+ */
+export function collectStepOutputEdges(manifest) {
+  /** @type {Array<{ step: string, output: string, site: string }>} */
+  const edges = [];
+  const seen = new Set();
+  for (const [name, output] of Object.entries(manifest.outputs ?? {})) {
+    recordEdges(`outputs.${name}`, output?.value ?? '', edges, seen);
+  }
+  for (const step of manifest.runs?.steps ?? []) {
+    const site = `step ${step.id ?? '(anonymous)'}`;
+    recordEdges(`${site} if`, step.if ?? '', edges, seen);
+    for (const [key, value] of Object.entries(step.with ?? {})) {
+      recordEdges(`${site} with.${key}`, value, edges, seen);
+    }
+    for (const [key, value] of Object.entries(step.env ?? {})) {
+      recordEdges(`${site} env.${key}`, value, edges, seen);
+    }
+    recordEdges(`${site} run`, step.run ?? '', edges, seen);
+  }
+  return edges;
+}
+
+/**
+ * @param {{ repo: string, tag: string, file?: string }} diag
+ * @returns {string}
+ */
+function diagLabel({ repo, tag, file }) {
+  const base = `${repo}@${tag}`;
+  return file ? `${base} ${file}` : base;
+}
+
+/**
+ * @param {object} args
+ * @param {string} args.stepId
+ * @param {string} args.repo
+ * @param {string} args.tag
+ * @param {Iterable<string>} args.withKeys
+ * @param {Iterable<string>} args.declaredInputs
+ * @returns {string[]}
+ */
+export function validateForwardedWithKeys({ stepId, repo, tag, withKeys, declaredInputs }) {
+  const declared = new Set(declaredInputs);
+  /** @type {string[]} */
+  const failures = [];
+  for (const key of withKeys) {
+    if (!declared.has(key)) {
+      failures.push(
+        `${stepId}: forwards with-key \`${key}\` but ${diagLabel({ repo, tag })} declares no such input`
+      );
+    }
+  }
+  return failures;
+}
+
+/**
+ * @param {object} args
+ * @param {Array<{ step: string, output: string, site: string }>} args.edges
+ * @param {string} args.stepId
+ * @param {string} args.repo
+ * @param {string} args.tag
+ * @param {Iterable<string>} args.declaredOutputs
+ * @returns {string[]}
+ */
+export function validateReferencedOutputs({ edges, stepId, repo, tag, declaredOutputs }) {
+  const declared = new Set(declaredOutputs);
+  /** @type {string[]} */
+  const failures = [];
+  for (const edge of edges) {
+    if (edge.step !== stepId) continue;
+    if (!declared.has(edge.output)) {
+      failures.push(
+        `${edge.site} references ${edge.step}.outputs.${edge.output}, not declared by ${diagLabel({
+          repo,
+          tag,
+          file: 'action.yml'
+        })}`
+      );
+    }
+  }
+  return failures;
+}
+
+/**
+ * @param {string} source
+ * @param {{ repo: string, tag: string, file?: string }} diag
+ * @returns {string[]}
+ */
+export function validateCollectionsJsonShape(source, diag) {
+  const label = diagLabel({ file: 'src/index.ts', ...diag });
+  const sites = [...source.matchAll(/'collections-json'\]?\s*[:=]\s*JSON\.stringify\(\{([^}]*)\}/g)];
+  if (sites.length < 3) {
+    return [`${label}: expected >=3 collections-json serialization sites, found ${sites.length}`];
+  }
+  /** @type {string[]} */
+  const failures = [];
+  const expected = [...COLLECTIONS_JSON_KEYS].sort().join(',');
+  for (const [index, site] of sites.entries()) {
+    const keys = [...site[1].matchAll(/([A-Za-z0-9_]+)\s*:/g)].map((match) => match[1]).sort();
+    if (keys.join(',') !== expected) {
+      failures.push(
+        `${label}: collections-json site ${index + 1} emits {${keys.join(', ')}} instead of {${expected.replace(/,/g, ', ')}}`
+      );
+    }
+  }
+  return failures;
+}
+
+/**
+ * @param {string} source
+ * @param {{ repo: string, tag: string, file?: string }} diag
+ * @returns {string[]}
+ */
+export function validateBranchDecisionInterface(source, diag) {
+  const label = diagLabel({ file: 'src/lib/repo/branch-decision.ts', ...diag });
+  const block = source.match(/export interface BranchDecision \{([\s\S]*?)\n\}/);
+  if (!block) {
+    return [`${label}: BranchDecision interface not found`];
+  }
+  const declared = [...block[1].matchAll(/^\s*([A-Za-z0-9_]+)\??:/gm)].map((match) => match[1]).sort();
+  const expected = [...BRANCH_DECISION_REQUIRED, ...BRANCH_DECISION_OPTIONAL].sort();
+  if (declared.join(',') !== expected.join(',')) {
+    return [
+      `${label}: BranchDecision declares {${declared.join(', ')}} instead of {${expected.join(', ')}}`
+    ];
+  }
+  return [];
+}
+
+/**
+ * @param {string} source
+ * @param {{ repo: string, tag: string, file?: string }} diag
+ * @returns {string[]}
+ */
+export function validateEnvironmentUidsEmit(source, diag) {
+  const label = diagLabel({ file: 'src/index.ts', ...diag });
+  /** @type {string[]} */
+  const failures = [];
+  if (!source.includes("setOutput('environment-uids-json', JSON.stringify(envUids))")) {
+    failures.push(`${label}: missing environment-uids-json setOutput(JSON.stringify(envUids)) emit`);
+  }
+  if (!source.includes("parseJsonMap(getInput('environment-uids-json', env) || '{}')")) {
+    failures.push(`${label}: missing environment-uids-json parseJsonMap consumer`);
+  }
+  return failures;
+}
+
+/**
+ * @param {string} source
+ * @param {{ repo: string, tag: string, file?: string }} diag
+ * @returns {string[]}
+ */
+export function validateRepoSyncSummaryKeys(source, diag) {
+  const label = diagLabel({ file: 'src/index.ts', ...diag });
+  const summary = source.match(/function createRepoSummary\([\s\S]*?JSON\.stringify\(\{([\s\S]*?)\}\);/);
+  if (!summary) {
+    return [`${label}: createRepoSummary JSON.stringify shape not found`];
+  }
+  const keys = [...summary[1].matchAll(/^\s*([A-Za-z0-9_]+)\s*(?:[,:]|$)/gm)].map((match) => match[1]).sort();
+  const expected = [...REPO_SYNC_SUMMARY_KEYS].sort();
+  if (keys.join(',') !== expected.join(',')) {
+    return [
+      `${label}: createRepoSummary emits {${keys.join(', ')}} instead of {${expected.join(', ')}}`
+    ];
+  }
+  return [];
+}
+
+/**
+ * @param {string} source
+ * @param {{ repo: string, tag: string, file?: string }} diag
+ * @returns {string[]}
+ */
+export function validateGatedSkipSummaryKeys(source, diag) {
+  const label = diagLabel({ file: 'src/index.ts', ...diag });
+  const gated = source.match(/outputs\['repo-sync-summary-json'\] = JSON\.stringify\(\{([\s\S]*?)\}\);/);
+  if (!gated) {
+    return [`${label}: gated-skip repo-sync-summary-json shape not found`];
+  }
+  /** @type {string[]} */
+  const failures = [];
+  if (!gated[1].includes("status: 'skipped-branch-gate'")) {
+    failures.push(`${label}: gated-skip summary missing status: 'skipped-branch-gate'`);
+  }
+  if (!gated[1].includes('reason: decision.reason')) {
+    failures.push(`${label}: gated-skip summary missing reason: decision.reason`);
+  }
+  const keys = [...gated[1].matchAll(/([A-Za-z0-9_]+)\s*:/g)].map((match) => match[1]).sort();
+  const expected = [...REPO_SYNC_SUMMARY_GATED_KEYS].sort();
+  if (keys.join(',') !== expected.join(',')) {
+    failures.push(
+      `${label}: gated-skip summary emits {${keys.join(', ')}} instead of {${expected.join(', ')}}`
+    );
+  }
+  return failures;
+}
+
+/**
+ * Validate golden source shapes for Bootstrap and Repo Sync pinned tags.
+ * @param {object} args
+ * @param {string} args.repo
+ * @param {string} args.tag
+ * @param {Record<string, string>} args.sources
+ * @returns {string[]}
+ */
+export function validatePinnedSourceShapes({ repo, tag, sources }) {
+  const diag = { repo, tag };
+  if (repo === 'postman-bootstrap-action') {
+    const source = sources['src/index.ts'];
+    if (typeof source !== 'string') {
+      return [`${diagLabel({ ...diag, file: 'src/index.ts' })}: source content was not supplied`];
+    }
+    return validateCollectionsJsonShape(source, diag);
+  }
+  if (repo === 'postman-repo-sync-action') {
+    /** @type {string[]} */
+    const failures = [];
+    const index = sources['src/index.ts'];
+    const branchDecision = sources['src/lib/repo/branch-decision.ts'];
+    if (typeof index !== 'string') {
+      failures.push(`${diagLabel({ ...diag, file: 'src/index.ts' })}: source content was not supplied`);
+    } else {
+      failures.push(
+        ...validateEnvironmentUidsEmit(index, diag),
+        ...validateRepoSyncSummaryKeys(index, diag),
+        ...validateGatedSkipSummaryKeys(index, diag)
+      );
+    }
+    if (typeof branchDecision !== 'string') {
+      failures.push(
+        `${diagLabel({ ...diag, file: 'src/lib/repo/branch-decision.ts' })}: source content was not supplied`
+      );
+    } else {
+      failures.push(...validateBranchDecisionInterface(branchDecision, diag));
+    }
+    return failures;
+  }
+  return [];
+}
+
+/**
+ * Pure contract validation over already-fetched sibling content.
+ *
+ * @param {object} args
+ * @param {string} args.compositeYmlText
+ * @param {Record<string, {
+ *   tag?: string,
+ *   actionYmlText?: string,
+ *   sources?: Record<string, string>,
+ *   tagExists?: boolean,
+ *   fetchError?: string
+ * }>} args.siblings keyed by repo name
+ * @returns {string[]}
+ */
+export function validateSiblingPinContracts({ compositeYmlText, siblings }) {
+  const manifest = parse(compositeYmlText);
+  const edges = collectStepOutputEdges(manifest);
+  /** @type {string[]} */
+  const failures = [];
+
+  for (const { repo, stepId, major } of REQUIRED_PINS) {
+    const step = (manifest.runs?.steps ?? []).find((candidate) => candidate.id === stepId);
+    const actual = step?.uses;
+    const prefix = `postman-cs/${repo}@`;
+    const tag =
+      typeof actual === 'string' && actual.startsWith(prefix) ? actual.slice(prefix.length) : '';
+    if (!semverForMajor(tag, major)) {
+      failures.push(`${stepId}: expected an immutable v${major} tag, found ${actual || '<missing>'}`);
+      continue;
+    }
+
+    const sibling = siblings[repo] ?? {};
+    if (sibling.tagExists === false) {
+      failures.push(`${stepId}: pinned tag ${tag} does not exist in postman-cs/${repo}`);
+      continue;
+    }
+    if (typeof sibling.fetchError === 'string' && sibling.fetchError.length > 0) {
+      failures.push(sibling.fetchError);
+      continue;
+    }
+    if (typeof sibling.actionYmlText !== 'string') {
+      failures.push(`${diagLabel({ repo, tag, file: 'action.yml' })}: action.yml content was not supplied`);
+      continue;
+    }
+
+    const siblingManifest = parse(sibling.actionYmlText);
+    failures.push(
+      ...validateForwardedWithKeys({
+        stepId,
+        repo,
+        tag,
+        withKeys: Object.keys(step?.with ?? {}),
+        declaredInputs: Object.keys(siblingManifest.inputs ?? {})
+      }),
+      ...validateReferencedOutputs({
+        edges,
+        stepId,
+        repo,
+        tag,
+        declaredOutputs: Object.keys(siblingManifest.outputs ?? {})
+      }),
+      ...validatePinnedSourceShapes({
+        repo,
+        tag,
+        sources: sibling.sources ?? {}
+      })
+    );
+  }
+
+  return failures;
+}
+
+/**
+ * @param {string} repo
+ * @param {string} tag
+ * @returns {boolean}
+ */
 function tagExists(repo, tag) {
-  const remote = 'https://github.com/postman-cs/' + repo + '.git';
-  const output = execFileSync('git', ['ls-remote', '--tags', remote, 'refs/tags/' + tag], {
-    encoding: 'utf8'
-  });
+  const remote = `https://github.com/postman-cs/${repo}.git`;
+  const output = execFileSync(
+    'git',
+    ['ls-remote', '--tags', remote, `refs/tags/${tag}`],
+    gitTagExistsExecOptions()
+  );
   return output.trim().length > 0;
 }
 
-const manifest = parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8'));
-const failures = [];
-
-// P3 composite wiring lint (.plans/e2e-suite-tuneup.md): beyond pin freshness,
-// assert every `with:` key the composite forwards exists as a declared input on
-// the pinned sibling's manifest, so an input rename in a sibling cannot ship a
-// silently-dropped forward.
-async function fetchSiblingInputs(repo, tag) {
-  const url = 'https://raw.githubusercontent.com/postman-cs/' + repo + '/' + tag + '/action.yml';
-  const response = await fetch(url);
+/**
+ * @param {string} repo
+ * @param {string} tag
+ * @param {string} filePath
+ * @returns {Promise<string>}
+ */
+async function fetchPinnedFile(repo, tag, filePath) {
+  const url = pinnedRawFileUrl(repo, tag, filePath);
+  const response = await fetch(url, pinnedFileFetchInit());
   if (!response.ok) {
-    throw new Error('Failed to fetch ' + url + ': HTTP ' + response.status);
+    throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
   }
-  const sibling = parse(await response.text());
-  return new Set(Object.keys(sibling.inputs ?? {}));
+  return response.text();
 }
 
-for (const { repo, stepId, major } of requiredPins) {
-  const step = manifest.runs.steps.find((candidate) => candidate.id === stepId);
-  const actual = step?.uses;
-  const prefix = 'postman-cs/' + repo + '@';
-  const tag = typeof actual === 'string' && actual.startsWith(prefix)
-    ? actual.slice(prefix.length)
-    : '';
-  if (!semverForMajor(tag, major)) {
-    failures.push(stepId + ': expected an immutable v' + major + ' tag, found ' + (actual || '<missing>'));
-    continue;
-  }
-  if (!tagExists(repo, tag)) {
-    failures.push(stepId + ': pinned tag ' + tag + ' does not exist in postman-cs/' + repo);
-    continue;
-  }
-  const siblingInputs = await fetchSiblingInputs(repo, tag);
-  for (const key of Object.keys(step?.with ?? {})) {
-    if (!siblingInputs.has(key)) {
-      failures.push(stepId + ': forwards with-key `' + key + '` but ' + repo + '@' + tag + ' declares no such input');
+async function main() {
+  const compositeYmlText = readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
+  const manifest = parse(compositeYmlText);
+  /** @type {Record<string, {
+   *   tag: string,
+   *   actionYmlText?: string,
+   *   sources?: Record<string, string>,
+   *   tagExists?: boolean,
+   *   fetchError?: string
+   * }>} */
+  const siblings = {};
+
+  for (const { repo, stepId, major } of REQUIRED_PINS) {
+    const step = (manifest.runs?.steps ?? []).find((candidate) => candidate.id === stepId);
+    const actual = step?.uses;
+    const prefix = `postman-cs/${repo}@`;
+    const tag =
+      typeof actual === 'string' && actual.startsWith(prefix) ? actual.slice(prefix.length) : '';
+    // Leave malformed pins absent so validateSiblingPinContracts owns the diagnostic.
+    if (!semverForMajor(tag, major)) continue;
+
+    if (!tagExists(repo, tag)) {
+      siblings[repo] = { tag, tagExists: false };
+      continue;
+    }
+
+    try {
+      const actionYmlText = await fetchPinnedFile(repo, tag, 'action.yml');
+      /** @type {Record<string, string>} */
+      const sources = {};
+      for (const filePath of SOURCE_CONTRACTS[repo] ?? []) {
+        sources[filePath] = await fetchPinnedFile(repo, tag, filePath);
+      }
+      siblings[repo] = { tag, actionYmlText, sources, tagExists: true };
+    } catch (error) {
+      siblings[repo] = {
+        tag,
+        tagExists: true,
+        fetchError: error instanceof Error ? error.message : String(error)
+      };
     }
   }
-}
 
-if (failures.length > 0) {
-  console.error('Composite sibling pins are invalid:');
-  for (const failure of failures) {
-    console.error('- ' + failure);
+  const failures = validateSiblingPinContracts({ compositeYmlText, siblings });
+
+  if (failures.length > 0) {
+    console.error('Composite sibling pins are invalid:');
+    for (const failure of failures) {
+      console.error('- ' + failure);
+    }
+    process.exit(1);
   }
-  process.exit(1);
+
+  console.log(
+    'Composite sibling pins are existing immutable tags of their recorded majors; every forwarded with-key and referenced producer output is declared; Bootstrap and Repo Sync golden payload shapes match the pinned sources.'
+  );
 }
 
-console.log('Composite sibling pins are existing immutable tags of their recorded majors and every forwarded with-key is a declared sibling input.');
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tests/check-sibling-pins.test.ts
+++ b/tests/check-sibling-pins.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Pure sibling-pin contract tests.
+ *
+ * These fixtures prove the validators accept valid pinned manifests/source
+ * shapes and reject undeclared producer outputs and golden-shape drift — all
+ * from supplied content, never from local sibling checkouts or live network.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  COLLECTIONS_JSON_KEYS,
+  REPO_SYNC_SUMMARY_GATED_KEYS,
+  REPO_SYNC_SUMMARY_KEYS,
+  SIBLING_PIN_NETWORK_TIMEOUT_MS,
+  gitTagExistsExecOptions,
+  pinnedFileFetchInit,
+  pinnedRawFileUrl,
+  validateBranchDecisionInterface,
+  validateCollectionsJsonShape,
+  validateEnvironmentUidsEmit,
+  validateForwardedWithKeys,
+  validateGatedSkipSummaryKeys,
+  validatePinnedSourceShapes,
+  validateReferencedOutputs,
+  validateRepoSyncSummaryKeys,
+  validateSiblingPinContracts
+} from '../scripts/check-sibling-pins.mjs';
+
+const VALID_BOOTSTRAP_INDEX = `
+outputs['collections-json'] = JSON.stringify({ baseline: a, contract: b, smoke: c });
+result['collections-json'] = JSON.stringify({ baseline: a, contract: b, smoke: c });
+payload['collections-json'] = JSON.stringify({ baseline: a, contract: b, smoke: c });
+`;
+
+const VALID_BRANCH_DECISION = `
+export interface BranchDecision {
+  tier: string;
+  strategy: string;
+  identity: string;
+  canonicalBranch?: string;
+  channel?: string;
+  reason: string;
+}
+`;
+
+const VALID_REPO_SYNC_INDEX = `
+setOutput('environment-uids-json', JSON.stringify(envUids));
+parseJsonMap(getInput('environment-uids-json', env) || '{}');
+
+function createRepoSummary(input) {
+  return JSON.stringify({
+    commitSha,
+    environmentCount,
+    environmentSyncStatus,
+    mockEnvironmentStatus,
+    mockEnvironmentUid,
+    mockAuthRequired,
+    mockUrl,
+    mockVisibility,
+    monitorId,
+    pushed,
+    resolvedCurrentRef,
+    workspaceLinkStatus,
+  });
+}
+
+outputs['repo-sync-summary-json'] = JSON.stringify({
+  status: 'skipped-branch-gate',
+  reason: decision.reason
+});
+`;
+
+function siblingBundle(overrides: {
+  bootstrapAction?: string;
+  bootstrapIndex?: string;
+  repoSyncAction?: string;
+  repoSyncIndex?: string;
+  branchDecision?: string;
+  smokeAction?: string;
+  insightsAction?: string;
+} = {}) {
+  return {
+    'postman-bootstrap-action': {
+      tag: 'v2.15.0',
+      tagExists: true,
+      actionYmlText:
+        overrides.bootstrapAction ??
+        `
+inputs:
+  api-key: {}
+outputs:
+  workspace-id:
+    description: workspace
+  collections-json:
+    description: collections
+`,
+      sources: {
+        'src/index.ts': overrides.bootstrapIndex ?? VALID_BOOTSTRAP_INDEX
+      }
+    },
+    'postman-repo-sync-action': {
+      tag: 'v2.7.1',
+      tagExists: true,
+      actionYmlText:
+        overrides.repoSyncAction ??
+        `
+inputs:
+  environment-uids-json: {}
+  branch-decision: {}
+outputs:
+  repo-sync-summary-json:
+    description: summary
+  environment-uids-json:
+    description: env map
+`,
+      sources: {
+        'src/index.ts': overrides.repoSyncIndex ?? VALID_REPO_SYNC_INDEX,
+        'src/lib/repo/branch-decision.ts': overrides.branchDecision ?? VALID_BRANCH_DECISION
+      }
+    },
+    'postman-smoke-flow-action': {
+      tag: 'v3.2.1',
+      tagExists: true,
+      actionYmlText:
+        overrides.smokeAction ??
+        `
+inputs:
+  workspace-id: {}
+outputs:
+  smoke-status:
+    description: status
+`
+    },
+    'postman-insights-onboarding-action': {
+      tag: 'v2.4.1',
+      tagExists: true,
+      actionYmlText:
+        overrides.insightsAction ??
+        `
+inputs:
+  workspace-id: {}
+outputs:
+  insights-status:
+    description: status
+`
+    }
+  };
+}
+
+const COMPOSITE_YML = `
+name: composite
+inputs: {}
+outputs:
+  summary:
+    value: \${{ steps.repo_sync.outputs.repo-sync-summary-json }}
+  collections:
+    value: \${{ steps.bootstrap.outputs.collections-json }}
+runs:
+  using: composite
+  steps:
+    - id: bootstrap
+      uses: postman-cs/postman-bootstrap-action@v2.15.0
+      with:
+        api-key: x
+    - id: smoke_flow
+      uses: postman-cs/postman-smoke-flow-action@v3.2.1
+      with:
+        workspace-id: \${{ steps.bootstrap.outputs.workspace-id }}
+    - id: repo_sync
+      uses: postman-cs/postman-repo-sync-action@v2.7.1
+      with:
+        environment-uids-json: '{}'
+        branch-decision: '{}'
+    - id: insights_onboarding
+      uses: postman-cs/postman-insights-onboarding-action@v2.4.1
+      with:
+        workspace-id: \${{ steps.bootstrap.outputs.workspace-id }}
+`;
+
+describe('network timeout bounds', () => {
+  it('exports a positive finite default timeout for git and fetch operations', () => {
+    expect(SIBLING_PIN_NETWORK_TIMEOUT_MS).toBe(30_000);
+    expect(Number.isFinite(SIBLING_PIN_NETWORK_TIMEOUT_MS)).toBe(true);
+    expect(SIBLING_PIN_NETWORK_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it('builds bounded git ls-remote exec options without live network calls', () => {
+    expect(gitTagExistsExecOptions()).toEqual({
+      encoding: 'utf8',
+      timeout: SIBLING_PIN_NETWORK_TIMEOUT_MS
+    });
+    expect(gitTagExistsExecOptions(5_000)).toEqual({ encoding: 'utf8', timeout: 5_000 });
+  });
+
+  it('builds bounded fetch init with AbortSignal.timeout and preserves pinned-tag URLs', () => {
+    const init = pinnedFileFetchInit();
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.signal.aborted).toBe(false);
+
+    const customInit = pinnedFileFetchInit(1_500);
+    expect(customInit.signal).toBeInstanceOf(AbortSignal);
+
+    expect(
+      pinnedRawFileUrl('postman-bootstrap-action', 'v2.15.0', 'action.yml')
+    ).toBe('https://raw.githubusercontent.com/postman-cs/postman-bootstrap-action/v2.15.0/action.yml');
+  });
+});
+
+describe('forwarded with-keys', () => {
+  it('accepts declared inputs and rejects unknown forwards', () => {
+    expect(
+      validateForwardedWithKeys({
+        stepId: 'bootstrap',
+        repo: 'postman-bootstrap-action',
+        tag: 'v2.15.0',
+        withKeys: ['api-key'],
+        declaredInputs: ['api-key']
+      })
+    ).toEqual([]);
+
+    const failures = validateForwardedWithKeys({
+      stepId: 'bootstrap',
+      repo: 'postman-bootstrap-action',
+      tag: 'v2.15.0',
+      withKeys: ['missing-key'],
+      declaredInputs: ['api-key']
+    });
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain('postman-bootstrap-action@v2.15.0');
+    expect(failures[0]).toContain('`missing-key`');
+  });
+});
+
+describe('referenced producer outputs', () => {
+  it('accepts declared outputs and rejects undeclared references with repo@tag diagnostics', () => {
+    const edges = [
+      { step: 'bootstrap', output: 'collections-json', site: 'outputs.collections' },
+      { step: 'bootstrap', output: 'ghost', site: 'step smoke_flow with.x' }
+    ];
+    expect(
+      validateReferencedOutputs({
+        edges,
+        stepId: 'bootstrap',
+        repo: 'postman-bootstrap-action',
+        tag: 'v2.15.0',
+        declaredOutputs: ['collections-json', 'workspace-id']
+      })
+    ).toEqual([
+      'step smoke_flow with.x references bootstrap.outputs.ghost, not declared by postman-bootstrap-action@v2.15.0 action.yml'
+    ]);
+  });
+});
+
+describe('golden source shapes', () => {
+  it('accepts the pinned collections-json key set', () => {
+    expect(validateCollectionsJsonShape(VALID_BOOTSTRAP_INDEX, {
+      repo: 'postman-bootstrap-action',
+      tag: 'v2.15.0'
+    })).toEqual([]);
+    expect([...COLLECTIONS_JSON_KEYS].sort()).toEqual(['baseline', 'contract', 'smoke']);
+  });
+
+  it('rejects collections-json shape drift with repo@tag file diagnostics', () => {
+    const bad = `outputs['collections-json'] = JSON.stringify({ baseline: a, contract: b });
+core.setOutput('collections-json', JSON.stringify({ baseline, contract }));
+fs.writeFileSync(out, "collections-json=" + JSON.stringify({ baseline: x, contract: y }));`;
+    const failures = validateCollectionsJsonShape(bad, {
+      repo: 'postman-bootstrap-action',
+      tag: 'v2.16.1'
+    });
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures[0]).toContain('postman-bootstrap-action@v2.16.1 src/index.ts');
+  });
+
+  it('accepts BranchDecision keys and rejects extras', () => {
+    expect(
+      validateBranchDecisionInterface(VALID_BRANCH_DECISION, {
+        repo: 'postman-repo-sync-action',
+        tag: 'v2.7.1'
+      })
+    ).toEqual([]);
+
+    const failures = validateBranchDecisionInterface(
+      `export interface BranchDecision {
+  tier: string;
+  strategy: string;
+  identity: string;
+  reason: string;
+  unexpected: string;
+}`,
+      { repo: 'postman-repo-sync-action', tag: 'v2.8.7' }
+    );
+    expect(failures[0]).toContain('postman-repo-sync-action@v2.8.7 src/lib/repo/branch-decision.ts');
+    expect(failures[0]).toContain('unexpected');
+  });
+
+  it('accepts and rejects repo-sync summary shapes', () => {
+    expect(
+      validateRepoSyncSummaryKeys(VALID_REPO_SYNC_INDEX, {
+        repo: 'postman-repo-sync-action',
+        tag: 'v2.7.1'
+      })
+    ).toEqual([]);
+    expect(REPO_SYNC_SUMMARY_KEYS).toHaveLength(12);
+
+    const failures = validateRepoSyncSummaryKeys(
+      `function createRepoSummary(input) {
+  return JSON.stringify({
+    commitSha,
+    pushed
+  });
+}`,
+      { repo: 'postman-repo-sync-action', tag: 'v2.8.7' }
+    );
+    expect(failures[0]).toContain('postman-repo-sync-action@v2.8.7 src/index.ts');
+    expect(failures[0]).toContain('createRepoSummary');
+  });
+
+  it('detects repo-sync summary drift when the final key has no trailing comma', () => {
+    const goldenBody = REPO_SYNC_SUMMARY_KEYS.map((key, index) => {
+      const isLast = index === REPO_SYNC_SUMMARY_KEYS.length - 1;
+      return `    ${key}${isLast ? '' : ','}`;
+    }).join('\n');
+    const goldenSource = `function createRepoSummary(i) {
+  return JSON.stringify({
+${goldenBody}
+  });
+}`;
+    expect(
+      validateRepoSyncSummaryKeys(goldenSource, {
+        repo: 'postman-repo-sync-action',
+        tag: 'v2.7.1'
+      })
+    ).toEqual([]);
+
+    const driftSource = `function createRepoSummary(i) {
+  return JSON.stringify({
+${goldenBody},
+    leakedSecretToken
+  });
+}`;
+    const failures = validateRepoSyncSummaryKeys(driftSource, {
+      repo: 'postman-repo-sync-action',
+      tag: 'v2.8.7'
+    });
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures[0]).toContain('postman-repo-sync-action@v2.8.7 src/index.ts');
+    expect(failures[0]).toContain('leakedSecretToken');
+  });
+
+  it('accepts and rejects gated-skip summary shapes', () => {
+    expect(
+      validateGatedSkipSummaryKeys(VALID_REPO_SYNC_INDEX, {
+        repo: 'postman-repo-sync-action',
+        tag: 'v2.7.1'
+      })
+    ).toEqual([]);
+    expect([...REPO_SYNC_SUMMARY_GATED_KEYS].sort()).toEqual(['reason', 'status']);
+
+    const failures = validateGatedSkipSummaryKeys(
+      `outputs['repo-sync-summary-json'] = JSON.stringify({
+  status: 'skipped-branch-gate',
+  reason: decision.reason,
+  extra: true
+});`,
+      { repo: 'postman-repo-sync-action', tag: 'v2.8.7' }
+    );
+    expect(failures[0]).toContain('postman-repo-sync-action@v2.8.7 src/index.ts');
+    expect(failures[0]).toContain('extra');
+  });
+
+  it('accepts and rejects environment-uids-json producer and consumer signatures', () => {
+    expect(
+      validateEnvironmentUidsEmit(VALID_REPO_SYNC_INDEX, {
+        repo: 'postman-repo-sync-action',
+        tag: 'v2.7.1'
+      })
+    ).toEqual([]);
+
+    const missingEmit = validateEnvironmentUidsEmit(
+      `parseJsonMap(getInput('environment-uids-json', env) || '{}');`,
+      { repo: 'postman-repo-sync-action', tag: 'v2.8.7' }
+    );
+    expect(missingEmit[0]).toContain('postman-repo-sync-action@v2.8.7 src/index.ts');
+    expect(missingEmit[0]).toContain(
+      'missing environment-uids-json setOutput(JSON.stringify(envUids)) emit'
+    );
+
+    const missingConsumer = validateEnvironmentUidsEmit(
+      `setOutput('environment-uids-json', JSON.stringify(envUids));`,
+      { repo: 'postman-repo-sync-action', tag: 'v2.8.7' }
+    );
+    expect(missingConsumer[0]).toContain('postman-repo-sync-action@v2.8.7 src/index.ts');
+    expect(missingConsumer[0]).toContain('missing environment-uids-json parseJsonMap consumer');
+  });
+});
+
+describe('validateSiblingPinContracts', () => {
+  it('accepts a fully valid pinned sibling bundle', () => {
+    expect(
+      validateSiblingPinContracts({
+        compositeYmlText: COMPOSITE_YML,
+        siblings: siblingBundle()
+      })
+    ).toEqual([]);
+  });
+
+  it('rejects undeclared producer outputs without reading sibling directories', () => {
+    const failures = validateSiblingPinContracts({
+      compositeYmlText: COMPOSITE_YML,
+      siblings: siblingBundle({
+        bootstrapAction: `
+inputs:
+  api-key: {}
+outputs:
+  workspace-id:
+    description: workspace
+`
+      })
+    });
+    expect(failures.some((failure) => failure.includes('collections-json'))).toBe(true);
+    expect(failures.some((failure) => failure.includes('postman-bootstrap-action@v2.15.0 action.yml'))).toBe(
+      true
+    );
+  });
+
+  it('rejects Bootstrap source shape drift using supplied pinned content only', () => {
+    const failures = validateSiblingPinContracts({
+      compositeYmlText: COMPOSITE_YML,
+      siblings: siblingBundle({
+        bootstrapIndex: `outputs['collections-json'] = JSON.stringify({ nope: 1 });
+core.setOutput('collections-json', JSON.stringify({ nope: 1 }));
+fs.writeFileSync(out, "collections-json=" + JSON.stringify({ nope: 1 }));`
+      })
+    });
+    expect(failures.some((failure) => failure.includes('postman-bootstrap-action@v2.15.0 src/index.ts'))).toBe(
+      true
+    );
+  });
+
+  it('rejects Repo Sync source drift through the composite validator', () => {
+    const failures = validateSiblingPinContracts({
+      compositeYmlText: COMPOSITE_YML,
+      siblings: siblingBundle({
+        repoSyncIndex: `parseJsonMap(getInput('environment-uids-json', env) || '{}');`
+      })
+    });
+    expect(
+      failures.some((failure) => failure.includes('postman-repo-sync-action@v2.7.1 src/index.ts'))
+    ).toBe(true);
+    expect(
+      failures.some((failure) =>
+        failure.includes('missing environment-uids-json setOutput(JSON.stringify(envUids)) emit')
+      )
+    ).toBe(true);
+  });
+
+  it('validatePinnedSourceShapes reports missing supplied files with repo@tag paths', () => {
+    const failures = validatePinnedSourceShapes({
+      repo: 'postman-repo-sync-action',
+      tag: 'v2.8.7',
+      sources: {}
+    });
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        'postman-repo-sync-action@v2.8.7 src/index.ts: source content was not supplied',
+        'postman-repo-sync-action@v2.8.7 src/lib/repo/branch-decision.ts: source content was not supplied'
+      ])
+    );
+  });
+});

--- a/tests/handoff-contract.test.ts
+++ b/tests/handoff-contract.test.ts
@@ -1,32 +1,32 @@
 /**
- * WS7 composite handoff contracts.
+ * WS7 composite handoff contracts (repository-local).
  *
  * Every `steps.<id>.outputs.<name>` reference inside action.yml is an edge from
  * a producing step to a consumer (a later step's `with:`/`env:` or the
  * composite `outputs:` block). This suite enumerates every edge mechanically
- * and asserts each one against the PRODUCING action's declared outputs, read
- * from the sibling checkout's action.yml (bootstrap, smoke-flow, repo-sync,
- * insights-onboarding) or, for local `run:` steps, from the literal
- * `$GITHUB_OUTPUT` writes in the step script. A renamed or dropped output in a
- * producer goes red here before it ships as a dangling `${{ }}` that GitHub
- * silently evaluates to an empty string.
+ * and asserts the local half of each contract:
+ * - edge surface ratchet
+ * - referenced step ids exist
+ * - uses-step producers are mapped and match their `uses:` targets
+ * - local `run:` steps write the referenced names to `$GITHUB_OUTPUT`
+ * - composite outputs forward something real
+ * - the local branch_decision serializer matches the BranchDecision key set
  *
- * Golden-shape assertions pin the cross-action JSON payloads (`collections-json`,
- * `branch-decision`, `environment-uids-json`, `repo-sync-summary-json`) to the
- * exact key sets the producers serialize today, sourced from the sibling
- * src/index.ts serializers — see the SHAPES table.
+ * Cross-repository producer declarations and golden payload shapes are
+ * validated against the exact immutable sibling tags in action.yml by
+ * `scripts/check-sibling-pins.mjs` (see tests/check-sibling-pins.test.ts).
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { parse } from 'yaml';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = path.resolve(__dirname, '..');
-const actionsRoot = path.resolve(repoRoot, '..');
 
 type Step = {
   id?: string;
+  if?: string;
   uses?: string;
   run?: string;
   env?: Record<string, string>;
@@ -42,22 +42,13 @@ function loadManifest(): ActionManifest {
   return parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8')) as ActionManifest;
 }
 
-/** Map step id -> sibling checkout directory holding the producing action. */
-const SIBLING_PRODUCERS: Record<string, string> = {
+/** Map step id -> sibling repo name for every uses-step that produces outputs. */
+const USES_PRODUCERS: Record<string, string> = {
   bootstrap: 'postman-bootstrap-action',
   smoke_flow: 'postman-smoke-flow-action',
   repo_sync: 'postman-repo-sync-action',
   insights_onboarding: 'postman-insights-onboarding-action'
 };
-
-function siblingManifestPath(dir: string): string {
-  return path.join(actionsRoot, dir, 'action.yml');
-}
-
-function declaredOutputs(dir: string): Set<string> {
-  const manifest = parse(readFileSync(siblingManifestPath(dir), 'utf8')) as ActionManifest;
-  return new Set(Object.keys(manifest.outputs ?? {}));
-}
 
 /** Outputs a local `run:` step writes via `>> $GITHUB_OUTPUT` / appendFileSync(GITHUB_OUTPUT). */
 function runStepOutputs(step: Step): Set<string> {
@@ -96,6 +87,7 @@ function collectEdges(manifest: ActionManifest): Edge[] {
   }
   for (const step of manifest.runs.steps ?? []) {
     const site = `step ${step.id ?? '(anonymous)'}`;
+    record(`${site} if`, step.if ?? '');
     for (const [key, value] of Object.entries(step.with ?? {})) record(`${site} with.${key}`, value);
     for (const [key, value] of Object.entries(step.env ?? {})) record(`${site} env.${key}`, value);
     record(`${site} run`, step.run ?? '');
@@ -109,15 +101,26 @@ describe('composite handoff edges', () => {
   const stepById = new Map(steps.filter((step) => step.id).map((step) => [step.id!, step]));
   const edges = collectEdges(manifest);
 
-  it('sibling checkouts exist for every uses-step producer', () => {
-    for (const dir of Object.values(SIBLING_PRODUCERS)) {
-      expect(existsSync(siblingManifestPath(dir)), `missing sibling checkout: ${dir}`).toBe(true);
+  it('uses-step producer mappings match uses targets and cover every output-producing uses-step', () => {
+    for (const [stepId, repo] of Object.entries(USES_PRODUCERS)) {
+      const step = stepById.get(stepId);
+      expect(step?.uses, `mapped producer ${stepId} has no uses target`).toMatch(
+        new RegExp(`^postman-cs/${repo}@[^@\\s]+$`)
+      );
+    }
+
+    for (const step of steps) {
+      if (!step.uses || !edges.some((edge) => edge.step === step.id)) continue;
+      expect(
+        USES_PRODUCERS[step.id ?? ''],
+        `uses-step ${step.id ?? '(anonymous)'} produces referenced outputs but is not mapped to a sibling producer`
+      ).toBeDefined();
     }
   });
 
   it('covers the full edge surface (ratchet: update this count when edges change)', () => {
     // Every distinct (producer step, output, consuming site) triple.
-    expect(edges.length).toBe(48);
+    expect(edges.length).toBe(54);
     const distinctPairs = new Set(edges.map((edge) => `${edge.step}.${edge.output}`));
     expect(distinctPairs.size).toBe(34);
   });
@@ -128,21 +131,9 @@ describe('composite handoff edges', () => {
     }
   });
 
-  it('every uses-step edge resolves to a declared output of the producing action', () => {
-    for (const edge of edges) {
-      const producerDir = SIBLING_PRODUCERS[edge.step];
-      if (!producerDir) continue;
-      const declared = declaredOutputs(producerDir);
-      expect(
-        declared.has(edge.output),
-        `${edge.site} references ${edge.step}.outputs.${edge.output}, not declared by ${producerDir}/action.yml`
-      ).toBe(true);
-    }
-  });
-
   it('every run-step edge resolves to a literal GITHUB_OUTPUT write in that step', () => {
     for (const edge of edges) {
-      if (SIBLING_PRODUCERS[edge.step]) continue;
+      if (USES_PRODUCERS[edge.step]) continue;
       const producer = stepById.get(edge.step);
       expect(producer, `${edge.site} references unknown local step ${edge.step}`).toBeDefined();
       const written = runStepOutputs(producer!);
@@ -171,87 +162,13 @@ describe('composite handoff edges', () => {
   });
 });
 
-/**
- * Golden shapes: exact key sets of the cross-action JSON payloads, pinned to
- * the producing serializers:
- * - collections-json: bootstrap src/index.ts (all three serialization sites emit {baseline, contract, smoke})
- * - branch-decision: composite branch_decision run step + repo-sync src/lib/repo/branch-decision.ts BranchDecision
- * - environment-uids-json: repo-sync setOutput(JSON.stringify(envUids)) — flat name->uid string map
- * - repo-sync-summary-json: repo-sync createRepoSummary + the gated-skip variant
- */
-describe('golden handoff shapes', () => {
-  const COLLECTIONS_JSON_KEYS = ['baseline', 'contract', 'smoke'] as const;
-  const BRANCH_DECISION_REQUIRED = ['tier', 'strategy', 'identity', 'reason'] as const;
-  const BRANCH_DECISION_OPTIONAL = ['canonicalBranch', 'channel'] as const;
-  const REPO_SYNC_SUMMARY_KEYS = [
-    'commitSha',
-    'environmentCount',
-    'environmentSyncStatus',
-    'mockEnvironmentStatus',
-    'mockEnvironmentUid',
-    'mockAuthRequired',
-    'mockUrl',
-    'mockVisibility',
-    'monitorId',
-    'pushed',
-    'resolvedCurrentRef',
-    'workspaceLinkStatus'
-  ] as const;
-  const REPO_SYNC_SUMMARY_GATED_KEYS = ['status', 'reason'] as const;
-
-  function sourceOf(dir: string, file: string): string {
-    return readFileSync(path.join(actionsRoot, dir, file), 'utf8');
-  }
-
-  it('collections-json: every bootstrap serialization site emits exactly {baseline, contract, smoke}', () => {
-    const source = sourceOf('postman-bootstrap-action', 'src/index.ts');
-    const sites = [...source.matchAll(/'collections-json'\]?\s*[:=]\s*JSON\.stringify\(\{([^}]*)\}/g)];
-    expect(sites.length).toBeGreaterThanOrEqual(3);
-    for (const site of sites) {
-      const keys = [...site[1]!.matchAll(/([A-Za-z0-9_]+)\s*:/g)].map((match) => match[1]).sort();
-      expect(keys).toEqual([...COLLECTIONS_JSON_KEYS].sort());
-    }
-  });
-
-  it('branch-decision: the composite decide step serializes the repo-sync BranchDecision key set', () => {
+describe('local golden handoff shapes', () => {
+  it('branch-decision: the composite decide step serializes the BranchDecision key set', () => {
     const manifest = loadManifest();
     const decide = (manifest.runs.steps ?? []).find((step) => step.id === 'branch_decision');
     expect(decide?.run).toBeDefined();
-    // The literal serialized object in the decide step.
     expect(decide!.run).toContain(
       "const decision = { tier, strategy, identity, canonicalBranch, ...(channel && tier === 'channel' ? { channel } : {}), reason };"
     );
-    // And the repo-sync consumer type declares the same keys, nothing more.
-    const bdSource = sourceOf('postman-repo-sync-action', 'src/lib/repo/branch-decision.ts');
-    const block = bdSource.match(/export interface BranchDecision \{([\s\S]*?)\n\}/);
-    expect(block).not.toBeNull();
-    const declared = [...block![1]!.matchAll(/^\s*([A-Za-z0-9_]+)\??:/gm)].map((match) => match[1]).sort();
-    expect(declared).toEqual(
-      [...BRANCH_DECISION_REQUIRED, ...BRANCH_DECISION_OPTIONAL].sort()
-    );
-  });
-
-  it('environment-uids-json: repo-sync emits a flat JSON map (JSON.stringify of the envUids record)', () => {
-    const source = sourceOf('postman-repo-sync-action', 'src/index.ts');
-    expect(source).toContain("setOutput('environment-uids-json', JSON.stringify(envUids))");
-    // Input side re-parses the same flat map.
-    expect(source).toContain("parseJsonMap(getInput('environment-uids-json', env) || '{}')");
-  });
-
-  it('repo-sync-summary-json: the summary serializer emits exactly the pinned key set', () => {
-    const source = sourceOf('postman-repo-sync-action', 'src/index.ts');
-    const summary = source.match(/function createRepoSummary\([\s\S]*?JSON\.stringify\(\{([\s\S]*?)\}\);/);
-    expect(summary).not.toBeNull();
-    const keys = [...summary![1]!.matchAll(/^\s*([A-Za-z0-9_]+)[,:]/gm)].map((match) => match[1]).sort();
-    expect(keys).toEqual([...REPO_SYNC_SUMMARY_KEYS].sort());
-  });
-
-  it('repo-sync-summary-json: the gated-skip variant emits exactly {status, reason}', () => {
-    const source = sourceOf('postman-repo-sync-action', 'src/index.ts');
-    const gated = source.match(
-      /outputs\['repo-sync-summary-json'\] = JSON\.stringify\(\{\s*status: 'skipped-branch-gate',\s*reason: decision\.reason\s*\}\);/
-    );
-    expect(gated, 'gated-skip summary shape changed').not.toBeNull();
-    void REPO_SYNC_SUMMARY_GATED_KEYS;
   });
 });


### PR DESCRIPTION
## Summary

Sibling pin updates could calculate the right versions but fail before committing them because `npm test` expected neighboring action repositories on disk. The repository-local suite no longer reads sibling checkouts, so it runs correctly in isolated GitHub Actions jobs and on Windows.

Cross-repository checks now run in the existing sibling-pin gate against the exact immutable tags referenced by `action.yml`. This lets the automated pin workflow validate and publish safe updates without depending on a developer workspace layout.

## What changed

- Validate forwarded inputs and referenced producer outputs from each pinned sibling `action.yml`.
- Validate Bootstrap and Repo Sync payload shapes from source files fetched at those same immutable tags.
- Keep network and process side effects behind the CLI entrypoint while exposing pure validators for deterministic tests.
- Retain repository-local edge, output, and serializer checks without reading `../postman-*-action` directories.
- Cover valid contracts, undeclared outputs, payload drift, timeout setup, and exact `repo@tag` diagnostics with supplied fixtures.

## Safety

The gate still rejects missing tags, malformed majors, undeclared forwarded inputs, and mismatched producer contracts. Network access remains confined to `node scripts/check-sibling-pins.mjs`; `npm test` stays self-contained.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint .github/workflows/*.yml`
