### PR TITLE
fix(release): keep pin ratchet synchronized

### DIFF
--- a/.github/workflows/advance-pins.yml
+++ b/.github/workflows/advance-pins.yml
@@ -88,7 +88,7 @@ jobs:
           set -euo pipefail
           git config user.name "postman-suite-pin-bot[bot]"
           git config user.email "311553872+postman-suite-pin-bot[bot]@users.noreply.github.com"
-          git add action.yml tests/contract.test.ts RELEASE_POLICY.md README.md
+          git add action.yml tests/contract.test.ts tests/advance-pins.test.ts RELEASE_POLICY.md README.md
           git commit -m "fix(deps): advance sibling pins to the latest released tags"
           # Direct main push requires the App token: a GITHUB_TOKEN push to main
           # may succeed at the git layer but does not trigger Auto Release, so a

--- a/scripts/advance-pins.mjs
+++ b/scripts/advance-pins.mjs
@@ -12,7 +12,13 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 // Every file that carries an immutable sibling pin literal. action.yml is the
 // source of truth; the rest mirror it and are normalized on every run so docs
 // and contract tests can never drift from the manifest.
-export const PIN_FILES = ['action.yml', 'tests/contract.test.ts', 'RELEASE_POLICY.md', 'README.md'];
+export const PIN_FILES = [
+  'action.yml',
+  'tests/contract.test.ts',
+  'tests/advance-pins.test.ts',
+  'RELEASE_POLICY.md',
+  'README.md'
+];
 
 const USES_PIN = /uses:\s*postman-cs\/(postman-[a-z-]+-action)@(v\d+\.\d+\.\d+)/g;
 const IMMUTABLE_FULL = /^v(\d+)\.(\d+)\.(\d+)$/;

--- a/tests/advance-pins.test.ts
+++ b/tests/advance-pins.test.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  PIN_FILES,
   extractPins,
   latestImmutableForMajor,
   planAdvance,
@@ -110,12 +111,20 @@ describe('advance-pins workflow', () => {
     expect(advanceWorkflow).toContain('fix(deps): advance sibling pins');
   });
 
-  it('locks current real pins: bootstrap v2.17.1, smoke v3.3.1, repo-sync v2.8.7', () => {
+  it('rewrites and stages its own current-pin lock', () => {
+    expect(PIN_FILES).toContain('tests/advance-pins.test.ts');
+    expect(advanceWorkflow).toContain('tests/advance-pins.test.ts');
+  });
+
+  it('locks the current real sibling refs', () => {
     const pins = extractPins(actionManifest);
-    const byRepo = new Map(pins.map((pin) => [pin.repo, pin.tag]));
-    expect(byRepo.get('postman-bootstrap-action')).toBe('v2.17.1');
-    expect(byRepo.get('postman-smoke-flow-action')).toBe('v3.3.1');
-    expect(byRepo.get('postman-repo-sync-action')).toBe('v2.8.7');
+    const refs = pins.map(({ repo, tag }) => `postman-cs/${repo}@${tag}`).sort();
+    expect(refs).toEqual([
+      'postman-cs/postman-bootstrap-action@v2.17.1',
+      'postman-cs/postman-insights-onboarding-action@v2.4.1',
+      'postman-cs/postman-repo-sync-action@v2.8.7',
+      'postman-cs/postman-smoke-flow-action@v3.3.1'
+    ]);
   });
 
   it('gates direct main push on a non-empty App token so GITHUB_TOKEN cannot land unreleased pins', () => {


### PR DESCRIPTION
## Summary

Sibling-pin automation rewrites the composite manifest before running the full test suite. The current-pin contract lived outside that rewrite set, so every real patch advance left stale expectations and failed closed before it could commit.

The current-pin contract now participates in the same normalization and staging path as the manifest, contract tests, and release policy. Release dispatches can advance all mirrored pin state together without weakening validation.

## What changed

- Include `tests/advance-pins.test.ts` in the updater's owned pin files and the workflow commit.
- Represent the exact current-pin lock as full immutable action refs, which the existing rewriter can update safely.
- Cover all four composite siblings and assert that the updater and workflow both own the lock file.

## Validation

- `npx vitest run tests/advance-pins.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint .github/workflows/advance-pins.yml`
- `node scripts/advance-pins.mjs --dry-run` confirmed the pending Bootstrap, Repo Sync, and Smoke Flow tags would also update `tests/advance-pins.test.ts`.
