### PR TITLE
fix(release): bound failed release recovery

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -50,6 +50,7 @@ jobs:
         id: reconcile
         env:
           GH_TOKEN: ${{ steps.release-dispatch-token.outputs.token }}
+          RELEASE_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
           ROLLING_ALIASES: major
         run: |
           set -euo pipefail
@@ -100,6 +101,15 @@ jobs:
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$TAG" ] && [ -n "$RELEASE_CONCLUSION" ] && [ "$RELEASE_CONCLUSION" != success ]; then
+            PENDING_RELEASE="$(node scripts/release-cut.mjs --plan |
+              node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).release === true")"
+            if [ "$PENDING_RELEASE" != true ]; then
+              echo "::notice::Not retrying failed release $LATEST without a newer pending cut."
+              echo "blocked=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
           if [ -z "$TAG" ]; then
             echo "blocked=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -175,8 +175,24 @@ describe('auto-release workflow', () => {
   it('reconciles after every completed release, including failed E2E gates', () => {
     expect(autoReleaseWorkflow).toContain('workflow_run:');
     expect(autoReleaseWorkflow).toContain('workflows: [Release]');
-    expect(autoReleaseWorkflow).not.toContain('github.event.workflow_run.conclusion');
+    expect(autoReleaseWorkflow).not.toContain("github.event_name != 'workflow_run'");
     expect(autoReleaseWorkflow).toContain('git rev-parse --verify "${ALIAS}^{commit}"');
+  });
+
+  it('does not loop a failed release without a newer pending cut', () => {
+    expect(autoReleaseWorkflow).toContain(
+      "RELEASE_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}"
+    );
+    const stop = autoReleaseWorkflow.indexOf(
+      '[ -n "$RELEASE_CONCLUSION" ] && [ "$RELEASE_CONCLUSION" != success ]'
+    );
+    const activeRun = autoReleaseWorkflow.indexOf('gh run list --workflow release.yml');
+    expect(stop).toBeGreaterThan(-1);
+    expect(stop).toBeLessThan(activeRun);
+    expect(autoReleaseWorkflow).toContain('if [ "$PENDING_RELEASE" != true ]; then');
+    expect(autoReleaseWorkflow).toContain(
+      'Not retrying failed release $LATEST without a newer pending cut.'
+    );
   });
 
   it('lets a pending release supersede a stale rolling alias', () => {


### PR DESCRIPTION
## Summary

Failed Release completions now reach Auto Release, but a failed gate with no newer main commit would re-dispatch the same immutable tag after every completion. A persistent E2E failure could therefore create an unbounded workflow loop.

Reconciliation now checks for a newer pending cut before retrying a failed completion. It stops cleanly when there is no new release to advance, while a newer main commit can still supersede the failed tag through the existing pending-release path.

## Root cause

The stale-alias recovery path treated every incomplete alias as retryable. Once App-authenticated dispatch restored failed completion events, that branch fed each failed Release back into itself without a termination condition.

## Safety

- The rolling alias remains on the last E2E-verified release.
- Push and manual recovery behavior is unchanged because they have no failed Release conclusion.
- Failed completions still proceed when `release-cut.mjs --plan` identifies a newer pending release.

## Validation

- `npx vitest run tests/auto-release.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-sibling-pins.mjs`
- `actionlint`
