### PR TITLE
fix(release): harden composite pin and E2E releases

### DIFF
--- a/.github/workflows/advance-pins.yml
+++ b/.github/workflows/advance-pins.yml
@@ -11,10 +11,11 @@ name: Advance Sibling Pins
 # covers missed or token-less dispatches; manual dispatch for on-demand runs.
 #
 # The postman-suite-pin-bot GitHub App mints a one-hour installation token
-# scoped to this repo for the push. When the App can bypass main's review
-# requirement, the bump lands directly on main and releases with no human in
-# the loop. Without bypass (or without App secrets) the push falls back to a
-# ready-to-review pull request.
+# scoped to this repo. The direct HEAD:main push attempts only when that token
+# is minted and non-empty; a GITHUB_TOKEN push would succeed at the git layer
+# but cannot trigger Auto Release, so it is never used for main. When the App
+# token is absent or the push fails, the workflow falls back to a
+# ready-to-review pull request opened with github.token.
 
 on:
   repository_dispatch:
@@ -81,19 +82,29 @@ jobs:
       - name: Commit and push
         if: steps.advance.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name "postman-suite-pin-bot[bot]"
           git config user.email "311553872+postman-suite-pin-bot[bot]@users.noreply.github.com"
           git add action.yml tests/contract.test.ts RELEASE_POLICY.md README.md
           git commit -m "fix(deps): advance sibling pins to the latest released tags"
-          if git push origin HEAD:main; then
-            echo "::notice::Pin advance pushed to main; Auto Release will cut the composite release."
-            exit 0
+          # Direct main push requires the App token: a GITHUB_TOKEN push to main
+          # may succeed at the git layer but does not trigger Auto Release, so a
+          # pin commit pushed without the bot App can remain unreleased on main.
+          # Only attempt the direct push when the App token was minted.
+          if [ -n "$APP_TOKEN" ]; then
+            if git push origin HEAD:main; then
+              echo "::notice::Pin advance pushed to main; Auto Release will cut the composite release."
+              exit 0
+            fi
+            echo "::notice::App-backed push to main failed; opening a pull request instead."
+          else
+            echo "::notice::No App token minted; skipping direct main push for review and opening a pull request instead."
           fi
-          # Protected main without bypass: carry the bump on a PR so a
-          # reviewer can land it. CI is dispatched explicitly because
+          # Protected main without bypass, or no App token: carry the bump on a
+          # PR so a reviewer can land it. CI is dispatched explicitly because
           # GITHUB_TOKEN-created pull requests do not emit pull_request runs.
           BRANCH="chore/advance-sibling-pins-$(date -u +%Y%m%d%H%M%S)"
           git push origin "HEAD:refs/heads/${BRANCH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,10 +207,18 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
+      - name: Mint composite release E2E dispatch App token
+        id: e2e-dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}
+          private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}
+          owner: postman-cs
+          repositories: postman-actions-e2e
       - name: Require real released-composite E2E and await exact correlated run
         id: verifier
         env:
-          E2E_DISPATCH_TOKEN: ${{ secrets.E2E_DISPATCH_TOKEN }}
+          E2E_DISPATCH_TOKEN: ${{ steps.e2e-dispatch-token.outputs.token }}
           E2E_GATE_MODE: ${{ inputs.e2e_verification_mode || 'enforce' }}
           E2E_GATE_ACTION: postman-api-onboarding-action
           E2E_GATE_SUITE: full

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -77,7 +77,7 @@ rewrite an immutable tag or force-push.
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.17.0`
+- `postman-cs/postman-bootstrap-action@v2.17.1`
 - `postman-cs/postman-repo-sync-action@v2.8.7`
 - `postman-cs/postman-smoke-flow-action@v3.3.1` when `flow-path` or `flow-mode` is set
 - `postman-cs/postman-insights-onboarding-action@v2.4.1` when Insights is enabled
@@ -94,10 +94,12 @@ contract tests, README, this file), then the workflow validates the result with
 `scripts/check-sibling-pins.mjs` and the full test suite before pushing to
 `main`, where Auto Release cuts the composite release. Majors never advance
 automatically; crossing a major stays a reviewed change. The push authenticates
-as the `postman-suite-pin-bot` GitHub App (org-owned, installed on the five
-suite repos), which mints a one-hour installation token per run and is allowed
-to bypass main's review requirement; without a usable App token the workflow
-opens a pull request instead.
+as the `postman-suite-pin-bot` GitHub App (org-owned, installed on the suite
+repos), which mints a one-hour installation token per run. The direct
+`HEAD:main` push attempts only when that App token is minted and non-empty, so
+a `GITHUB_TOKEN` push that would silently bypass Auto Release cannot land
+unreleased on `main`. When the App token is absent or the direct push fails, the
+workflow falls back to a ready-to-review pull request opened with `github.token`.
 
 ### Composite release rule
 
@@ -167,6 +169,23 @@ the rolling `v3` alias. A manual `report-only` selection is the only explicit
 override; enforcement is the default. Verification fails closed with
 `E2E_COMPOSITE_USES_UNAVAILABLE` when a released composite `uses:` path is
 unavailable rather than claiming constituent-action coverage for the composite.
+
+### Release E2E dispatch token
+
+The release workflow's `verify-release-e2e` job mints a short-lived GitHub App
+installation token (one hour) via `actions/create-github-app-token`, scoped to
+`postman-cs` on `postman-actions-e2e`. This token carries the App installation
+permissions **Actions: write** and **Contents: read** on that repository and is
+fed to the E2E verifier as `E2E_DISPATCH_TOKEN` so the verifier can dispatch and
+observe the release-gated workflow run.
+
+> **Operator prerequisite:** the `postman-suite-pin-bot` GitHub App must be
+> installed on `postman-cs/postman-actions-e2e` with at least **Actions: write**
+> and **Contents: read** permissions. The composite release workflow does not
+> create or provision this installation itself; an operator must install the App
+> and grant those permissions before a correlated E2E gate can dispatch and
+> observe a run. If the App token cannot be minted or is empty, verification
+> fails closed — the verifier never falls back to an ambient or default token.
 
 ## Compatibility matrix
 

--- a/action.yml
+++ b/action.yml
@@ -502,7 +502,7 @@ runs:
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
-        # Bootstrap v2.15.0 reads this normalized env key through its exported
+        # Bootstrap v2.17.0 reads this normalized env key through its exported
         # getInput('repo-url') seam, while its action metadata does not declare a
         # nested with-key. Keep the composite input explicit without violating
         # the pinned child metadata contract.

--- a/action.yml
+++ b/action.yml
@@ -498,11 +498,11 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
-      uses: postman-cs/postman-bootstrap-action@v2.17.0
+      uses: postman-cs/postman-bootstrap-action@v2.17.1
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
-        # Bootstrap v2.17.0 reads this normalized env key through its exported
+        # Bootstrap v2.17.1 reads this normalized env key through its exported
         # getInput('repo-url') seam, while its action metadata does not declare a
         # nested with-key. Keep the composite input explicit without violating
         # the pinned child metadata contract.

--- a/docs/non-github-ci.md
+++ b/docs/non-github-ci.md
@@ -24,17 +24,31 @@ POSTMAN_TEAM_ID=$(jq -r '.["team-id"]' postman-token.json)
 
 Use `POSTMAN_REGION=eu` for EU data residency and pass the same region to every Postman CLI in the pipeline.
 
+`POSTMAN_TEAM_ID` (from the resolver output above) is the parent/org
+integration id; it is never a squad id. Set `POSTMAN_WORKSPACE_TEAM_ID`
+independently to the numeric squad id when the PMAK's team is scoped under a
+Postman organization with multiple sub-teams; leave it unset otherwise. The two
+ids are distinct and are never interchangeable.
+
 Run bootstrap first and save its JSON output:
 
 ```bash
-postman-bootstrap \
-  --project-name "my-api" \
-  --spec-url "https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml" \
-  --postman-api-key "$POSTMAN_API_KEY" \
-  --postman-access-token "$POSTMAN_ACCESS_TOKEN" \
-  --postman-team-id "$POSTMAN_TEAM_ID" \
-  --postman-region "$POSTMAN_REGION" \
+# POSTMAN_WORKSPACE_TEAM_ID is optional; only set it for a multi-squad org.
+bootstrap_args=(
+  --project-name "my-api"
+  --spec-url "https://raw.githubusercontent.com/postman-cs/postman-api-onboarding-action/main/examples/core-payments-openapi.yaml"
+  --postman-api-key "$POSTMAN_API_KEY"
+  --postman-access-token "$POSTMAN_ACCESS_TOKEN"
+  --postman-team-id "$POSTMAN_TEAM_ID"
+  --postman-region "$POSTMAN_REGION"
   --result-json ./bootstrap-result.json
+)
+
+if [ -n "$POSTMAN_WORKSPACE_TEAM_ID" ]; then
+  bootstrap_args+=(--workspace-team-id "$POSTMAN_WORKSPACE_TEAM_ID")
+fi
+
+postman-bootstrap "${bootstrap_args[@]}"
 ```
 
 Extract the outputs you need from the JSON:

--- a/templates/azure-devops/windows-onboarding.yml
+++ b/templates/azure-devops/windows-onboarding.yml
@@ -60,7 +60,7 @@ parameters:
     default: 2.0.9
   - name: bootstrapVersion
     type: string
-    default: 2.11.5
+    default: 2.17.1
   - name: smokeFlowVersion
     type: string
     default: 2.1.10

--- a/tests/advance-pins.test.ts
+++ b/tests/advance-pins.test.ts
@@ -110,7 +110,56 @@ describe('advance-pins workflow', () => {
     expect(advanceWorkflow).toContain('fix(deps): advance sibling pins');
   });
 
-  it('falls back to a pull request when main cannot be pushed directly', () => {
-    expect(advanceWorkflow).toContain('gh pr create');
+  it('locks current real pins: bootstrap v2.17.1, smoke v3.3.1, repo-sync v2.8.7', () => {
+    const pins = extractPins(actionManifest);
+    const byRepo = new Map(pins.map((pin) => [pin.repo, pin.tag]));
+    expect(byRepo.get('postman-bootstrap-action')).toBe('v2.17.1');
+    expect(byRepo.get('postman-smoke-flow-action')).toBe('v3.3.1');
+    expect(byRepo.get('postman-repo-sync-action')).toBe('v2.8.7');
+  });
+
+  it('gates direct main push on a non-empty App token so GITHUB_TOKEN cannot land unreleased pins', () => {
+    // APP_TOKEN is the raw App token without fallback to github.token
+    expect(advanceWorkflow).toContain('APP_TOKEN: ${{ steps.app-token.outputs.token }}');
+    expect(advanceWorkflow).not.toContain('APP_TOKEN: ${{ steps.app-token.outputs.token || github.token }}');
+    // GH_TOKEN is github.token for the PR fallback only
+    expect(advanceWorkflow).toContain('GH_TOKEN: ${{ github.token }}');
+    expect(advanceWorkflow).not.toContain('GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}');
+    // Direct main push is gated on APP_TOKEN being non-empty
+    expect(advanceWorkflow).toContain('if [ -n "$APP_TOKEN" ]');
+    expect(advanceWorkflow).toContain('git push origin HEAD:main');
+    // The direct push precedes the PR fallback in script order
+    expect(advanceWorkflow.indexOf('if [ -n "$APP_TOKEN" ]')).toBeGreaterThan(-1);
+    expect(advanceWorkflow.indexOf('git push origin HEAD:main')).toBeGreaterThan(-1);
+    expect(advanceWorkflow.indexOf('if [ -n "$APP_TOKEN" ]')).toBeLessThan(
+      advanceWorkflow.indexOf('git push origin HEAD:main')
+    );
+    expect(advanceWorkflow.indexOf('git push origin HEAD:main')).toBeLessThan(
+      advanceWorkflow.indexOf('gh pr create')
+    );
+    // Notice printed when App token is absent
+    expect(advanceWorkflow).toContain('No App token minted');
+  });
+
+  it('reaches PR fallback instead of a direct main push when no App token is minted', () => {
+    const noTokenNoticeIdx = advanceWorkflow.indexOf('No App token minted');
+    const prFallbackIdx = advanceWorkflow.indexOf('gh pr create');
+    expect(noTokenNoticeIdx).toBeGreaterThan(-1);
+    expect(prFallbackIdx).toBeGreaterThan(-1);
+    expect(noTokenNoticeIdx).toBeLessThan(prFallbackIdx);
+    expect(advanceWorkflow).toContain('BRANCH="chore/advance-sibling-pins-');
+    expect(advanceWorkflow).toContain('gh workflow run ci.yml');
+    // The no-App path must NOT attempt a direct main push
+    const noAppSection = advanceWorkflow.slice(noTokenNoticeIdx, prFallbackIdx);
+    expect(noAppSection).not.toContain('git push origin HEAD:main');
+  });
+
+  it('falls back to PR when an App-backed direct push fails', () => {
+    // The push failure notice precedes the PR fallback
+    const pushFailNoticeIdx = advanceWorkflow.indexOf('App-backed push to main failed');
+    const prFallbackIdx = advanceWorkflow.indexOf('gh pr create');
+    expect(pushFailNoticeIdx).toBeGreaterThan(-1);
+    expect(prFallbackIdx).toBeGreaterThan(-1);
+    expect(pushFailNoticeIdx).toBeLessThan(prFallbackIdx);
   });
 });

--- a/tests/azure-devops-windows-template.test.ts
+++ b/tests/azure-devops-windows-template.test.ts
@@ -51,6 +51,16 @@ describe('Azure DevOps Windows onboarding template', () => {
     expect(source).toMatch(/onboarding-insights@\$\{\{ parameters\.insightsVersion \}\}/);
   });
 
+  it('defaults bootstrapVersion to the pinned immutable 2.17.1', () => {
+    const template = parse(readFileSync(templatePath, 'utf8'));
+    const param = template.parameters.find(
+      (p: { name: string }) => p.name === 'bootstrapVersion'
+    );
+    expect(param).toBeDefined();
+    expect(param.type).toBe('string');
+    expect(param.default).toBe('2.17.1');
+  });
+
   it('declares a workspaceTeamId parameter with an empty default', () => {
     const template = parse(readFileSync(templatePath, 'utf8'));
     const param = template.parameters.find(
@@ -83,5 +93,11 @@ describe('Azure DevOps Windows onboarding template', () => {
     expect(bootstrapStep.pwsh).not.toMatch(
       /--workspace-team-id',\s*\$env:POSTMAN_TEAM_ID/
     );
+
+    // The pinned bootstrap CLI default tracks the released bootstrap version.
+    const bootstrapParam = template.parameters.find(
+      (p: { name: string }) => p.name === 'bootstrapVersion'
+    );
+    expect(bootstrapParam.default).toBe('2.17.1');
   });
 });

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -766,16 +766,24 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(bootstrapStep?.with?.['workspace-team-id']).toBe(
         '${{ inputs.workspace-team-id }}'
       );
+      expect(bootstrapStep?.with?.['workspace-team-id']).not.toBe(
+        '${{ inputs.postman-team-id }}'
+      );
       expect(repoSyncStep?.with?.['workspace-team-id']).toBeUndefined();
       expect(insightsStep?.with?.['workspace-team-id']).toBeUndefined();
     });
 
     it('workspace-team-id input is optional with no default', () => {
       const manifest = loadManifest();
+      const description = manifest.inputs['workspace-team-id']?.description ?? '';
       expect(manifest.inputs['workspace-team-id']).toBeDefined();
       expect(manifest.inputs['workspace-team-id']?.required).toBe(false);
       expect(manifest.inputs['workspace-team-id']?.default).toBeUndefined();
-      expect(manifest.inputs['workspace-team-id']?.description).toContain('org-mode');
+      expect(description).toContain('org-mode');
+      expect(description).toContain('SUB-TEAM');
+      expect(description).toContain('squad');
+      expect(description).toMatch(/parent\/org/);
+      expect(description).toContain('never a valid value');
     });
 
     it('passes hidden postman-stack through to bootstrap', () => {

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -381,7 +381,7 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.17.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.17.1');
       expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.8.7');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
@@ -630,7 +630,7 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.17.0');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.17.1');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
       ).toBe('postman-cs/postman-repo-sync-action@v2.8.7');

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -351,6 +351,52 @@ describe('release workflow publishing contract', () => {
     expect(releaseWorkflow).toContain('default: enforce');
   });
 
+  it('mints a target-scoped App token for E2E dispatch instead of consuming a long-lived PAT secret', () => {
+    // The mint step uses the SHA-pinned create-github-app-token with suite App secrets
+    expect(releaseWorkflow).toContain(
+      'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1'
+    );
+    expect(releaseWorkflow).toContain('app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}');
+    expect(releaseWorkflow).toContain('private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}');
+    expect(releaseWorkflow).toContain('owner: postman-cs');
+    expect(releaseWorkflow).toContain('repositories: postman-actions-e2e');
+
+    const mintStep = namedStep('Mint composite release E2E dispatch App token');
+    expect(mintStep).toBeTruthy();
+    expect(mintStep).toContain(
+      'uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1'
+    );
+    expect(mintStep).toContain('app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}');
+    expect(mintStep).toContain('private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}');
+    expect(mintStep).toContain('owner: postman-cs');
+    expect(mintStep).toContain('repositories: postman-actions-e2e');
+    // The mint step must NOT have continue-on-error so a mint failure is surfaced
+    expect(mintStep).not.toContain('continue-on-error');
+
+    // The minted token feeds the verifier as E2E_DISPATCH_TOKEN, not a long-lived PAT
+    const verifier = job('verify-release-e2e');
+    expect(verifier).toContain(
+      'E2E_DISPATCH_TOKEN: ${{ steps.e2e-dispatch-token.outputs.token }}'
+    );
+    expect(releaseWorkflow).not.toContain('secrets.E2E_DISPATCH_TOKEN');
+
+    // Mint step immediately precedes the verifier in source order
+    const mintIdx = releaseWorkflow.indexOf('Mint composite release E2E dispatch App token');
+    const verifierIdx = releaseWorkflow.indexOf('Require real released-composite E2E');
+    expect(mintIdx).toBeGreaterThan(-1);
+    expect(verifierIdx).toBeGreaterThan(-1);
+    expect(mintIdx).toBeLessThan(verifierIdx);
+
+    // Verifier remains fail-closed: exact capability/correlation enforcement unchanged
+    expect(verifier).not.toContain('continue-on-error');
+    expect(verifier).toContain("E2E_GATE_MODE: ${{ inputs.e2e_verification_mode || 'enforce' }}");
+    expect(verifier).toContain('E2E_GATE_ACTION: postman-api-onboarding-action');
+    expect(verifier).toContain('E2E_GATE_SUITE: full');
+    expect(verifier).toContain('E2E_GATE_REF: ${{ github.ref_name }}');
+    expect(verifier).toContain('E2E_GATE_SOURCE_DIGEST: ${{ needs.verify-package.outputs.release_tgz_sha256 }}');
+    expect(verifier).toContain('node scripts/verify-e2e-release.mjs');
+  });
+
   it('documents publication independence and correlated alias verification in the current v3 release policy', () => {
     expect(releasePolicy).toContain('nightly `full` monitor');
     expect(releasePolicy).toContain('not a PR or immutable-publication gate');


### PR DESCRIPTION
## Summary

Automated composite releases had two authorization gaps: a pin commit could land with `GITHUB_TOKEN` without triggering Auto Release, and the release E2E gate expected a long-lived dispatch secret that wasn't provisioned. That left updated pins on `main` while the rolling `v3` alias stayed behind.

Direct pin pushes now require a minted App token and otherwise fall back to a pull request. The release gate mints its own short-lived App token scoped to `postman-actions-e2e`, so correlated released-composite verification remains fail-closed without a stored PAT.

## What changed

- Gate direct `HEAD:main` pin pushes on a non-empty App token and retain the existing PR fallback.
- Mint a target-scoped installation token for the release E2E dispatch and remove the long-lived-token dependency.
- Advance the Bootstrap pin to `v2.17.1` across the composite contract and release policy.
- Keep the Azure DevOps Windows template and org workspace squad contract on Bootstrap `v2.17.1`.

## Operational notes

`postman-suite-pin-bot` is installed on `postman-actions-e2e` with Actions write and code read/write permissions. Release verification still fails closed if token minting or the correlated E2E run fails.

## Validation

- `npm test` (212 Vitest tests and 9 verifier tests)
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint .github/workflows/release.yml .github/workflows/advance-pins.yml`
- Pre-commit typecheck and staged secret scans
