### PR TITLE
fix(release): reconcile failed release completions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,8 +5,8 @@ name: Auto Release
 # The tag is an OUTPUT of a passing run, never an input to one. release.yml
 # still triggers on `push: tags`, but nothing hand-pushes those tags any more:
 # this workflow creates a tag only after the exact bytes of the release commit
-# pass the full gate set. A failed cut therefore leaves no tag and burns no
-# version number, and the next merge to main retries the cut on a fresh one.
+# pass the package gate set. Every completed release is reconciled so a failed
+# E2E gate cannot strand a pending main commit behind its published tag.
 
 on:
   push:
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   cut:
-    if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -153,10 +153,10 @@ describe('auto-release workflow', () => {
     );
   });
 
-  it('recovers alias failures and resumes after a successful release', () => {
+  it('reconciles after every completed release, including failed E2E gates', () => {
     expect(autoReleaseWorkflow).toContain('workflow_run:');
     expect(autoReleaseWorkflow).toContain('workflows: [Release]');
-    expect(autoReleaseWorkflow).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(autoReleaseWorkflow).not.toContain('github.event.workflow_run.conclusion');
     expect(autoReleaseWorkflow).toContain('git rev-parse --verify "${ALIAS}^{commit}"');
   });
 


### PR DESCRIPTION
## Summary

A release can publish npm and GitHub artifacts before its enforced E2E gate finishes. If that gate fails after another main push has observed the active release, the success-only completion filter leaves the newer commit unreleased and the rolling alias stale.

Auto Release now reconciles every completed Release run. Failed E2E gates can be retried or superseded by a newer pending cut while the rolling alias remains guarded by verified E2E success.

## Root cause

The Auto Release job ignored failed Release completions even though publication happens before E2E verification. Its earlier main-push run had already exited after finding the same release active, so neither event remained to reconcile published state.

## Fix

- Keep the main-branch execution guard and remove the release-conclusion filter.
- Pin the recovery contract with a test that rejects conclusion-specific workflow filtering.

## Validation

- `npx vitest run tests/auto-release.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
