### PR TITLE
fix(security): harden workflow trust boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,12 @@ jobs:
             if [ "${result[$n]}" -eq 0 ]; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi
           done
           for n in "${names[@]}"; do
-            echo "::group::$n"; cat "$n.log"; echo "::endgroup::"
+            echo "::group::$n"
+            stop_token="$(node -p "require('node:crypto').randomUUID()")"
+            echo "::stop-commands::$stop_token"
+            cat "$n.log"
+            echo "::$stop_token::"
+            echo "::endgroup::"
           done
           exit $fail
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,6 @@ You should receive an acknowledgement within five business days. Please include 
 
 ## Scope Notes
 
-- This action handles Postman API keys and access tokens. Both are masked in logs by the action itself; never echo them in your own workflow steps.
+- This action registers all four Postman API-key and access-token inputs with GitHub's log masker in its first step. Store static credentials in GitHub Actions secrets, and ensure any action that produces a dynamic token masks it before setting its output; the supported `postman-resolve-service-token-action` does so. Never echo credentials in your own workflow steps.
 - This composite action chains sibling actions. If the issue appears only when the composite action wires those steps together, report it here. If it is isolated to a lower-level action, mention that action in the report.
 - Reports about secrets exposed in your own workflow configuration are out of scope for a code fix. Rotate the credential in Postman immediately.

--- a/action.yml
+++ b/action.yml
@@ -400,6 +400,28 @@ outputs:
 runs:
   using: composite
   steps:
+    - id: mask_postman_credentials
+      name: Mask Postman credentials
+      shell: bash
+      env:
+        POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
+        POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
+        POSTMAN_ACCESS_TOKEN: ${{ inputs.postman-access-token }}
+        INSIGHTS_POSTMAN_API_KEY: ${{ inputs.insights-postman-api-key }}
+        INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ inputs.insights-postman-access-token }}
+      run: |
+        mask_secret() {
+          local value="$1"
+          [ -n "$value" ] || return 0
+          value=${value//'%'/%25}
+          value=${value//$'\r'/%0D}
+          value=${value//$'\n'/%0A}
+          printf '::add-mask::%s\n' "$value"
+        }
+        mask_secret "$POSTMAN_API_KEY"
+        mask_secret "$POSTMAN_ACCESS_TOKEN"
+        mask_secret "$INSIGHTS_POSTMAN_API_KEY"
+        mask_secret "$INSIGHTS_POSTMAN_ACCESS_TOKEN"
     - id: branch_decision
       name: Resolve immutable branch decision
       shell: bash
@@ -440,10 +462,11 @@ runs:
           if (!rules.some((rule) => rule.pattern === 'release/*')) rules.push({ pattern: 'release/*', code: 'RC' });
           channel = rules.find((rule) => rule.pattern.endsWith('*') ? headBranch?.startsWith(rule.pattern.slice(0, -1)) : headBranch === rule.pattern);
           if (refKind === 'tag' || refKind === 'unknown' || !headBranch) { tier = 'gated'; reason = `ref kind ${refKind}: no-op`; }
+          else if (isForkPr) { tier = 'gated'; reason = 'fork PR: credentialed tiers are ineligible'; }
           else if (headBranch === canonicalBranch) { tier = 'canonical'; reason = `head branch equals canonical branch ${canonicalBranch}`; }
           else if (channel) { tier = 'channel'; reason = `branch ${headBranch} matches channel ${channel.pattern}=${channel.code}`; }
-          else if (strategy === 'preview' && !isForkPr) { tier = 'preview'; reason = `branch ${headBranch} under branch-strategy preview`; }
-          else { tier = 'gated'; reason = isForkPr ? 'fork PR: preview-ineligible, gated instead' : `branch ${headBranch} under branch-strategy publish-gate`; }
+          else if (strategy === 'preview') { tier = 'preview'; reason = `branch ${headBranch} under branch-strategy preview`; }
+          else { tier = 'gated'; reason = `branch ${headBranch} under branch-strategy publish-gate`; }
         }
         const decision = { tier, strategy, identity, canonicalBranch, ...(channel && tier === 'channel' ? { channel } : {}), reason };
         const serialized = JSON.stringify(decision);
@@ -458,6 +481,7 @@ runs:
         POSTMAN_REGION: ${{ inputs.postman-region }}
         POSTMAN_STACK: ${{ inputs.postman-stack }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        SPEC_PATH: ${{ inputs.spec-path }}
         CREDENTIAL_PREFLIGHT: ${{ inputs.credential-preflight }}
         REPO_WRITE_MODE: ${{ inputs.repo-write-mode }}
         POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
@@ -469,8 +493,14 @@ runs:
         INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ inputs.insights-postman-access-token }}
       run: |
         if [ -n "$WORKING_DIRECTORY" ]; then
-          if ! node -e 'const fs=require("node:fs"),path=require("node:path");const target=path.resolve(process.env.GITHUB_WORKSPACE,process.env.WORKING_DIRECTORY);process.exit(fs.existsSync(target)&&fs.statSync(target).isDirectory()?0:1)'; then
+          if ! node -e 'const fs=require("node:fs"),path=require("node:path");const workspace=fs.realpathSync(process.env.GITHUB_WORKSPACE);const target=path.resolve(workspace,process.env.WORKING_DIRECTORY);if(!fs.existsSync(target)||!fs.statSync(target).isDirectory())process.exit(1);const realTarget=fs.realpathSync(target);const relative=path.relative(workspace,realTarget);process.exit(relative===""||(!relative.startsWith(`..${path.sep}`)&&relative!==".."&&!path.isAbsolute(relative))?0:1)'; then
             echo "::error::working-directory does not exist under GITHUB_WORKSPACE. Create the directory or correct the input."
+            exit 1
+          fi
+        fi
+        if [ -n "$SPEC_PATH" ]; then
+          if ! node -e 'const fs=require("node:fs"),path=require("node:path");const workspace=fs.realpathSync(process.env.GITHUB_WORKSPACE);const root=path.resolve(workspace,process.env.WORKING_DIRECTORY||"");const target=path.resolve(root,process.env.SPEC_PATH);if(!fs.existsSync(target)||!fs.statSync(target).isFile())process.exit(1);const realTarget=fs.realpathSync(target);const relative=path.relative(workspace,realTarget);process.exit(!relative.startsWith(`..${path.sep}`)&&relative!==".."&&!path.isAbsolute(relative)?0:1)'; then
+            echo "::error::spec-path does not name a file under GITHUB_WORKSPACE. Check out the file and use a repository-relative path."
             exit 1
           fi
         fi

--- a/examples/monorepo-dispatcher.yml
+++ b/examples/monorepo-dispatcher.yml
@@ -41,6 +41,10 @@ jobs:
 
           record_service() {
             local service=$1 relative=$2 skip_onboard=$3
+            if [[ ! "$service" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+              echo "Unsupported service directory name; use letters, digits, dots, underscores, or hyphens." >&2
+              exit 1
+            fi
             [ -d "services/$service" ] || return 0
             printf '%s\n' "$service" >> "$COLLECTION_SERVICES"
             if [[ "$relative" != postman/* && "$relative" != .postman/* && "$skip_onboard" != true ]]; then
@@ -52,8 +56,7 @@ jobs:
             for service_dir in services/*; do
               [ -d "$service_dir" ] || continue
               service=${service_dir#services/}
-              printf '%s\n' "$service" >> "$CODE_SERVICES"
-              printf '%s\n' "$service" >> "$COLLECTION_SERVICES"
+              record_service "$service" openapi.yaml false
             done
           else
             SKIP_ONBOARD=false
@@ -160,7 +163,7 @@ jobs:
         run: |
           ruby <<'RUBY'
           require 'yaml'
-          config = YAML.load_file('.postman/resources.yaml') || {}
+          config = YAML.safe_load(File.read('.postman/resources.yaml'), aliases: false) || {}
           cloud = config.fetch('canonical', config.fetch('cloudResources', {}))
           collections = cloud.fetch('collections', {})
           environments = cloud.fetch('environments', {})
@@ -172,19 +175,21 @@ jobs:
           missing << 'contract collection' unless contract
           missing << 'environment' unless environment
           abort("Missing Postman resource IDs in .postman/resources.yaml: #{missing.join(', ')}") unless missing.empty?
+          values = { 'POSTMAN_SMOKE_COLLECTION_UID' => smoke, 'POSTMAN_CONTRACT_COLLECTION_UID' => contract, 'POSTMAN_ENVIRONMENT_UID' => environment }
+          abort('Postman resource IDs must not contain CR or LF characters') if values.values.any? { |value| value.to_s.match?(/[\r\n]/) }
           File.open(ENV.fetch('GITHUB_ENV'), 'a') do |file|
-            file.puts("POSTMAN_SMOKE_COLLECTION_UID=#{smoke}")
-            file.puts("POSTMAN_CONTRACT_COLLECTION_UID=#{contract}")
-            file.puts("POSTMAN_ENVIRONMENT_UID=#{environment}")
+            values.each { |name, value| file.puts("#{name}=#{value}") }
           end
           RUBY
       - name: Run service collections
         working-directory: services/${{ matrix.service }}
+        env:
+          SERVICE_NAME: ${{ matrix.service }}
         run: |
           set -euo pipefail
           run_collection() {
             local label=$1 uid=$2 result
-            echo "::group::${{ matrix.service }} $label collection"
+            echo "::group::$SERVICE_NAME $label collection"
             set +e
             postman collection run "$uid" -e "$POSTMAN_ENVIRONMENT_UID" --report-events
             result=$?

--- a/scripts/check-sibling-pins.mjs
+++ b/scripts/check-sibling-pins.mjs
@@ -258,11 +258,16 @@ export function validateEnvironmentUidsEmit(source, diag) {
  */
 export function validateRepoSyncSummaryKeys(source, diag) {
   const label = diagLabel({ file: 'src/index.ts', ...diag });
-  const summary = source.match(/function createRepoSummary\([\s\S]*?JSON\.stringify\(\{([\s\S]*?)\}\);/);
-  if (!summary) {
+  const functionStart = source.indexOf('function createRepoSummary(');
+  const stringifyMarker = 'JSON.stringify({';
+  const stringifyStart = functionStart < 0 ? -1 : source.indexOf(stringifyMarker, functionStart);
+  const bodyStart = stringifyStart < 0 ? -1 : stringifyStart + stringifyMarker.length;
+  const bodyEnd = bodyStart < 0 ? -1 : source.indexOf('});', bodyStart);
+  if (functionStart < 0 || stringifyStart < 0 || bodyEnd < 0) {
     return [`${label}: createRepoSummary JSON.stringify shape not found`];
   }
-  const keys = [...summary[1].matchAll(/^\s*([A-Za-z0-9_]+)\s*(?:[,:]|$)/gm)].map((match) => match[1]).sort();
+  const summaryBody = source.slice(bodyStart, bodyEnd);
+  const keys = [...summaryBody.matchAll(/^\s*([A-Za-z0-9_]+)\s*(?:[,:]|$)/gm)].map((match) => match[1]).sort();
   const expected = [...REPO_SYNC_SUMMARY_KEYS].sort();
   if (keys.join(',') !== expected.join(',')) {
     return [

--- a/templates/azure-devops/windows-onboarding.yml
+++ b/templates/azure-devops/windows-onboarding.yml
@@ -89,15 +89,21 @@ jobs:
       - pwsh: |
           $ErrorActionPreference = 'Stop'
           $packages = @(
-            '@postman-cs/onboarding-resolve-service-token@${{ parameters.resolveVersion }}',
-            '@postman-cs/onboarding-bootstrap@${{ parameters.bootstrapVersion }}',
-            '@postman-cs/onboarding-smoke-flow@${{ parameters.smokeFlowVersion }}',
-            '@postman-cs/onboarding-repo-sync@${{ parameters.repoSyncVersion }}',
-            '@postman-cs/onboarding-insights@${{ parameters.insightsVersion }}'
+            "@postman-cs/onboarding-resolve-service-token@$env:RESOLVE_VERSION",
+            "@postman-cs/onboarding-bootstrap@$env:BOOTSTRAP_VERSION",
+            "@postman-cs/onboarding-smoke-flow@$env:SMOKE_FLOW_VERSION",
+            "@postman-cs/onboarding-repo-sync@$env:REPO_SYNC_VERSION",
+            "@postman-cs/onboarding-insights@$env:INSIGHTS_VERSION"
           )
           & npm install --global @packages --no-audit --no-fund
           if ($LASTEXITCODE -ne 0) { throw "Onboarding CLI install failed with exit code $LASTEXITCODE" }
         displayName: Install pinned Postman onboarding CLIs
+        env:
+          RESOLVE_VERSION: ${{ parameters.resolveVersion }}
+          BOOTSTRAP_VERSION: ${{ parameters.bootstrapVersion }}
+          SMOKE_FLOW_VERSION: ${{ parameters.smokeFlowVersion }}
+          REPO_SYNC_VERSION: ${{ parameters.repoSyncVersion }}
+          INSIGHTS_VERSION: ${{ parameters.insightsVersion }}
 
       - pwsh: |
           $ErrorActionPreference = 'Stop'

--- a/tests/azure-devops-windows-template.test.ts
+++ b/tests/azure-devops-windows-template.test.ts
@@ -43,12 +43,24 @@ describe('Azure DevOps Windows onboarding template', () => {
 
   it('pins every installed onboarding package instead of resolving latest', () => {
     const source = readFileSync(templatePath, 'utf8');
+    const template = parse(source);
+    const installStep = template.jobs[0].steps.find(
+      (step: { displayName?: string }) => step.displayName === 'Install pinned Postman onboarding CLIs'
+    );
     expect(source).not.toContain('@latest');
-    expect(source).toMatch(/onboarding-resolve-service-token@\$\{\{ parameters\.resolveVersion \}\}/);
-    expect(source).toMatch(/onboarding-bootstrap@\$\{\{ parameters\.bootstrapVersion \}\}/);
-    expect(source).toMatch(/onboarding-smoke-flow@\$\{\{ parameters\.smokeFlowVersion \}\}/);
-    expect(source).toMatch(/onboarding-repo-sync@\$\{\{ parameters\.repoSyncVersion \}\}/);
-    expect(source).toMatch(/onboarding-insights@\$\{\{ parameters\.insightsVersion \}\}/);
+    expect(installStep.pwsh).toContain('onboarding-resolve-service-token@$env:RESOLVE_VERSION');
+    expect(installStep.pwsh).toContain('onboarding-bootstrap@$env:BOOTSTRAP_VERSION');
+    expect(installStep.pwsh).toContain('onboarding-smoke-flow@$env:SMOKE_FLOW_VERSION');
+    expect(installStep.pwsh).toContain('onboarding-repo-sync@$env:REPO_SYNC_VERSION');
+    expect(installStep.pwsh).toContain('onboarding-insights@$env:INSIGHTS_VERSION');
+    expect(installStep.pwsh).not.toContain('${{ parameters.');
+    expect(installStep.env).toEqual({
+      RESOLVE_VERSION: '${{ parameters.resolveVersion }}',
+      BOOTSTRAP_VERSION: '${{ parameters.bootstrapVersion }}',
+      SMOKE_FLOW_VERSION: '${{ parameters.smokeFlowVersion }}',
+      REPO_SYNC_VERSION: '${{ parameters.repoSyncVersion }}',
+      INSIGHTS_VERSION: '${{ parameters.insightsVersion }}'
+    });
   });
 
   it('defaults bootstrapVersion to the pinned immutable 2.17.1', () => {

--- a/tests/branch-decision.test.ts
+++ b/tests/branch-decision.test.ts
@@ -1,0 +1,78 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function branchDecisionScript(): string {
+  const manifest = parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8')) as {
+    runs: { steps: Array<{ id?: string; run?: string }> };
+  };
+  const run = manifest.runs.steps.find((step) => step.id === 'branch_decision')?.run ?? '';
+  const match = run.match(/^node <<'NODE'\n(?<script>[\s\S]*?)\nNODE\s*$/);
+  if (!match?.groups?.script) throw new Error('branch_decision Node script not found');
+  return match.groups.script;
+}
+
+function decide(headRepo: string): Record<string, unknown> {
+  const root = mkdtempSync(path.join(tmpdir(), 'branch-decision-'));
+  try {
+    const eventPath = path.join(root, 'event.json');
+    const outputPath = path.join(root, 'output.txt');
+    const envPath = path.join(root, 'env.txt');
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        repository: { default_branch: 'main', full_name: 'postman-cs/example' },
+        pull_request: {
+          head: { repo: { full_name: headRepo } },
+          base: { repo: { full_name: 'postman-cs/example' } },
+        },
+      }),
+    );
+    const result = spawnSync(process.execPath, ['-e', branchDecisionScript()], {
+      env: {
+        ...process.env,
+        BRANCH_STRATEGY: 'publish-gate',
+        CANONICAL_BRANCH: 'main',
+        CHANNELS: '',
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_REF: 'refs/pull/1/merge',
+        GITHUB_REF_NAME: '1/merge',
+        GITHUB_HEAD_REF: 'release/attacker-controlled',
+        GITHUB_SHA: '0123456789abcdef',
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_ENV: envPath,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    const serialized = readFileSync(outputPath, 'utf8')
+      .split('\n')
+      .find((line) => line.startsWith('branch-decision='))
+      ?.slice('branch-decision='.length);
+    if (!serialized) throw new Error('branch-decision output not found');
+    return JSON.parse(serialized) as Record<string, unknown>;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('branch decision fork gating', () => {
+  it('keeps a fork PR gated even when its head branch matches the release channel', () => {
+    const decision = decide('attacker/fork');
+    expect(decision.tier).toBe('gated');
+    expect(decision.reason).toBe('fork PR: credentialed tiers are ineligible');
+    expect(decision).not.toHaveProperty('channel');
+  });
+
+  it('still assigns a same-repository release branch to the injected RC channel', () => {
+    const decision = decide('postman-cs/example');
+    expect(decision.tier).toBe('channel');
+    expect(decision.channel).toEqual({ pattern: 'release/*', code: 'RC' });
+  });
+});

--- a/tests/check-sibling-pins.test.ts
+++ b/tests/check-sibling-pins.test.ts
@@ -348,6 +348,18 @@ ${goldenBody},
     expect(failures[0]).toContain('leakedSecretToken');
   });
 
+  it('rejects a missing summary terminator without backtracking over repeated markers', () => {
+    const hostileSource =
+      'function createRepoSummary(input) {\n' + 'JSON.stringify({\n'.repeat(100_000);
+    const started = performance.now();
+    const failures = validateRepoSyncSummaryKeys(hostileSource, {
+      repo: 'postman-repo-sync-action',
+      tag: 'v2.8.7'
+    });
+    expect(failures[0]).toContain('createRepoSummary JSON.stringify shape not found');
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
   it('accepts and rejects gated-skip summary shapes', () => {
     expect(
       validateGatedSkipSummaryKeys(VALID_REPO_SYNC_INDEX, {

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -102,6 +102,15 @@ describe('CI workflow contract', () => {
     expect(runGates).toContain('--to "${{ github.event.pull_request.head.sha }}"');
     expect(runGates).toContain('gate:$n=pass');
     expect(runGates).toContain('gate:$n=fail');
+    expect(runGates).toContain("require('node:crypto').randomUUID()");
+    expect(runGates).toContain('::stop-commands::$stop_token');
+    expect(runGates).toContain('::$stop_token::');
+    expect(runGates.indexOf('::stop-commands::$stop_token')).toBeLessThan(
+      runGates.indexOf('cat "$n.log"')
+    );
+    expect(runGates.indexOf('cat "$n.log"')).toBeLessThan(
+      runGates.indexOf('::$stop_token::')
+    );
     expect(runGates).toContain('exit $fail');
   });
 

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -451,7 +451,7 @@ describe('postman-api-onboarding-action composite contract', () => {
     it('is a composite action with the expected step count', () => {
       const manifest = loadManifest();
       expect(manifest.runs.using).toBe('composite');
-      expect(manifest.runs.steps).toHaveLength(10);
+      expect(manifest.runs.steps).toHaveLength(11);
     });
 
     it('uses pinned bootstrap, repo-sync, junit-runner, junit-uploader, and insights actions', () => {
@@ -493,10 +493,10 @@ describe('postman-api-onboarding-action composite contract', () => {
       expect(validateStep?.run).toContain('Accepted values: us, eu');
     });
 
-    it('validates repo-write-mode in the first composite step before any child runs', () => {
+    it('validates repo-write-mode before any child runs', () => {
       const manifest = loadManifest();
       const steps = manifest.runs.steps;
-      const validateStep = steps[1];
+      const validateStep = steps[2];
 
       expect(validateStep?.id).toBe('validate_postman_stack');
       expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
@@ -509,9 +509,10 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
     });
 
-    it('resolves one branch decision before validation and every child invocation', () => {
+    it('masks credentials before resolving one branch decision and every child invocation', () => {
       const manifest = loadManifest();
-      expect(manifest.runs.steps[0]?.id).toBe('branch_decision');
+      expect(manifest.runs.steps[0]?.id).toBe('mask_postman_credentials');
+      expect(manifest.runs.steps[1]?.id).toBe('branch_decision');
       for (const id of ['bootstrap', 'repo_sync', 'smoke_flow', 'insights_onboarding']) {
         expect(manifest.runs.steps.find((step) => step.id === id)?.env?.POSTMAN_BRANCH_DECISION).toBe('${{ steps.branch_decision.outputs.branch-decision }}');
       }

--- a/tests/monorepo-dispatcher.test.ts
+++ b/tests/monorepo-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -167,13 +168,46 @@ describe('monorepo dispatcher example', () => {
   it('runs both tracked collections through the Postman CLI from service-local resources', () => {
     const run = workflow.jobs.run;
     const combined = run.steps.map((step) => step.run ?? '').join('\n');
-    expect(combined).toContain("YAML.load_file('.postman/resources.yaml')");
+    expect(combined).toContain("YAML.safe_load(File.read('.postman/resources.yaml'), aliases: false)");
+    expect(combined).toContain('Postman resource IDs must not contain CR or LF characters');
     expect(combined).toContain('postman login --with-api-key "$POSTMAN_API_KEY"');
     expect(combined).toContain('postman collection run "$uid"');
     expect(combined).toContain('run_collection Smoke "$POSTMAN_SMOKE_COLLECTION_UID"');
     expect(combined).toContain('run_collection Contract "$POSTMAN_CONTRACT_COLLECTION_UID"');
     expect(combined).toContain('::group::');
     expect(combined).toContain('::endgroup::');
+    expect(combined).not.toContain('::group::${{ matrix.service }}');
+    const collectionStep = run.steps.find((step) => step.name === 'Run service collections');
+    expect(collectionStep?.env?.SERVICE_NAME).toBe('${{ matrix.service }}');
+    expect(collectionStep?.run).toContain('::group::$SERVICE_NAME');
+  });
+
+  it('rejects service directory names that are unsafe to propagate through the matrix', () => {
+    const { root, initial } = createFixture();
+    const unsafeService = '$(touch pwned)';
+    mkdirSync(path.join(root, 'services', unsafeService), { recursive: true });
+    writeFileSync(path.join(root, 'services', unsafeService, 'openapi.yaml'), 'openapi: 3.1.0\n');
+    const head = commit(root, 'test: add unsafe service name');
+    const outputPath = path.join(root, 'github-output.txt');
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-c', detector], {
+      cwd: root,
+      env: {
+        ...process.env,
+        EVENT_NAME: 'push',
+        BEFORE_SHA: initial,
+        HEAD_SHA: head,
+        BASE_REF: '',
+        DEFAULT_BRANCH: 'main',
+        SYNC_COMMITTER_NAME: 'Postman',
+        SYNC_COMMITTER_EMAIL: 'support@postman.com',
+        GITHUB_OUTPUT: outputPath,
+        RUNNER_TEMP: root,
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain('Unsupported service directory name');
+    expect(existsSync(path.join(root, 'pwned'))).toBe(false);
   });
 
   it('dispatches every existing service deterministically', () => {

--- a/tests/validate-inputs.test.ts
+++ b/tests/validate-inputs.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { parse } from 'yaml';
@@ -40,6 +41,7 @@ function runValidation(env: Record<string, string>): { status: number; stderr: s
         PATH: process.env.PATH ?? '',
         GITHUB_WORKSPACE: repoRoot,
         WORKING_DIRECTORY: '',
+        SPEC_PATH: '',
         POSTMAN_STACK: 'prod',
         POSTMAN_REGION: 'us',
         CREDENTIAL_PREFLIGHT: 'warn',
@@ -90,13 +92,15 @@ describe('composite first-step input validation', () => {
     expect(manifest.inputs['repo-write-mode']?.default).toBe('commit-and-push');
   });
 
-  it('resolves branch decision first, then validates before any child', () => {
+  it('masks credentials, resolves branch decision, then validates before any child', () => {
     const steps = loadManifest().runs.steps;
-    expect(steps[0]?.id).toBe('branch_decision');
-    const validateStep = steps[1];
+    expect(steps[0]?.id).toBe('mask_postman_credentials');
+    expect(steps[1]?.id).toBe('branch_decision');
+    const validateStep = steps[2];
     expect(validateStep?.id).toBe('validate_postman_stack');
     expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
     expect(validateStep?.env?.WORKING_DIRECTORY).toBe('${{ inputs.working-directory }}');
+    expect(validateStep?.env?.SPEC_PATH).toBe('${{ inputs.spec-path }}');
     expect(validateStep?.env?.POSTMAN_API_KEY).toBe('${{ inputs.postman-api-key }}');
     expect(validateStep?.env?.POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.postman-access-token }}');
     expect(validateStep?.env?.ENABLE_INSIGHTS).toBe('${{ inputs.enable-insights }}');
@@ -170,6 +174,30 @@ describe('composite first-step input validation', () => {
 
   it('accepts an existing working directory', () => {
     expect(runValidation({ WORKING_DIRECTORY: 'tests' }).status).toBe(0);
+  }, 20_000);
+
+  it('rejects a working directory that resolves outside GITHUB_WORKSPACE', () => {
+    const result = runValidation({ WORKING_DIRECTORY: '..' });
+    expect(result.status).toBe(1);
+    expect(combinedOutput(result)).toContain('working-directory does not exist under GITHUB_WORKSPACE');
+  }, 20_000);
+
+  it('accepts an existing repository-relative spec path', () => {
+    expect(runValidation({ SPEC_PATH: 'action.yml' }).status).toBe(0);
+  }, 20_000);
+
+  it('rejects an existing spec path outside GITHUB_WORKSPACE', () => {
+    const outside = mkdtempSync(path.join(tmpdir(), 'outside-spec-'));
+    const outsideSpec = path.join(outside, 'openapi.yaml');
+    writeFileSync(outsideSpec, 'openapi: 3.1.0\n');
+    try {
+      const result = runValidation({ SPEC_PATH: outsideSpec });
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('spec-path does not name a file under GITHUB_WORKSPACE');
+      expect(combinedOutput(result)).not.toContain(outsideSpec);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   }, 20_000);
 
   it('rejects a missing working directory without reflecting the input', () => {
@@ -300,6 +328,40 @@ describe('composite first-step input validation', () => {
 });
 
 describe('child invocation order and credential forwarding', () => {
+  it('masks every Postman credential before branch resolution and child actions', () => {
+    const steps = loadManifest().runs.steps;
+    const maskStep = steps.find((step) => step.id === 'mask_postman_credentials');
+    expect(steps.indexOf(maskStep!)).toBe(0);
+    expect(maskStep?.env).toEqual({
+      POSTMAN_TEAM_ID: '${{ inputs.postman-team-id }}',
+      POSTMAN_API_KEY: '${{ inputs.postman-api-key }}',
+      POSTMAN_ACCESS_TOKEN: '${{ inputs.postman-access-token }}',
+      INSIGHTS_POSTMAN_API_KEY: '${{ inputs.insights-postman-api-key }}',
+      INSIGHTS_POSTMAN_ACCESS_TOKEN: '${{ inputs.insights-postman-access-token }}'
+    });
+    expect(maskStep?.run).toContain("value=${value//'%'/%25}");
+    expect(maskStep?.run).toContain("value=${value//$'\\n'/%0A}");
+    expect(maskStep?.run).toContain("printf '::add-mask::%s\\n' \"$value\"");
+
+    const output = execFileSync('bash', ['--noprofile', '--norc', '-c', maskStep?.run ?? ''], {
+      env: {
+        PATH: process.env.PATH ?? '',
+        POSTMAN_TEAM_ID: '',
+        POSTMAN_API_KEY: 'primary%key\nnext',
+        POSTMAN_ACCESS_TOKEN: 'primary-token',
+        INSIGHTS_POSTMAN_API_KEY: 'insights-key',
+        INSIGHTS_POSTMAN_ACCESS_TOKEN: 'insights-token'
+      },
+      encoding: 'utf8'
+    });
+    expect(output.trim().split('\n')).toEqual([
+      '::add-mask::primary%25key%0Anext',
+      '::add-mask::primary-token',
+      '::add-mask::insights-key',
+      '::add-mask::insights-token'
+    ]);
+  });
+
   it('invokes bootstrap, repo-sync, and insights exactly once in that order', () => {
     const steps = loadManifest().runs.steps;
     const childIds = steps


### PR DESCRIPTION
## Summary

- gate every fork PR before channel or preview tier selection
- mask Postman credentials before child actions and contain repository paths
- harden copied GitHub/Azure workflow templates and CI log replay
- replace the sibling-source quadratic matcher with bounded scans

## Verification

- npm test (243 Vitest + 11 release-verifier tests)
- npm run typecheck
- npm run lint
- node scripts/check-sibling-pins.mjs
- actionlint 1.7.11