### PR TITLE
fix(release): wait for correlated E2E run names

### DIFF
--- a/scripts/verify-e2e-release.mjs
+++ b/scripts/verify-e2e-release.mjs
@@ -170,7 +170,7 @@ export function validateRunIdentity(run, expected) {
     throw new ReleaseVerificationError(
       'correlation_mismatch',
       `Workflow run does not match exact release correlation: ${mismatch.join(', ')}`,
-      { runId: run?.id ? String(run.id) : null }
+      { runId: run?.id ? String(run.id) : null, mismatch }
     );
   }
   return run;
@@ -354,6 +354,35 @@ export async function lookupCorrelatedRun({ config, expected, fetchImpl, now = D
   throw new ReleaseVerificationError('blocked', `No exact workflow run appeared for correlation ${expected.correlationId}`);
 }
 
+function isPendingRunTitle(error) {
+  const mismatch = error instanceof ReleaseVerificationError ? error.details?.mismatch : null;
+  return (
+    error?.code === 'correlation_mismatch' &&
+    Array.isArray(mismatch) &&
+    mismatch.length === 1 &&
+    mismatch[0] === 'action/ref/correlation/digest'
+  );
+}
+
+export async function waitForExactRunIdentity({ config, runId, expected, fetchRun: getRun, now = Date.now, sleep }) {
+  const deadline = now() + config.lookupTimeoutMs;
+  let delayMs = config.initialPollMs;
+  let titleError;
+  while (now() <= deadline) {
+    try {
+      return validateRunIdentity(await getRun(runId), { ...expected, runId });
+    } catch (error) {
+      if (!isPendingRunTitle(error)) throw error;
+      titleError = error;
+    }
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(delayMs, remaining));
+    delayMs = Math.min(config.maxPollMs, delayMs * 2);
+  }
+  throw titleError;
+}
+
 export async function waitForTerminalRun({ config, runId, expected, fetchRun: getRun, now = Date.now, sleep }) {
   const deadline = now() + config.verificationTimeoutMs;
   let delayMs = config.initialPollMs;
@@ -455,9 +484,13 @@ export async function runReleaseVerificationCli(env = process.env, dependencies 
     const dispatchDetails = await dispatchWorkflow(config, fetchImpl);
     let run;
     if (dispatchDetails?.workflowRunId) {
-      run = validateRunIdentity(await fetchRun(config, fetchImpl, dispatchDetails.workflowRunId), {
-        ...expected,
-        runId: dispatchDetails.workflowRunId
+      run = await waitForExactRunIdentity({
+        config,
+        runId: dispatchDetails.workflowRunId,
+        expected,
+        fetchRun: (id) => fetchRun(config, fetchImpl, id),
+        now,
+        sleep
       });
     } else {
       run = await lookupCorrelatedRun({ config, expected, fetchImpl, now, sleep });

--- a/scripts/verify-e2e-release.test.mjs
+++ b/scripts/verify-e2e-release.test.mjs
@@ -14,6 +14,7 @@ import {
   runReleaseVerificationCli,
   shouldFailRelease,
   validateRunIdentity,
+  waitForExactRunIdentity,
   waitForTerminalRun
 } from './verify-e2e-release.mjs';
 
@@ -141,6 +142,64 @@ test('run identity rejects ref, action, correlation, digest, and run-id mismatch
       (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
     );
   }
+});
+
+test('exact dispatch waits for run-name propagation but rejects stable identity mismatches', async () => {
+  let clock = 0;
+  let calls = 0;
+  const exact = await waitForExactRunIdentity({
+    config: { lookupTimeoutMs: 10, initialPollMs: 2, maxPollMs: 4 },
+    runId: '77',
+    expected: EXPECTED,
+    fetchRun: async () => {
+      calls += 1;
+      return calls === 1
+        ? run({ display_title: 'e2e (live sandbox)', status: 'queued', conclusion: null })
+        : run({ status: 'queued', conclusion: null });
+    },
+    now: () => clock,
+    sleep: async (ms) => {
+      clock += ms;
+    }
+  });
+  assert.equal(exact.id, 77);
+  assert.equal(calls, 2);
+
+  calls = 0;
+  await assert.rejects(
+    () =>
+      waitForExactRunIdentity({
+        config: { lookupTimeoutMs: 10, initialPollMs: 2, maxPollMs: 4 },
+        runId: '77',
+        expected: EXPECTED,
+        fetchRun: async () => {
+          calls += 1;
+          return run({ head_branch: 'release' });
+        },
+        now: () => 0,
+        sleep: async () => {}
+      }),
+    (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
+  );
+  assert.equal(calls, 1);
+});
+
+test('exact dispatch bounds run-name propagation waits', async () => {
+  let clock = 0;
+  await assert.rejects(
+    () =>
+      waitForExactRunIdentity({
+        config: { lookupTimeoutMs: 5, initialPollMs: 2, maxPollMs: 2 },
+        runId: '77',
+        expected: EXPECTED,
+        fetchRun: async () => run({ display_title: 'e2e (live sandbox)' }),
+        now: () => clock,
+        sleep: async (ms) => {
+          clock += ms;
+        }
+      }),
+    (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
+  );
 });
 
 test('terminal conclusions distinguish success, failure, cancelled, timed out, and blocked', () => {


### PR DESCRIPTION
## Summary

GitHub can return the exact workflow run ID before the custom `run-name` reaches the run API. The release verifier rejected that correct run immediately, even though the correlated E2E workflow continued with the expected action, ref, digest, and correlation ID.

The verifier now gives only that transient title field the existing lookup window to converge. Every stable identity field still fails closed on the first mismatch, so rolling aliases wait for the exact released-composite result without weakening correlation.

## Root cause

The direct-dispatch path validated the returned run once. Unlike the run ID, event, branch, workflow path, and creation time, GitHub's custom display title is eventually consistent during the first seconds after dispatch.

## Fix

- Poll the exact returned run ID until its expected title appears.
- Bound title propagation by the existing 120-second lookup timeout and exponential backoff.
- Reject run ID, event, branch, workflow path, and dispatch-time mismatches immediately.
- Preserve the separate 45-minute terminal E2E timeout after identity is established.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
- Live release probe: the exact E2E run exposed the expected custom title after the verifier's initial title-only rejection, and its released-composite job passed.
