### PR TITLE
fix(release): emit automated completion events

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -37,10 +37,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Mint release dispatch App token
+        id: release-dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}
+          private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}
+          owner: postman-cs
+          repositories: postman-api-onboarding-action
+
       - name: Reconcile prior release
         id: reconcile
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-dispatch-token.outputs.token }}
           ROLLING_ALIASES: major
         run: |
           set -euo pipefail
@@ -152,7 +161,7 @@ jobs:
         id: release_target
         if: steps.reconcile.outputs.blocked != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-dispatch-token.outputs.token }}
           PLAN_FILE: ${{ runner.temp }}/plan.json
         run: |
           set -euo pipefail

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -138,6 +138,25 @@ describe('auto-release workflow', () => {
     expect(autoReleaseWorkflow).toContain('gh workflow run release.yml --ref "$TAG"');
   });
 
+  it('uses an App token so dispatched releases emit completion events', () => {
+    const token = autoReleaseWorkflow.indexOf('id: release-dispatch-token');
+    const reconcile = autoReleaseWorkflow.indexOf('name: Reconcile prior release');
+    expect(token).toBeGreaterThan(-1);
+    expect(token).toBeLessThan(reconcile);
+    expect(autoReleaseWorkflow).toContain('actions/create-github-app-token@');
+    expect(autoReleaseWorkflow).toContain('app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}');
+    expect(autoReleaseWorkflow).toContain(
+      'private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}'
+    );
+    expect(autoReleaseWorkflow).toContain('repositories: postman-api-onboarding-action');
+    expect(
+      autoReleaseWorkflow.match(
+        /GH_TOKEN: \$\{\{ steps\.release-dispatch-token\.outputs\.token \}\}/g
+      )
+    ).toHaveLength(2);
+    expect(autoReleaseWorkflow).not.toContain('GH_TOKEN: ${{ github.token }}');
+  });
+
   it('reconciles the prior incomplete tag before planning another cut', () => {
     const reconcile = autoReleaseWorkflow.indexOf('name: Reconcile prior release');
     const plan = autoReleaseWorkflow.indexOf('name: Plan release');


### PR DESCRIPTION
## Summary

Auto Release dispatches Release as a separate workflow, then relies on the Release completion event to reconcile failed gates and stale aliases. GitHub allows `workflow_dispatch` with `GITHUB_TOKEN` but suppresses the resulting `workflow_run` cascade, so automated releases never reached that reconciliation path.

Release dispatch now uses a repository-scoped installation token from the existing suite-pin App. GitHub emits completion events for App-generated runs, while tag creation and all other repository writes keep their existing permissions.

## Root cause

Both Release dispatch sites authenticated as `github-actions[bot]`. GitHub's recursion guard prevents events created by `GITHUB_TOKEN` from starting most subsequent workflows, including the completion listener used here.

## Safety

- The installation token is scoped to `postman-api-onboarding-action` and expires automatically.
- Both initial and recovery dispatches use the same token source.
- A contract test rejects fallback to `GITHUB_TOKEN` for Release dispatch.

## Validation

- `npx vitest run tests/auto-release.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
