### PR TITLE
fix(release): require pull requests for pin advances

### DIFF
--- a/.github/workflows/advance-pins.yml
+++ b/.github/workflows/advance-pins.yml
@@ -11,12 +11,9 @@ name: Advance Sibling Pins
 # covers missed or token-less dispatches; manual dispatch for on-demand runs.
 #
 # The postman-suite-pin-bot GitHub App mints a one-hour installation token
-# scoped to this repo. The direct HEAD:main push attempts only when that token
-# is minted and non-empty; a GITHUB_TOKEN push would succeed at the git layer
-# but cannot trigger Auto Release, so it is never used for main. When the App
-# token is absent or the push fails, the workflow falls back to a
-# ready-to-review pull request opened with github.token.
-
+# scoped to this repo so the pull request this workflow opens can trigger CI.
+# This workflow never writes the default branch: every pin advance lands
+# through a reviewed pull request, and CI is dispatched explicitly for it.
 on:
   repository_dispatch:
     types: [sibling-release]
@@ -79,38 +76,27 @@ jobs:
           node scripts/check-sibling-pins.mjs
           npm test
 
-      - name: Commit and push
+      - name: Commit and open pull request
         if: steps.advance.outputs.changed == 'true'
         env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           set -euo pipefail
           git config user.name "postman-suite-pin-bot[bot]"
           git config user.email "311553872+postman-suite-pin-bot[bot]@users.noreply.github.com"
           git add action.yml tests/contract.test.ts RELEASE_POLICY.md README.md
           git commit -m "fix(deps): advance sibling pins to the latest released tags"
-          # Direct main push requires the App token: a GITHUB_TOKEN push to main
-          # may succeed at the git layer but does not trigger Auto Release, so a
-          # pin commit pushed without the bot App can remain unreleased on main.
-          # Only attempt the direct push when the App token was minted.
-          if [ -n "$APP_TOKEN" ]; then
-            if git push origin HEAD:main; then
-              echo "::notice::Pin advance pushed to main; Auto Release will cut the composite release."
-              exit 0
-            fi
-            echo "::notice::App-backed push to main failed; opening a pull request instead."
-          else
-            echo "::notice::No App token minted; skipping direct main push for review and opening a pull request instead."
-          fi
-          # Protected main without bypass, or no App token: carry the bump on a
-          # PR so a reviewer can land it. CI is dispatched explicitly because
-          # GITHUB_TOKEN-created pull requests do not emit pull_request runs.
+          # Pin advances always land through a reviewed pull request. This
+          # workflow has no default-branch write path: a direct push to main
+          # would bypass branch protection and raise the
+          # GitHub_Multiple_Protected_Branch_Policy_Override alarm.
           BRANCH="chore/advance-sibling-pins-$(date -u +%Y%m%d%H%M%S)"
           git push origin "HEAD:refs/heads/${BRANCH}"
           gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "fix(deps): advance sibling pins to the latest released tags" \
-            --body "Automated sibling pin advance. Opened by advance-pins.yml because main requires review and the pin bot App cannot bypass it."
+            --body "Automated sibling pin advance. Opened by advance-pins.yml; merging it lets Auto Release cut the composite release."
+          # CI is dispatched explicitly because GITHUB_TOKEN-created pull
+          # requests do not emit pull_request runs.
           gh workflow run ci.yml --ref "$BRANCH"

--- a/tests/advance-pins.test.ts
+++ b/tests/advance-pins.test.ts
@@ -97,17 +97,19 @@ describe('advance-pins workflow', () => {
     expect(advanceWorkflow).toContain('workflow_dispatch');
   });
 
-  it('validates moved pins with the sibling-pin gate and full tests before pushing', () => {
+  it('validates moved pins with the sibling-pin gate and full tests before opening a PR', () => {
     const validate = advanceWorkflow.indexOf('node scripts/check-sibling-pins.mjs');
     const fullTests = advanceWorkflow.indexOf('npm test');
-    const push = advanceWorkflow.indexOf('git push origin HEAD:main');
+    const branchPush = advanceWorkflow.indexOf('git push origin "HEAD:refs/heads/${BRANCH}"');
+    const prCreate = advanceWorkflow.indexOf('gh pr create');
     expect(validate).toBeGreaterThan(-1);
     expect(fullTests).toBeGreaterThan(-1);
-    expect(push).toBeGreaterThan(-1);
-    expect(validate).toBeLessThan(push);
-    expect(fullTests).toBeLessThan(push);
+    expect(branchPush).toBeGreaterThan(-1);
+    expect(prCreate).toBeGreaterThan(-1);
+    expect(validate).toBeLessThan(branchPush);
+    expect(fullTests).toBeLessThan(branchPush);
+    expect(branchPush).toBeLessThan(prCreate);
   });
-
   it('commits with a conventional fix scope so Auto Release cuts a patch', () => {
     expect(advanceWorkflow).toContain('fix(deps): advance sibling pins');
   });
@@ -120,48 +122,34 @@ describe('advance-pins workflow', () => {
     }
   });
 
-  it('gates direct main push on a non-empty App token so GITHUB_TOKEN cannot land unreleased pins', () => {
-    // APP_TOKEN is the raw App token without fallback to github.token
-    expect(advanceWorkflow).toContain('APP_TOKEN: ${{ steps.app-token.outputs.token }}');
-    expect(advanceWorkflow).not.toContain('APP_TOKEN: ${{ steps.app-token.outputs.token || github.token }}');
-    // GH_TOKEN is github.token for the PR fallback only
-    expect(advanceWorkflow).toContain('GH_TOKEN: ${{ github.token }}');
-    expect(advanceWorkflow).not.toContain('GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}');
-    // Direct main push is gated on APP_TOKEN being non-empty
-    expect(advanceWorkflow).toContain('if [ -n "$APP_TOKEN" ]');
-    expect(advanceWorkflow).toContain('git push origin HEAD:main');
-    // The direct push precedes the PR fallback in script order
-    expect(advanceWorkflow.indexOf('if [ -n "$APP_TOKEN" ]')).toBeGreaterThan(-1);
-    expect(advanceWorkflow.indexOf('git push origin HEAD:main')).toBeGreaterThan(-1);
-    expect(advanceWorkflow.indexOf('if [ -n "$APP_TOKEN" ]')).toBeLessThan(
-      advanceWorkflow.indexOf('git push origin HEAD:main')
-    );
-    expect(advanceWorkflow.indexOf('git push origin HEAD:main')).toBeLessThan(
-      advanceWorkflow.indexOf('gh pr create')
-    );
-    // Notice printed when App token is absent
-    expect(advanceWorkflow).toContain('No App token minted');
+  it('contains no default-branch push path at all', () => {
+    expect(advanceWorkflow).not.toMatch(/git push\s+\S+\s+HEAD:main/);
+    expect(advanceWorkflow).not.toMatch(/git push[^\n]*\bmain\b/);
+    for (const line of advanceWorkflow.split('\n')) {
+      if (!line.includes('git push')) continue;
+      expect(line, 'every git push targets a non-default branch ref').toContain(
+        'HEAD:refs/heads/${BRANCH}'
+      );
+    }
   });
 
-  it('reaches PR fallback instead of a direct main push when no App token is minted', () => {
-    const noTokenNoticeIdx = advanceWorkflow.indexOf('No App token minted');
-    const prFallbackIdx = advanceWorkflow.indexOf('gh pr create');
-    expect(noTokenNoticeIdx).toBeGreaterThan(-1);
-    expect(prFallbackIdx).toBeGreaterThan(-1);
-    expect(noTokenNoticeIdx).toBeLessThan(prFallbackIdx);
+  it('always lands a pin advance through a branch push plus pull request', () => {
     expect(advanceWorkflow).toContain('BRANCH="chore/advance-sibling-pins-');
+    expect(advanceWorkflow).toContain('git push origin "HEAD:refs/heads/${BRANCH}"');
+    expect(advanceWorkflow).toContain('gh pr create');
+    expect(advanceWorkflow).toContain('--base main');
     expect(advanceWorkflow).toContain('gh workflow run ci.yml');
-    // The no-App path must NOT attempt a direct main push
-    const noAppSection = advanceWorkflow.slice(noTokenNoticeIdx, prFallbackIdx);
-    expect(noAppSection).not.toContain('git push origin HEAD:main');
+    // No conditional gate can route the advance around the pull request.
+    expect(advanceWorkflow).not.toContain('if [ -n "$APP_TOKEN" ]');
+    expect(advanceWorkflow).not.toContain('No App token minted');
+    expect(advanceWorkflow).not.toContain('App-backed push to main failed');
   });
 
-  it('falls back to PR when an App-backed direct push fails', () => {
-    // The push failure notice precedes the PR fallback
-    const pushFailNoticeIdx = advanceWorkflow.indexOf('App-backed push to main failed');
-    const prFallbackIdx = advanceWorkflow.indexOf('gh pr create');
-    expect(pushFailNoticeIdx).toBeGreaterThan(-1);
-    expect(prFallbackIdx).toBeGreaterThan(-1);
-    expect(pushFailNoticeIdx).toBeLessThan(prFallbackIdx);
+  it('keeps write credentials scoped to the branch push and pull request', () => {
+    expect(advanceWorkflow).toContain('pull-requests: write');
+    expect(advanceWorkflow).toContain(
+      'GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}'
+    );
+    expect(advanceWorkflow).not.toContain('APP_TOKEN:');
   });
 });


### PR DESCRIPTION
## Summary
- remove the App-backed direct `main` push from sibling pin automation
- always push a branch and open a pull request
- enforce the no-default-branch-write contract in tests

## Validation
- `npx vitest run tests/advance-pins.test.ts`
- `npx actionlint .github/workflows/advance-pins.yml`
- `npm run typecheck`