### PR TITLE
fix(ci): preserve pin updater test fixtures

### DIFF
--- a/.github/workflows/advance-pins.yml
+++ b/.github/workflows/advance-pins.yml
@@ -88,7 +88,7 @@ jobs:
           set -euo pipefail
           git config user.name "postman-suite-pin-bot[bot]"
           git config user.email "311553872+postman-suite-pin-bot[bot]@users.noreply.github.com"
-          git add action.yml tests/contract.test.ts tests/advance-pins.test.ts RELEASE_POLICY.md README.md
+          git add action.yml tests/contract.test.ts RELEASE_POLICY.md README.md
           git commit -m "fix(deps): advance sibling pins to the latest released tags"
           # Direct main push requires the App token: a GITHUB_TOKEN push to main
           # may succeed at the git layer but does not trigger Auto Release, so a

--- a/scripts/advance-pins.mjs
+++ b/scripts/advance-pins.mjs
@@ -12,13 +12,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 // Every file that carries an immutable sibling pin literal. action.yml is the
 // source of truth; the rest mirror it and are normalized on every run so docs
 // and contract tests can never drift from the manifest.
-export const PIN_FILES = [
-  'action.yml',
-  'tests/contract.test.ts',
-  'tests/advance-pins.test.ts',
-  'RELEASE_POLICY.md',
-  'README.md'
-];
+export const PIN_FILES = ['action.yml', 'tests/contract.test.ts', 'RELEASE_POLICY.md', 'README.md'];
 
 const USES_PIN = /uses:\s*postman-cs\/(postman-[a-z-]+-action)@(v\d+\.\d+\.\d+)/g;
 const IMMUTABLE_FULL = /^v(\d+)\.(\d+)\.(\d+)$/;

--- a/tests/advance-pins.test.ts
+++ b/tests/advance-pins.test.ts
@@ -25,6 +25,7 @@ const advanceWorkflow = readFileSync(
   'utf8'
 ).replace(/\r\n/g, '\n');
 const actionManifest = readFileSync(join(repoRoot, 'action.yml'), 'utf8');
+const contractTests = readFileSync(join(repoRoot, 'tests/contract.test.ts'), 'utf8');
 
 describe('pin extraction', () => {
   it('extracts every immutable sibling pin from the real manifest', () => {
@@ -111,20 +112,12 @@ describe('advance-pins workflow', () => {
     expect(advanceWorkflow).toContain('fix(deps): advance sibling pins');
   });
 
-  it('rewrites and stages its own current-pin lock', () => {
-    expect(PIN_FILES).toContain('tests/advance-pins.test.ts');
-    expect(advanceWorkflow).toContain('tests/advance-pins.test.ts');
-  });
-
-  it('locks the current real sibling refs', () => {
+  it('keeps current real sibling refs in updater-owned contract tests', () => {
+    expect(PIN_FILES).toContain('tests/contract.test.ts');
     const pins = extractPins(actionManifest);
-    const refs = pins.map(({ repo, tag }) => `postman-cs/${repo}@${tag}`).sort();
-    expect(refs).toEqual([
-      'postman-cs/postman-bootstrap-action@v2.17.1',
-      'postman-cs/postman-insights-onboarding-action@v2.4.1',
-      'postman-cs/postman-repo-sync-action@v2.8.7',
-      'postman-cs/postman-smoke-flow-action@v3.3.1'
-    ]);
+    for (const { repo, tag } of pins) {
+      expect(contractTests).toContain(`postman-cs/${repo}@${tag}`);
+    }
   });
 
   it('gates direct main push on a non-empty App token so GITHUB_TOKEN cannot land unreleased pins', () => {


### PR DESCRIPTION
## Problem

The live Advance Sibling Pins run normalized `tests/advance-pins.test.ts` along with release-owned pin mirrors. That rewrote historical input fixtures and collapsed conflict cases before validation.

## Change

- keep normalization scoped to the manifest, contract tests, and release documentation
- derive real-current-ref coverage from the updater-owned contract test instead of duplicating bare tag locks
- stage only updater-owned pin mirrors

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` (213 Vitest + 11 Node tests)
- `node scripts/check-sibling-pins.mjs`
- `node scripts/advance-pins.mjs --dry-run` lists only `action.yml`, `tests/contract.test.ts`, and `RELEASE_POLICY.md` for the pending advance