### PR TITLE
fix(release): supersede stale aliases with pending cuts

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -77,7 +77,13 @@ jobs:
                 esac
                 if ! ALIAS_COMMIT="$(git rev-parse --verify "${ALIAS}^{commit}" 2>/dev/null)" ||
                   [ "$ALIAS_COMMIT" != "$TARGET" ]; then
-                  TAG="$LATEST"
+                  PENDING_RELEASE="$(node scripts/release-cut.mjs --plan |
+                    node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).release === true")"
+                  if [ "$PENDING_RELEASE" = true ]; then
+                    echo "::notice::The pending release will supersede stale $ALIAS instead of retrying $LATEST."
+                  else
+                    TAG="$LATEST"
+                  fi
                   break
                 fi
               done

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -160,6 +160,13 @@ describe('auto-release workflow', () => {
     expect(autoReleaseWorkflow).toContain('git rev-parse --verify "${ALIAS}^{commit}"');
   });
 
+  it('lets a pending release supersede a stale rolling alias', () => {
+    expect(autoReleaseWorkflow).toContain('PENDING_RELEASE="$(node scripts/release-cut.mjs --plan');
+    expect(autoReleaseWorkflow).toContain('if [ "$PENDING_RELEASE" = true ]; then');
+    expect(autoReleaseWorkflow).toContain('The pending release will supersede stale $ALIAS');
+    expect(autoReleaseWorkflow).toContain('TAG="$LATEST"');
+  });
+
   it('never cancels a cut in flight', () => {
     expect(autoReleaseWorkflow).toContain('cancel-in-progress: false');
   });


### PR DESCRIPTION
## Summary

A published immutable tag with a stale rolling alias made Auto Release replay the old tag before planning newer work. If that tag's historical workflow could no longer authenticate its E2E dispatch, every release from main stayed blocked.

Auto Release now checks the current release plan when the latest alias is stale. A pending cut supersedes the old alias and advances it only after the new tag passes its release gate; when no cut is pending, the existing recovery path remains in place.

## Root cause

Prior-release reconciliation treated every alias mismatch as an incomplete release, without distinguishing an old tag from newer shippable work on main.

## Fix

- Evaluate the release plan before retrying a stale alias.
- Continue to block and recover the latest tag when no new release is due.
- Keep the rolling alias gated behind the new immutable tag's correlated E2E verification.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
- `node scripts/release-cut.mjs --plan` selected `v3.2.1` from the current main history.
