### PR TITLE
feat: publish as @postman/onboarding-api with best-effort npm publish

### DIFF
--- a/.github/workflows/backfill-npm.yml
+++ b/.github/workflows/backfill-npm.yml
@@ -1,0 +1,49 @@
+name: Backfill npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: Ordered space-separated immutable tags, oldest first.
+        required: true
+        type: string
+
+permissions: {contents: read, id-token: write}
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish immutable release artifacts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"; fi
+          PACKAGE_NAME='@postman/onboarding-api'
+          for TAG in $TAGS; do
+            DIRECTORY=$(mktemp -d)
+            trap 'rm -rf "$DIRECTORY"' EXIT
+            gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'release.tgz' --dir "$DIRECTORY"
+            TARBALL="$DIRECTORY/release.tgz"
+            PACKAGE_JSON=$(tar -xOf "$TARBALL" package/package.json)
+            NAME=$(printf '%s' "$PACKAGE_JSON" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name")
+            VERSION=$(printf '%s' "$PACKAGE_JSON" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+            [ "$NAME" = "$PACKAGE_NAME" ] || { echo "::error::$TAG contains $NAME, expected $PACKAGE_NAME"; exit 1; }
+            [ "$VERSION" = "${TAG#v}" ] || { echo "::error::$TAG contains version $VERSION, expected ${TAG#v}"; exit 1; }
+            if npm view "$PACKAGE_NAME@$VERSION" version >/dev/null 2>&1; then
+              echo "::notice::$PACKAGE_NAME@$VERSION already exists; skipping"
+            else
+              npm publish "$TARBALL" --provenance --access public --tag backfill
+            fi
+            rm -rf "$DIRECTORY"
+            trap - EXIT
+          done
+          HIGHEST=$(npm view "$PACKAGE_NAME" versions --json | node -e "let input=''; process.stdin.on('data', chunk => input += chunk).on('end', () => { const versions = JSON.parse(input); const sorted = versions.filter(version => /^\\d+\\.\\d+\\.\\d+$/.test(version)).sort((a, b) => { const aa = a.split('.').map(Number); const bb = b.split('.').map(Number); return aa[0] - bb[0] || aa[1] - bb[1] || aa[2] - bb[2]; }); if (!sorted.length) process.exit(1); console.log(sorted.at(-1)); });")
+          npm dist-tag add "$PACKAGE_NAME@$HIGHEST" latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      published: ${{ steps.npm-publish.outputs.published }}
     steps:
       - uses: actions/setup-node@v7
         with:
@@ -170,9 +172,20 @@ jobs:
             throw new Error(`tag ${process.env.GITHUB_REF_NAME} does not match package version ${packageJson.version}`);
           }
           NODE
-      - name: Publish or verify npm package
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          generate_release_notes: true
+          files: |
+            release/release.tgz
+            release/release-manifest.json
+      - name: Publish npm package
+        id: npm-publish
+        continue-on-error: true
         run: |
           set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then sed -i '/_authToken/d' "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"; fi
+          echo "published=false" >> "$GITHUB_OUTPUT"
           PKG_NAME=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name")
           PKG_VERSION=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
           SRI="sha512-$(openssl dgst -sha512 -binary release/release.tgz | openssl base64 -A)"
@@ -181,15 +194,24 @@ jobs:
           else
             npm publish ./release/release.tgz --provenance --access public
           fi
+          echo "published=true" >> "$GITHUB_OUTPUT"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish GitHub release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          generate_release_notes: true
-          files: |
-            release/release.tgz
-            release/release-manifest.json
+      - name: Verify npm registry identity
+        if: steps.npm-publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name")
+          PKG_VERSION=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          SRI="sha512-$(openssl dgst -sha512 -binary release/release.tgz | openssl base64 -A)"
+          EXISTING=$(npm view "$PKG_NAME@$PKG_VERSION" dist.integrity)
+          [ "$EXISTING" = "$SRI" ] || { echo '::error::Published npm integrity differs from staged tarball'; exit 1; }
+      - name: Report npm publish skipped
+        if: steps.npm-publish.outputs.published != 'true'
+        run: |
+          PACKAGE_VERSION=$(tar -xOf release/release.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          echo "::warning::npm publish for @postman/onboarding-api@$PACKAGE_VERSION did not complete (missing/invalid NPM_TOKEN or registry error); GitHub Release remains authoritative; recover via backfill-npm.yml once publish access exists"
+          echo "npm publish for @postman/onboarding-api@$PACKAGE_VERSION did not complete (missing/invalid NPM_TOKEN or registry error); GitHub Release remains authoritative; recover via backfill-npm.yml once publish access exists" >> "$GITHUB_STEP_SUMMARY"
 
   verify-release-e2e:
     needs: [classify, verify-package, publish]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Postman API Onboarding
 
-[![CI](https://github.com/postman-cs/postman-api-onboarding-action/actions/workflows/ci.yml/badge.svg)](https://github.com/postman-cs/postman-api-onboarding-action/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/postman-cs/postman-api-onboarding-action?sort=semver)](https://github.com/postman-cs/postman-api-onboarding-action/releases) [![npm](https://img.shields.io/npm/v/%40postman-cse%2Fonboarding-api)](https://www.npmjs.com/package/@postman-cse/onboarding-api) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![CI](https://github.com/postman-cs/postman-api-onboarding-action/actions/workflows/ci.yml/badge.svg)](https://github.com/postman-cs/postman-api-onboarding-action/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/postman-cs/postman-api-onboarding-action?sort=semver)](https://github.com/postman-cs/postman-api-onboarding-action/releases) [![npm](https://img.shields.io/npm/v/%40postman%2Fonboarding-api)](https://www.npmjs.com/package/@postman/onboarding-api) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Canonical entrypoint for the Postman API Onboarding suite. Use this composite action when a GitHub repository needs the full onboarding path: workspace bootstrap, OpenAPI upload, collection generation, repository artifact sync, built-in smoke and contract runs, and optional Postman Insights linking.
 
@@ -392,7 +392,7 @@ Releases use immutable `v3.x.y` tags with `v3` as the rolling release channel; p
 
 ## Resources
 
-- npm package: [@postman-cse/onboarding-api](https://www.npmjs.com/package/@postman-cse/onboarding-api)
+- npm package: [@postman/onboarding-api](https://www.npmjs.com/package/@postman/onboarding-api)
 - Docs in this repo: [credentials](docs/credentials.md), [contract and output mapping](docs/contract.md), [protected-branch workflows](docs/protected-branch-workflows.md), [deferred tests](docs/deferred-tests.md), [non-GitHub CI](docs/non-github-ci.md)
 - Marketplace docs: [support](SUPPORT.md), [security](SECURITY.md), [release policy](RELEASE_POLICY.md)
 - Postman API and auth references: [Postman API](https://learning.postman.com/docs/reference/postman-api/intro-api/), [API authentication](https://learning.postman.com/docs/reference/postman-api/authentication/), [service accounts](https://learning.postman.com/docs/administration/service-accounts/), [EU data residency](https://learning.postman.com/docs/administration/enterprise/about-eu-data-residency/)

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -158,9 +158,12 @@ The composite release verifies immutable sibling pins before packaging. Its
 release workflow classifies a tag before installing dependencies, validates and
 packs in an unprivileged job, then publishes only checksummed staged artifacts in
 the privileged job. Trusted envelope verification establishes artifact identity
-and checksums before any packaged verifier code is extracted. npm publication
-(or SRI identity verification on retry) precedes the GitHub Release. That
-immutable publication remains separate from live verification.
+and checksums before any packaged verifier code is extracted. The GitHub Release
+precedes the best-effort npm publication attempt, so tags and GitHub Releases
+remain authoritative when npm access is unavailable. A successful npm publish
+still receives hard SRI identity verification; failed attempts warn and can be
+recovered through `backfill-npm.yml`. That immutable publication remains
+separate from live verification.
 
 Live sandbox E2E is not a PR or immutable-publication gate. The `onboarding-e2e`
 harness runs a nightly `full` monitor. After an immutable release publishes, the

--- a/docs/non-github-ci.md
+++ b/docs/non-github-ci.md
@@ -5,7 +5,7 @@ On GitHub Actions, use the composite action as documented in the [README](../REA
 Install the CLIs globally:
 
 ```bash
-npm install -g @postman-cse/onboarding-bootstrap @postman-cse/onboarding-repo-sync @postman-cse/onboarding-resolve-service-token
+npm install -g @postman/onboarding-bootstrap @postman/onboarding-repo-sync @postman/onboarding-resolve-service-token
 ```
 
 For CI jobs that need governance, workspace linking, or system environment association, mint a service-account access token before bootstrap:
@@ -78,4 +78,4 @@ postman-repo-sync \
 
 Both CLIs support `--dotenv-path` for shell-friendly KEY=VALUE output that can be sourced with `source ./bootstrap.env`.
 
-For Insights linking outside GitHub Actions, install `@postman-cse/onboarding-insights` and run `postman-insights-onboard` after the service has been discovered by Insights. See [postman-insights-onboarding-action/docs/cli.md](https://github.com/postman-cs/postman-insights-onboarding-action/blob/main/docs/cli.md) for the required service, workspace, and environment inputs.
+For Insights linking outside GitHub Actions, install `@postman/onboarding-insights` and run `postman-insights-onboard` after the service has been discovered by Insights. See [postman-insights-onboarding-action/docs/cli.md](https://github.com/postman-cs/postman-insights-onboarding-action/blob/main/docs/cli.md) for the required service, workspace, and environment inputs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@postman-cse/onboarding-api",
+  "name": "@postman/onboarding-api",
   "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@postman-cse/onboarding-api",
+      "name": "@postman/onboarding-api",
       "version": "3.1.2",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@postman-cse/onboarding-api",
+  "name": "@postman/onboarding-api",
   "version": "3.1.2",
   "description": "Composite Postman API onboarding GitHub Action.",
   "files": [

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -92,7 +92,7 @@ describe('postman-api-onboarding-action composite contract', () => {
 
     it('package.json name matches repository name', () => {
       const pkg = loadPackageJson();
-      expect(pkg.name).toBe('@postman-cse/onboarding-api');
+      expect(pkg.name).toBe('@postman/onboarding-api');
     });
 
     it('description carries the suite suffix, not beta', () => {
@@ -176,10 +176,12 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(classifier?.run).toContain("release_kind=alias");
       expect(verify.if).toBe("needs.classify.outputs.release_kind == 'immutable'");
       expect(publish.if).toBe("needs.classify.outputs.release_kind == 'immutable'");
-      const publishStep = publish.steps.find((step) => step.name === 'Publish or verify npm package');
+      const publishStep = publish.steps.find((step) => step.id === 'npm-publish');
       const releaseStep = publish.steps.find((step) => step.name === 'Publish GitHub release');
       expect(publishStep?.run).toContain('npm publish ./release/release.tgz --provenance --access public');
+      expect(publishStep?.['continue-on-error']).toBe(true);
       expect(releaseStep?.uses).toContain('softprops/action-gh-release');
+      expect(publish.steps.indexOf(releaseStep!)).toBeLessThan(publish.steps.indexOf(publishStep!));
     });
 
     it('README documents all inputs from action.yml', () => {

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -48,10 +48,12 @@ function npmCliPath(npmExecPath: string | undefined): string {
 }
 
 type WorkflowStep = {
+  id?: string;
   name?: string;
   uses?: string;
   run?: string;
   env?: Record<string, string>;
+  'continue-on-error'?: boolean;
   with?: Record<string, unknown>;
 };
 
@@ -89,7 +91,7 @@ function ensurePacked(packageVersion: string): string {
   writeFileSync(
     join(source, 'package.json'),
     `${JSON.stringify({
-      name: '@postman-cse/onboarding-api',
+      name: '@postman/onboarding-api',
       version: packageVersion,
       files: ['scripts/verify-release-artifacts.mjs']
     }, null, 2)}\n`
@@ -121,7 +123,7 @@ function caseFixture(options?: { packageVersion?: string; tag?: string }): strin
       repository: 'postman-cs/postman-api-onboarding-action',
       commit_sha: 'a'.repeat(40),
       tag,
-      package_name: '@postman-cse/onboarding-api',
+      package_name: '@postman/onboarding-api',
       package_version: packageVersion,
       artifacts: [{ path: 'release.tgz', sha256: sha256(releaseTarball) }]
     })
@@ -190,8 +192,9 @@ describe('release workflow artifact handoff', () => {
     expect(JSON.stringify(publish)).not.toContain('package/scripts/verify-release-artifacts.mjs');
     const tokenSteps = (publish?.steps ?? []).filter((step) => JSON.stringify(step).includes('NODE_AUTH_TOKEN'));
     expect(tokenSteps).toHaveLength(1);
-    expect(tokenSteps[0]?.name).toBe('Publish or verify npm package');
+    expect(tokenSteps[0]?.id).toBe('npm-publish');
     expect(tokenSteps[0]?.env?.NODE_AUTH_TOKEN).toBe('${{ secrets.NPM_TOKEN }}');
+    expect(tokenSteps[0]?.['continue-on-error']).toBe(true);
   });
 
   it('executes the trusted inline verifier on a real tarball without running package code under OIDC env', () => {
@@ -217,7 +220,7 @@ describe('release workflow artifact handoff', () => {
         repository: 'postman-cs/postman-api-onboarding-action',
         commit_sha: 'a'.repeat(40),
         tag: 'v2.1.2',
-        package_name: '@postman-cse/onboarding-api',
+        package_name: '@postman/onboarding-api',
         package_version: '2.1.2',
         artifacts: [{ path: 'release.tgz', sha256: sha256(tarballPath) }]
       })
@@ -265,7 +268,7 @@ describe('release artifact verifier', () => {
     const directory = caseFixture();
     const manifestPath = join(directory, 'release-manifest.json');
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-    manifest.package_name = '@postman-cse/wrong';
+    manifest.package_name = '@postman/wrong';
     writeFileSync(manifestPath, JSON.stringify(manifest));
     expect(() => verifyReleaseArtifacts(directory, expected())).toThrow(/package name/);
   });

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -293,7 +293,7 @@ describe('release workflow publishing contract', () => {
     expect(publish).not.toContain('RUNNER_TEMP/verify-release-artifacts.mjs');
     expect(publish).not.toContain('$RUNNER_TEMP/verify-release-artifacts.mjs');
     const envelope = namedStep('Verify release artifact envelope');
-    const npm = namedStep('Publish or verify npm package');
+    const npm = namedStep('Publish npm package');
     expect(envelope).toContain("artifact.path !== 'release.tgz'");
     expect(envelope).toContain('/^[a-f0-9]{64}$/');
     expect(envelope).toContain("execFileSync('tar', ['-xOf', tarballPath, 'package/package.json']");
@@ -307,14 +307,20 @@ describe('release workflow publishing contract', () => {
     );
   });
 
-  it('publishes or verifies npm before GitHub Release and attaches staged artifacts', () => {
+  it('publishes the GitHub Release before the best-effort npm attempt and attaches staged artifacts', () => {
     const publish = job('publish');
     const npmPublish = publish.indexOf('npm publish ./release/release.tgz --provenance --access public');
     const githubRelease = publish.indexOf('softprops/action-gh-release');
     expect(npmPublish).toBeGreaterThanOrEqual(0);
     expect(githubRelease).toBeGreaterThanOrEqual(0);
-    expect(npmPublish).toBeLessThan(githubRelease);
+    expect(githubRelease).toBeLessThan(npmPublish);
     expect(publish).toContain('Published npm integrity differs from staged tarball');
+    expect(publish).toContain('id: npm-publish');
+    expect(publish).toContain('continue-on-error: true');
+    expect(publish).toContain('published: ${{ steps.npm-publish.outputs.published }}');
+    expect(publish).toContain("if: steps.npm-publish.outputs.published == 'true'");
+    expect(publish).toContain("if: steps.npm-publish.outputs.published != 'true'");
+    expect(publish).toContain('recover via backfill-npm.yml once publish access exists');
     expect(publish).toContain('release/release.tgz');
     expect(publish).toContain('release/release-manifest.json');
     expect(releaseWorkflow).toContain('group: release-${{ github.repository }}');


### PR DESCRIPTION
## What changed\n- Decoupled GitHub Release publication from a best-effort npm publish attempt and added immutable artifact backfill.\n- Renamed the npm package to @postman/onboarding-api while preserving customer-facing Azure DevOps old-scope literals.\n\n## Why\nGitHub Releases and tags remain authoritative while @postman npm publishing access is unavailable.\n\n## Gates\n- npm ci\n- npm test\n- npm run typecheck\n- npm run lint\n- node scripts/check-sibling-pins.mjs\n- actionlint .github/workflows/release.yml .github/workflows/backfill-npm.yml