### PR TITLE
fix(security): harden onboarding and release boundaries

### DIFF
--- a/.github/workflows/advance-pins.yml
+++ b/.github/workflows/advance-pins.yml
@@ -106,7 +106,14 @@ jobs:
           set -euo pipefail
           git config user.name "postman-suite-pin-bot[bot]"
           git config user.email "311553872+postman-suite-pin-bot[bot]@users.noreply.github.com"
-          git add action.yml tests/contract.test.ts RELEASE_POLICY.md README.md
+          git add \
+            action.yml \
+            .github/workflows/release.yml \
+            scripts/verify-e2e-release.test.mjs \
+            tests/contract.test.ts \
+            tests/release-workflow.test.ts \
+            RELEASE_POLICY.md \
+            README.md
           git commit -m "fix(deps): advance sibling pins to promoted releases"
           # Pin advances always land through a reviewed pull request. This
           # workflow has no default-branch write path: a direct push to main

--- a/.github/workflows/advance-pins.yml
+++ b/.github/workflows/advance-pins.yml
@@ -1,19 +1,20 @@
 name: Advance Sibling Pins
 
 # Advances the immutable sibling pins in action.yml (and their mirrored
-# literals in the contract tests, README, and RELEASE_POLICY) to the newest
-# released tag of each pin's recorded major, then hands the commit to Auto
-# Release, which cuts the composite release. Majors never move here: crossing
-# a major boundary stays a reviewed change per RELEASE_POLICY.md.
+# literals in the contract tests, README, and RELEASE_POLICY) only to the exact
+# immutable tag selected by each sibling's promoted rolling major alias. The
+# selector also binds that tag and commit to its non-draft GitHub Release
+# manifest before editing. Publication without alias promotion is ineligible.
 #
 # Triggers: sibling repos dispatch `sibling-release` after a successful
 # Release run (via the postman-suite-pin-bot App); a daily cron backstop
 # covers missed or token-less dispatches; manual dispatch for on-demand runs.
 #
-# The postman-suite-pin-bot GitHub App mints a one-hour installation token
-# scoped to this repo so the pull request this workflow opens can trigger CI.
-# This workflow never writes the default branch: every pin advance lands
-# through a reviewed pull request, and CI is dispatched explicitly for it.
+# The postman-suite-pin-bot GitHub App mints separate one-hour installation
+# tokens: a contents-read token scoped only to the four sibling repositories,
+# and a write token scoped only to this composite repository. This workflow
+# never writes the default branch: every pin advance lands through a reviewed
+# pull request, and CI is dispatched explicitly for it.
 on:
   repository_dispatch:
     types: [sibling-release]
@@ -32,24 +33,27 @@ jobs:
   advance:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      actions: write
+      contents: read
     steps:
-      - name: Mint repo-scoped App token
-        id: app-token
-        continue-on-error: true
+      - name: Mint sibling release read token
+        id: sibling-read-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}
           private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}
           owner: postman-cs
-          repositories: postman-api-onboarding-action
+          repositories: |
+            postman-bootstrap-action
+            postman-insights-onboarding-action
+            postman-repo-sync-action
+            postman-smoke-flow-action
+          permission-contents: read
 
       - uses: actions/checkout@v7
         with:
           ref: main
-          token: ${{ steps.app-token.outputs.token || github.token }}
+          token: ${{ github.token }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:
@@ -59,6 +63,8 @@ jobs:
 
       - name: Advance pins
         id: advance
+        env:
+          GH_TOKEN: ${{ steps.sibling-read-token.outputs.token }}
         run: |
           set -euo pipefail
           node scripts/advance-pins.mjs
@@ -71,32 +77,49 @@ jobs:
 
       - name: Validate advanced pins
         if: steps.advance.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.sibling-read-token.outputs.token }}
         run: |
           set -euo pipefail
+          node scripts/advance-pins.mjs --check
           node scripts/check-sibling-pins.mjs
           npm test
+
+      - name: Mint composite write token
+        if: steps.advance.outputs.changed == 'true'
+        id: composite-write-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SUITE_PIN_BOT_APP_ID }}
+          private-key: ${{ secrets.SUITE_PIN_BOT_PRIVATE_KEY }}
+          owner: postman-cs
+          repositories: postman-api-onboarding-action
+          permission-contents: write
+          permission-pull-requests: write
+          permission-actions: write
 
       - name: Commit and open pull request
         if: steps.advance.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.composite-write-token.outputs.token }}
         run: |
           set -euo pipefail
           git config user.name "postman-suite-pin-bot[bot]"
           git config user.email "311553872+postman-suite-pin-bot[bot]@users.noreply.github.com"
           git add action.yml tests/contract.test.ts RELEASE_POLICY.md README.md
-          git commit -m "fix(deps): advance sibling pins to the latest released tags"
+          git commit -m "fix(deps): advance sibling pins to promoted releases"
           # Pin advances always land through a reviewed pull request. This
           # workflow has no default-branch write path: a direct push to main
           # would bypass branch protection and raise the
           # GitHub_Multiple_Protected_Branch_Policy_Override alarm.
           BRANCH="chore/advance-sibling-pins-$(date -u +%Y%m%d%H%M%S)"
+          gh auth setup-git
           git push origin "HEAD:refs/heads/${BRANCH}"
           gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "fix(deps): advance sibling pins to the latest released tags" \
-            --body "Automated sibling pin advance. Opened by advance-pins.yml; merging it lets Auto Release cut the composite release."
+            --title "fix(deps): advance sibling pins to promoted releases" \
+            --body "Automated sibling pin advance to exact rolling-alias targets with verified GitHub Release manifests. Opened by advance-pins.yml; merging it lets Auto Release cut the composite release."
           # CI is dispatched explicitly because GITHUB_TOKEN-created pull
           # requests do not emit pull_request runs.
           gh workflow run ci.yml --ref "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           E2E_GATE_PROVIDER_TAG: e2e-provider-v1.2.0
           E2E_GATE_PROVIDER_COMMIT: 53c5d10093b7dafb165d3caafbe3f1d70dec687d
           E2E_GATE_PROVIDER_SOURCE_DIGEST: 8c7ee211fccd2869f3901fcbc5ed154d6dea8e3d0d7d2e5312f6c0b57b4f6b78
-          E2E_GATE_PEER_TAGS: '{"postman-cs/postman-bootstrap-action":"v2.21.5","postman-cs/postman-insights-onboarding-action":"v2.5.2","postman-cs/postman-repo-sync-action":"v2.10.3","postman-cs/postman-resolve-service-token-action":"v2.2.4","postman-cs/postman-smoke-flow-action":"v3.7.3"}'
+          E2E_GATE_PEER_TAGS: '{"postman-cs/postman-bootstrap-action":"v2.21.10","postman-cs/postman-insights-onboarding-action":"v2.5.2","postman-cs/postman-repo-sync-action":"v2.10.9","postman-cs/postman-resolve-service-token-action":"v2.2.4","postman-cs/postman-smoke-flow-action":"v3.7.4"}'
         run: node scripts/verify-e2e-release.mjs
 
   advance-major-alias:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,6 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
-    inputs:
-      e2e_verification_mode:
-        description: Enforce correlated E2E success before moving the rolling alias, or explicitly report-only.
-        required: true
-        type: choice
-        options:
-          - enforce
-          - report-only
-        default: enforce
 
 permissions:
   contents: read
@@ -232,6 +223,9 @@ jobs:
     outputs:
       outcome: ${{ steps.verifier.outputs.e2e_outcome }}
       correlation_id: ${{ steps.verifier.outputs.e2e_correlation_id }}
+      manifest_sha256: ${{ steps.verifier.outputs.e2e_manifest_sha256 }}
+      provider_commit: ${{ steps.verifier.outputs.e2e_provider_commit }}
+      provider_tag: ${{ steps.verifier.outputs.e2e_provider_tag }}
       workflow_run_id: ${{ steps.verifier.outputs.e2e_workflow_run_id }}
       run_url: ${{ steps.verifier.outputs.e2e_run_url }}
     steps:
@@ -251,16 +245,21 @@ jobs:
         id: verifier
         env:
           E2E_DISPATCH_TOKEN: ${{ steps.e2e-dispatch-token.outputs.token }}
-          E2E_GATE_MODE: ${{ inputs.e2e_verification_mode || 'enforce' }}
+          E2E_GATE_MODE: enforce
           E2E_GATE_ACTION: postman-api-onboarding-action
           E2E_GATE_SUITE: full
           E2E_GATE_REF: ${{ github.ref_name }}
+          E2E_GATE_RELEASE_COMMIT: ${{ github.sha }}
           E2E_GATE_SOURCE_DIGEST: ${{ needs.verify-package.outputs.release_tgz_sha256 }}
+          E2E_GATE_PROVIDER_TAG: e2e-provider-v1.2.0
+          E2E_GATE_PROVIDER_COMMIT: 53c5d10093b7dafb165d3caafbe3f1d70dec687d
+          E2E_GATE_PROVIDER_SOURCE_DIGEST: 8c7ee211fccd2869f3901fcbc5ed154d6dea8e3d0d7d2e5312f6c0b57b4f6b78
+          E2E_GATE_PEER_TAGS: '{"postman-cs/postman-bootstrap-action":"v2.21.5","postman-cs/postman-insights-onboarding-action":"v2.5.2","postman-cs/postman-repo-sync-action":"v2.10.3","postman-cs/postman-resolve-service-token-action":"v2.2.4","postman-cs/postman-smoke-flow-action":"v3.7.3"}'
         run: node scripts/verify-e2e-release.mjs
 
   advance-major-alias:
     needs: [classify, publish, verify-release-e2e]
-    if: ${{ !cancelled() && needs.classify.outputs.release_kind == 'immutable' && needs.publish.result == 'success' && needs.verify-release-e2e.result == 'success' }}
+    if: ${{ !cancelled() && needs.classify.outputs.release_kind == 'immutable' && needs.publish.result == 'success' && needs.verify-release-e2e.result == 'success' && needs.verify-release-e2e.outputs.outcome == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -282,9 +281,25 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
-      - name: Advance rolling major alias
+      - name: Advance rolling major alias without regression
+        env:
+          VERIFIED_E2E_MANIFEST_SHA256: ${{ needs.verify-release-e2e.outputs.manifest_sha256 }}
+          VERIFIED_E2E_PROVIDER_COMMIT: ${{ needs.verify-release-e2e.outputs.provider_commit }}
+          VERIFIED_E2E_PROVIDER_TAG: ${{ needs.verify-release-e2e.outputs.provider_tag }}
         run: |
           set -euo pipefail
+          [[ "$VERIFIED_E2E_MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo '::error::verified E2E manifest digest is missing or invalid'
+            exit 1
+          }
+          [ "$VERIFIED_E2E_PROVIDER_TAG" = 'e2e-provider-v1.2.0' ] || {
+            echo '::error::verified E2E provider tag mismatch'
+            exit 1
+          }
+          [ "$VERIFIED_E2E_PROVIDER_COMMIT" = '53c5d10093b7dafb165d3caafbe3f1d70dec687d' ] || {
+            echo '::error::verified E2E provider commit mismatch'
+            exit 1
+          }
           VERSION="${GITHUB_REF_NAME#v}"; MAJOR="v${VERSION%%.*}"
           set +e
           ROWS=$(git ls-remote --tags origin "refs/tags/$MAJOR" "refs/tags/$MAJOR^{}" "refs/tags/$MAJOR.*")
@@ -300,6 +315,33 @@ jobs:
             exit 0
           fi
           [ "$STATUS" -eq 0 ] || exit "$STATUS"
+          RELEASE_TAG_REF="refs/tags/$GITHUB_REF_NAME"
+          REMOTE_RELEASE_REFS="$(git ls-remote --exit-code --tags origin "$RELEASE_TAG_REF" "${RELEASE_TAG_REF}^{}")" || {
+            echo "::error::failed to re-resolve immutable release tag $GITHUB_REF_NAME"
+            exit 1
+          }
+          REMOTE_RELEASE_TAG=''
+          REMOTE_RELEASE_PEELED=''
+          while IFS=$'\t' read -r object ref; do
+            if [ "$ref" = "$RELEASE_TAG_REF" ]; then
+              [ -z "$REMOTE_RELEASE_TAG" ] || { echo '::error::duplicate immutable release tag ref'; exit 1; }
+              REMOTE_RELEASE_TAG="$object"
+            elif [ "$ref" = "${RELEASE_TAG_REF}^{}" ]; then
+              [ -z "$REMOTE_RELEASE_PEELED" ] || { echo '::error::duplicate peeled release tag ref'; exit 1; }
+              REMOTE_RELEASE_PEELED="$object"
+            else
+              echo "::error::unexpected ref while resolving immutable release tag: $ref"
+              exit 1
+            fi
+          done <<< "$REMOTE_RELEASE_REFS"
+          [[ "$REMOTE_RELEASE_TAG" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::immutable release tag did not resolve to an object'; exit 1; }
+          REMOTE_RELEASE_COMMIT="${REMOTE_RELEASE_PEELED:-$REMOTE_RELEASE_TAG}"
+          [[ "$REMOTE_RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::immutable release tag did not peel to a commit'; exit 1; }
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::release workflow SHA is invalid'; exit 1; }
+          [ "$REMOTE_RELEASE_COMMIT" = "$GITHUB_SHA" ] || {
+            echo "::error::immutable release tag moved: expected $GITHUB_SHA, resolved $REMOTE_RELEASE_COMMIT"
+            exit 1
+          }
           git config user.name 'github-actions[bot]'; git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$GITHUB_SHA"
           git push origin "$MAJOR" --force

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -63,9 +63,12 @@ Do not duplicate full input and output tables across repositories. Link to the a
 ### Branch-aware v3 contract
 
 The v3 composite exposes `branch-strategy`, `canonical-branch`, `channels`, and
-`preview-ttl`, resolves one `POSTMAN_BRANCH_DECISION` before every child, and
-surfaces `sync-status` and `spec-version-url`. Gated bootstrap receives empty
-credentials; repo-sync and Insights are skipped. There are no public migration knobs.
+`preview-ttl`, resolves one credential-free `POSTMAN_BRANCH_DECISION` before
+any secret-bearing step, and surfaces `sync-status` and `spec-version-url`.
+Direct and nested PR-derived events are credential-eligible only after positive
+same-repository ID and name proof. Unknown, malformed, fork, and unsupported
+events fail closed under every strategy, including legacy. Every gated-path
+child and secret-bearing step is skipped. There are no public migration knobs.
 
 The branch-aware v3 contract and bottom-up v3 child releases are shipped. This
 composite pins those released immutable child tags on the v3 channel, and the
@@ -86,20 +89,28 @@ Because these are immutable sibling pins, a consumer who pins `postman-api-onboa
 
 ### Automatic pin advance
 
-`.github/workflows/advance-pins.yml` keeps these pins at the newest released
-tag of each pin's recorded major. It runs on a `sibling-release` repository
-dispatch from sibling Release runs, on a daily cron backstop, and on manual
-dispatch. `scripts/advance-pins.mjs` rewrites every pin literal (manifest,
-contract tests, README, this file), then the workflow validates the result with
-`scripts/check-sibling-pins.mjs` and the full test suite before pushing to
-`main`, where Auto Release cuts the composite release. Majors never advance
-automatically; crossing a major stays a reviewed change. The push authenticates
-as the `postman-suite-pin-bot` GitHub App (org-owned, installed on the suite
-repos), which mints a one-hour installation token per run. The direct
-`HEAD:main` push attempts only when that App token is minted and non-empty, so
-a `GITHUB_TOKEN` push that would silently bypass Auto Release cannot land
-unreleased on `main`. When the App token is absent or the direct push fails, the
-workflow falls back to a ready-to-review pull request opened with `github.token`.
+`.github/workflows/advance-pins.yml` selects only the unique immutable tag whose
+commit equals each sibling's promoted rolling major alias. Before editing, it
+also requires a non-draft GitHub Release whose `release-manifest.json` binds the
+exact repository, tag, peeled commit, package version, and `release.tgz` digest.
+Newer published-but-unpromoted tags are ineligible; missing or ambiguous aliases,
+releases, manifests, and attempted regressions fail closed. Notification, daily
+cron, and manual runs all use this same selector and ignore dispatch payloads.
+
+The selector rewrites every pin literal (manifest, contract tests, README, and
+this file), then the workflow validates the result with
+`scripts/check-sibling-pins.mjs` and the full test suite. It pushes only a topic
+branch and opens a pull request; it never writes `main` directly. The
+`postman-suite-pin-bot` GitHub App supplies two short-lived, non-overlapping
+tokens: a **Contents: read** token explicitly scoped to the four sibling
+repositories for release selection and verification, and a separate token
+scoped only to this composite repository with **Contents: write**, **Pull
+requests: write**, and **Actions: write** for the topic-branch push, PR creation,
+and CI dispatch. Initial checkout uses the workflow's read-only ambient
+`github.token` without persisting credentials; it is never a fallback for either
+App token. The composite write token is minted only after selection and all
+validation pass. Either required token mint failure aborts the run. Majors never
+advance automatically; crossing a major remains a reviewed change.
 
 ### Composite release rule
 
@@ -168,11 +179,16 @@ live verification.
 
 Live sandbox E2E is not a PR or immutable-publication gate. The `onboarding-e2e`
 harness runs a nightly `full` monitor. After an immutable release publishes, the
-release workflow requires an exact correlated terminal success before advancing
-the rolling `v3` alias. A manual `report-only` selection is the only explicit
-override; enforcement is the default. Verification fails closed with
-`E2E_COMPOSITE_USES_UNAVAILABLE` when a released composite `uses:` path is
-unavailable rather than claiming constituent-action coverage for the composite.
+release workflow constructs a canonical closed manifest binding the immutable
+provider tag, its annotated source-manifest digest and peeled commit, the release
+tag/commit/artifact digest, and the exact tags, peeled commits, and action or CLI
+digests of all six suite repositories. The pinned provider runs the `full` suite,
+validates that the released composite's four child pins match that closure, and
+returns one bounded, canonical terminal result artifact tied to the exact run.
+Only that artifact's exact correlated success can advance the rolling `v3`
+alias. No manual or diagnostic mode can weaken promotion. Immediately before
+mutation, the alias job also re-resolves the immutable release tag and requires
+its peeled commit to equal the release workflow's `GITHUB_SHA`.
 
 ### Release E2E dispatch token
 
@@ -222,8 +238,8 @@ Before pushing a new release tag:
 7. Merge to `main` and let auto-release cut the immutable tag after gates pass.
 8. Confirm npm publication or matching SRI retry identity and the matching
    GitHub release.
-9. Confirm exact correlated E2E terminal success before the rolling alias moves,
-   or record the explicit manual `report-only` override and blocker.
+9. Confirm exact correlated E2E terminal success before the rolling alias moves.
+   A failed, blocked, cancelled, or timed-out verifier leaves the alias unchanged.
 
 ## What changes the policy
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -80,9 +80,9 @@ rewrite an immutable tag or force-push.
 
 The composite action currently depends on:
 
-- `postman-cs/postman-bootstrap-action@v2.21.5`
-- `postman-cs/postman-repo-sync-action@v2.10.3`
-- `postman-cs/postman-smoke-flow-action@v3.7.3` when `flow-path` or `flow-mode` is set
+- `postman-cs/postman-bootstrap-action@v2.21.10`
+- `postman-cs/postman-repo-sync-action@v2.10.9`
+- `postman-cs/postman-smoke-flow-action@v3.7.4` when `flow-path` or `flow-mode` is set
 - `postman-cs/postman-insights-onboarding-action@v2.5.2` when Insights is enabled
 
 Because these are immutable sibling pins, a consumer who pins `postman-api-onboarding-action` to an immutable tag gets a reproducible lower-level action set at runtime.

--- a/action.yml
+++ b/action.yml
@@ -715,7 +715,7 @@ runs:
     - id: bootstrap
       name: Bootstrap Postman Assets
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-bootstrap-action@v2.21.5
+      uses: postman-cs/postman-bootstrap-action@v2.21.10
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
@@ -774,7 +774,7 @@ runs:
     - id: smoke_flow
       name: Apply Smoke flow
       if: ${{ inputs.onboarding-scope == 'full' && (inputs.flow-path != '' || inputs.flow-mode != '') && steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-smoke-flow-action@v3.7.3
+      uses: postman-cs/postman-smoke-flow-action@v3.7.4
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}
@@ -799,7 +799,7 @@ runs:
     - id: repo_sync
       name: Sync Repository and Workspace
       if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
-      uses: postman-cs/postman-repo-sync-action@v2.10.3
+      uses: postman-cs/postman-repo-sync-action@v2.10.9
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
         POSTMAN_BRANCH_DECISION: ${{ steps.branch_decision.outputs.branch-decision }}

--- a/action.yml
+++ b/action.yml
@@ -400,15 +400,226 @@ outputs:
 runs:
   using: composite
   steps:
+    - id: branch_decision
+      name: Resolve immutable branch decision
+      shell: bash
+      env:
+        BRANCH_STRATEGY: ${{ inputs.branch-strategy }}
+        CANONICAL_BRANCH: ${{ inputs.canonical-branch }}
+        CHANNELS: ${{ inputs.channels }}
+      run: |
+        node <<'NODE'
+        const fs = require('node:fs');
+        const MAX_EVENT_PAYLOAD_BYTES = 1 * 1024 * 1024;
+        const clean = (value) => typeof value === 'string' ? value.trim() || undefined : undefined;
+        const normalizeRepoName = (value) => {
+          const name = clean(value)?.toLowerCase();
+          return name && /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(name) ? name : undefined;
+        };
+        const fieldState = (value, normalize) => {
+          if (value === undefined || value === null || value === '') return { state: 'absent' };
+          const normalized = normalize(value);
+          return normalized === undefined ? { state: 'malformed' } : { state: 'valid', value: normalized };
+        };
+        const repoIdentity = (value) => {
+          if (!value || typeof value !== 'object') return undefined;
+          const id = fieldState(value.id, (candidate) => {
+            if (typeof candidate === 'number' && Number.isSafeInteger(candidate) && candidate > 0) return String(candidate);
+            return typeof candidate === 'string' && /^[1-9][0-9]*$/.test(candidate) ? candidate : undefined;
+          });
+          const fullName = fieldState(value.full_name, normalizeRepoName);
+          return { id, fullName };
+        };
+        const sameRepo = (left, right) => {
+          if (!left || !right) return false;
+          if (left.id.state !== 'absent' || right.id.state !== 'absent') {
+            if (left.id.state !== 'valid' || right.id.state !== 'valid' || left.id.value !== right.id.value) return false;
+            if (left.fullName.state === 'malformed' || right.fullName.state === 'malformed') return false;
+            return left.fullName.state !== 'valid' || right.fullName.state !== 'valid' || left.fullName.value === right.fullName.value;
+          }
+          return left.fullName.state === 'valid' && right.fullName.state === 'valid' && left.fullName.value === right.fullName.value;
+        };
+        const directPrEvents = new Set([
+          'pull_request',
+          'pull_request_target',
+          'pull_request_review',
+          'pull_request_review_comment'
+        ]);
+        const nestedPrEvents = new Set(['workflow_run', 'check_run', 'check_suite']);
+        const trustedNonPrEvents = new Set(['push', 'schedule', 'workflow_dispatch']);
+
+        const strategy = clean(process.env.BRANCH_STRATEGY) || 'legacy';
+        if (!['legacy', 'publish-gate', 'preview'].includes(strategy)) throw new Error('CONTRACT_BRANCH_STRATEGY_INVALID: expected legacy, publish-gate, or preview');
+        const eventName = clean(process.env.GITHUB_EVENT_NAME);
+        let event;
+        try {
+          const eventPath = clean(process.env.GITHUB_EVENT_PATH);
+          if (!eventPath) throw new Error('event path is missing');
+          const fd = fs.openSync(eventPath, 'r');
+          let payload;
+          try {
+            const stat = fs.fstatSync(fd);
+            if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_EVENT_PAYLOAD_BYTES) throw new Error('event payload size is invalid');
+            payload = Buffer.alloc(stat.size);
+            let offset = 0;
+            while (offset < payload.length) {
+              const count = fs.readSync(fd, payload, offset, payload.length - offset, offset);
+              if (count === 0) throw new Error('event payload changed while reading');
+              offset += count;
+            }
+            if (fs.readSync(fd, Buffer.alloc(1), 0, 1, payload.length) !== 0) throw new Error('event payload exceeds size cap');
+          } finally {
+            fs.closeSync(fd);
+          }
+          event = JSON.parse(payload.toString('utf8'));
+          if (!event || typeof event !== 'object' || Array.isArray(event)) event = undefined;
+        } catch {}
+        const rawRef = clean(process.env.GITHUB_REF) || clean(process.env.GITHUB_REF_NAME);
+        const envHeadBranch = clean(process.env.GITHUB_HEAD_REF);
+        const defaultBranch = clean(process.env.CANONICAL_BRANCH) || clean(event?.repository?.default_branch);
+        const workflowRepo = repoIdentity({
+          id: process.env.GITHUB_REPOSITORY_ID,
+          full_name: process.env.GITHUB_REPOSITORY
+        });
+        const eventRepo = repoIdentity(event?.repository);
+        const hasPrMarker = Boolean(
+          event && (
+            Object.prototype.hasOwnProperty.call(event, 'pull_request') ||
+            event.issue?.pull_request ||
+            event.merge_group
+          )
+        );
+        let isPrContext = Boolean(
+          envHeadBranch || hasPrMarker || directPrEvents.has(eventName) || nestedPrEvents.has(eventName)
+        );
+        let isForkPr = false;
+        let sameRepository = false;
+        let eventEligible = false;
+        let eventReason;
+        let headBranch;
+
+        if (!eventName) {
+          eventReason = 'event name is missing';
+        } else if (!event) {
+          eventReason = `event ${eventName} payload is missing or unreadable`;
+        } else if (!workflowRepo) {
+          eventReason = 'workflow repository identity is missing or malformed';
+        } else if (!eventRepo || !sameRepo(eventRepo, workflowRepo)) {
+          eventReason = `event ${eventName} repository does not match the workflow repository`;
+        } else if (trustedNonPrEvents.has(eventName)) {
+          if (isPrContext) {
+            eventReason = `event ${eventName} unexpectedly carries pull-request metadata`;
+          } else {
+            eventEligible = true;
+            sameRepository = true;
+            headBranch = rawRef?.startsWith('refs/heads/') ? rawRef.slice(11) : undefined;
+            eventReason = `trusted non-PR event ${eventName}`;
+          }
+        } else if (directPrEvents.has(eventName)) {
+          isPrContext = true;
+          const pullRequest = event.pull_request;
+          const headRepo = repoIdentity(pullRequest?.head?.repo);
+          const baseRepo = repoIdentity(pullRequest?.base?.repo);
+          const payloadHeadBranch = clean(pullRequest?.head?.ref);
+          if (!eventRepo || !headRepo || !baseRepo || !payloadHeadBranch) {
+            eventReason = `${eventName} repository or head-branch identity is missing or malformed`;
+          } else if (!sameRepo(baseRepo, eventRepo)) {
+            eventReason = `${eventName} base repository does not match the workflow repository`;
+          } else if (!sameRepo(headRepo, eventRepo)) {
+            isForkPr = true;
+            eventReason = `${eventName} head repository is not the workflow repository`;
+          } else if (envHeadBranch && envHeadBranch !== payloadHeadBranch) {
+            eventReason = `${eventName} head branch does not match GITHUB_HEAD_REF`;
+          } else {
+            eventEligible = true;
+            sameRepository = true;
+            headBranch = payloadHeadBranch;
+            eventReason = `same-repository ${eventName}`;
+          }
+        } else if (nestedPrEvents.has(eventName)) {
+          isPrContext = true;
+          const container = eventName === 'workflow_run' ? event.workflow_run : event[eventName];
+          const pullRequests = Array.isArray(container?.pull_requests) ? container.pull_requests : [];
+          if (!eventRepo || pullRequests.length !== 1) {
+            eventReason = `${eventName} requires exactly one pull request with repository identity`;
+          } else {
+            const pullRequest = pullRequests[0];
+            const headRepo = repoIdentity(pullRequest?.head?.repo);
+            const baseRepo = repoIdentity(pullRequest?.base?.repo);
+            const payloadHeadBranch = clean(pullRequest?.head?.ref);
+            if (!headRepo || !baseRepo || !payloadHeadBranch) {
+              eventReason = `${eventName} pull-request repository or head-branch identity is missing or malformed`;
+            } else if (!sameRepo(baseRepo, eventRepo)) {
+              eventReason = `${eventName} base repository does not match the workflow repository`;
+            } else if (!sameRepo(headRepo, eventRepo)) {
+              isForkPr = true;
+              eventReason = `${eventName} head repository is not the workflow repository`;
+            } else if (envHeadBranch && envHeadBranch !== payloadHeadBranch) {
+              eventReason = `${eventName} head branch does not match GITHUB_HEAD_REF`;
+            } else {
+              eventEligible = true;
+              sameRepository = true;
+              headBranch = payloadHeadBranch;
+              eventReason = `same-repository ${eventName}`;
+            }
+          }
+        } else {
+          eventReason = `event ${eventName} is not credential-eligible`;
+        }
+        if (isPrContext && !eventEligible) isForkPr = true;
+
+        let refKind = rawRef?.startsWith('refs/tags/') ? 'tag' : headBranch ? 'branch' : 'unknown';
+        if (headBranch && defaultBranch && headBranch === defaultBranch) refKind = 'default-branch';
+        const identity = {
+          provider: 'github',
+          eventName,
+          headBranch,
+          rawRef,
+          defaultBranch,
+          refKind,
+          isPrContext,
+          isForkPr,
+          sameRepository,
+          eventEligible,
+          headSha: clean(process.env.GITHUB_SHA)
+        };
+        const canonicalBranch = clean(process.env.CANONICAL_BRANCH) || defaultBranch;
+        let tier = 'gated';
+        let reason = `${eventReason}: credentials and mutations are ineligible`;
+        let channel;
+        if (eventEligible && strategy === 'legacy') {
+          tier = 'legacy';
+          reason = `${eventReason}; branch-strategy legacy: branch-blind pre-v2 behavior`;
+        } else if (eventEligible) {
+          if (!canonicalBranch) throw new Error('CONTRACT_DEFAULT_BRANCH_UNRESOLVED: set the canonical-branch input');
+          const rules = (clean(process.env.CHANNELS)?.split(',') || []).filter(Boolean).map((entry) => {
+            const parts = entry.split('=').map((part) => part.trim());
+            if (parts.length !== 2 || !parts[0] || !/^[A-Za-z][A-Za-z0-9_-]{0,15}$/.test(parts[1])) throw new Error(`CONTRACT_CHANNELS_INPUT_INVALID: ${entry}`);
+            return { pattern: parts[0], code: parts[1].toUpperCase() };
+          });
+          if (!rules.some((rule) => rule.pattern === 'release/*')) rules.push({ pattern: 'release/*', code: 'RC' });
+          channel = rules.find((rule) => rule.pattern.endsWith('*') ? headBranch?.startsWith(rule.pattern.slice(0, -1)) : headBranch === rule.pattern);
+          if (refKind === 'tag' || refKind === 'unknown' || !headBranch) { tier = 'gated'; reason = `ref kind ${refKind}: no-op`; }
+          else if (headBranch === canonicalBranch) { tier = 'canonical'; reason = `head branch equals canonical branch ${canonicalBranch}`; }
+          else if (channel) { tier = 'channel'; reason = `branch ${headBranch} matches channel ${channel.pattern}=${channel.code}`; }
+          else if (strategy === 'preview') { tier = 'preview'; reason = `branch ${headBranch} under branch-strategy preview`; }
+          else { tier = 'gated'; reason = `branch ${headBranch} under branch-strategy publish-gate`; }
+        }
+        const decision = { tier, strategy, identity, canonicalBranch, ...(channel && tier === 'channel' ? { channel } : {}), reason };
+        const serialized = JSON.stringify(decision);
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `tier=${tier}\nbranch-decision=${serialized}\n`);
+        fs.appendFileSync(process.env.GITHUB_ENV, `POSTMAN_BRANCH_DECISION=${serialized}\n`);
+        NODE
     - id: mask_postman_credentials
       name: Mask Postman credentials
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
       shell: bash
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
-        POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
-        POSTMAN_ACCESS_TOKEN: ${{ inputs.postman-access-token }}
-        INSIGHTS_POSTMAN_API_KEY: ${{ inputs.insights-postman-api-key }}
-        INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ inputs.insights-postman-access-token }}
+        POSTMAN_API_KEY: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
+        POSTMAN_ACCESS_TOKEN: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}
+        INSIGHTS_POSTMAN_API_KEY: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-api-key || '' }}
+        INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-access-token || '' }}
       run: |
         mask_secret() {
           local value="$1"
@@ -422,59 +633,9 @@ runs:
         mask_secret "$POSTMAN_ACCESS_TOKEN"
         mask_secret "$INSIGHTS_POSTMAN_API_KEY"
         mask_secret "$INSIGHTS_POSTMAN_ACCESS_TOKEN"
-    - id: branch_decision
-      name: Resolve immutable branch decision
-      shell: bash
-      env:
-        POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
-        BRANCH_STRATEGY: ${{ inputs.branch-strategy }}
-        CANONICAL_BRANCH: ${{ inputs.canonical-branch }}
-        CHANNELS: ${{ inputs.channels }}
-      run: |
-        node <<'NODE'
-        const fs = require('node:fs');
-        const clean = (value) => (value || '').trim() || undefined;
-        const strategy = clean(process.env.BRANCH_STRATEGY) || 'legacy';
-        if (!['legacy', 'publish-gate', 'preview'].includes(strategy)) throw new Error('CONTRACT_BRANCH_STRATEGY_INVALID: expected legacy, publish-gate, or preview');
-        let event = {};
-        try { event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')); } catch {}
-        const rawRef = clean(process.env.GITHUB_REF) || clean(process.env.GITHUB_REF_NAME);
-        const headBranch = clean(process.env.GITHUB_HEAD_REF) || (rawRef?.startsWith('refs/heads/') ? rawRef.slice(11) : undefined);
-        const defaultBranch = clean(process.env.CANONICAL_BRANCH) || clean(event.repository?.default_branch);
-        const isPrContext = Boolean(clean(process.env.GITHUB_HEAD_REF));
-        const headRepo = event.pull_request?.head?.repo?.full_name;
-        const baseRepo = event.pull_request?.base?.repo?.full_name || event.repository?.full_name;
-        const isForkPr = Boolean(headRepo && baseRepo && headRepo !== baseRepo);
-        let refKind = rawRef?.startsWith('refs/tags/') ? 'tag' : headBranch ? 'branch' : 'unknown';
-        if (headBranch && defaultBranch && headBranch === defaultBranch) refKind = 'default-branch';
-        const identity = { provider: 'github', headBranch, rawRef, defaultBranch, refKind, isPrContext, isForkPr, headSha: clean(process.env.GITHUB_SHA) };
-        const canonicalBranch = clean(process.env.CANONICAL_BRANCH) || defaultBranch;
-        let tier = 'legacy';
-        let reason = 'branch-strategy legacy: branch-blind pre-v2 behavior';
-        let channel;
-        if (strategy !== 'legacy') {
-          if (!canonicalBranch) throw new Error('CONTRACT_DEFAULT_BRANCH_UNRESOLVED: set the canonical-branch input');
-          const rules = (clean(process.env.CHANNELS)?.split(',') || []).filter(Boolean).map((entry) => {
-            const parts = entry.split('=').map((part) => part.trim());
-            if (parts.length !== 2 || !parts[0] || !/^[A-Za-z][A-Za-z0-9_-]{0,15}$/.test(parts[1])) throw new Error(`CONTRACT_CHANNELS_INPUT_INVALID: ${entry}`);
-            return { pattern: parts[0], code: parts[1].toUpperCase() };
-          });
-          if (!rules.some((rule) => rule.pattern === 'release/*')) rules.push({ pattern: 'release/*', code: 'RC' });
-          channel = rules.find((rule) => rule.pattern.endsWith('*') ? headBranch?.startsWith(rule.pattern.slice(0, -1)) : headBranch === rule.pattern);
-          if (refKind === 'tag' || refKind === 'unknown' || !headBranch) { tier = 'gated'; reason = `ref kind ${refKind}: no-op`; }
-          else if (isForkPr) { tier = 'gated'; reason = 'fork PR: credentialed tiers are ineligible'; }
-          else if (headBranch === canonicalBranch) { tier = 'canonical'; reason = `head branch equals canonical branch ${canonicalBranch}`; }
-          else if (channel) { tier = 'channel'; reason = `branch ${headBranch} matches channel ${channel.pattern}=${channel.code}`; }
-          else if (strategy === 'preview') { tier = 'preview'; reason = `branch ${headBranch} under branch-strategy preview`; }
-          else { tier = 'gated'; reason = `branch ${headBranch} under branch-strategy publish-gate`; }
-        }
-        const decision = { tier, strategy, identity, canonicalBranch, ...(channel && tier === 'channel' ? { channel } : {}), reason };
-        const serialized = JSON.stringify(decision);
-        fs.appendFileSync(process.env.GITHUB_OUTPUT, `tier=${tier}\nbranch-decision=${serialized}\n`);
-        fs.appendFileSync(process.env.GITHUB_ENV, `POSTMAN_BRANCH_DECISION=${serialized}\n`);
-        NODE
     - id: validate_postman_stack
       name: Validate Postman stack and region
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
       shell: bash
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
@@ -484,13 +645,13 @@ runs:
         SPEC_PATH: ${{ inputs.spec-path }}
         CREDENTIAL_PREFLIGHT: ${{ inputs.credential-preflight }}
         REPO_WRITE_MODE: ${{ inputs.repo-write-mode }}
-        POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
-        POSTMAN_ACCESS_TOKEN: ${{ inputs.postman-access-token }}
+        POSTMAN_API_KEY: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
+        POSTMAN_ACCESS_TOKEN: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}
         ENABLE_INSIGHTS: ${{ inputs.enable-insights }}
         ONBOARDING_SCOPE: ${{ inputs.onboarding-scope }}
         BRANCH_TIER: ${{ steps.branch_decision.outputs.tier }}
-        INSIGHTS_POSTMAN_API_KEY: ${{ inputs.insights-postman-api-key }}
-        INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ inputs.insights-postman-access-token }}
+        INSIGHTS_POSTMAN_API_KEY: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-api-key || '' }}
+        INSIGHTS_POSTMAN_ACCESS_TOKEN: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-access-token || '' }}
       run: |
         if [ -n "$WORKING_DIRECTORY" ]; then
           if ! node -e 'const fs=require("node:fs"),path=require("node:path");const workspace=fs.realpathSync(process.env.GITHUB_WORKSPACE);const target=path.resolve(workspace,process.env.WORKING_DIRECTORY);if(!fs.existsSync(target)||!fs.statSync(target).isDirectory())process.exit(1);const realTarget=fs.realpathSync(target);const relative=path.relative(workspace,realTarget);process.exit(relative===""||(!relative.startsWith(`..${path.sep}`)&&relative!==".."&&!path.isAbsolute(relative))?0:1)'; then
@@ -553,6 +714,7 @@ runs:
         fi
     - id: bootstrap
       name: Bootstrap Postman Assets
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' }}
       uses: postman-cs/postman-bootstrap-action@v2.21.5
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
@@ -598,8 +760,8 @@ runs:
         breaking-summary-path: ${{ inputs.breaking-summary-path }}
         breaking-log-path: ${{ inputs.breaking-log-path }}
         governance-mapping-json: ${{ inputs.governance-mapping-json }}
-        github-token: ${{ inputs.github-token }}
-        gh-fallback-token: ${{ inputs.gh-fallback-token }}
+        github-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.github-token || '' }}
+        gh-fallback-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.gh-fallback-token || '' }}
         postman-api-key: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
         postman-access-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}
         credential-preflight: ${{ inputs.credential-preflight }}
@@ -627,8 +789,8 @@ runs:
         flow-allow-delete: ${{ inputs.flow-allow-delete }}
         persist-derived-flow: ${{ inputs.persist-derived-flow }}
         spec-path: ${{ inputs.spec-path }}
-        postman-api-key: ${{ inputs.postman-api-key }}
-        postman-access-token: ${{ inputs.postman-access-token }}
+        postman-api-key: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
+        postman-access-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}
         postman-region: ${{ inputs.postman-region }}
         team-id: ${{ inputs.postman-team-id }}
         branch-strategy: ${{ inputs.branch-strategy }}
@@ -668,15 +830,15 @@ runs:
         current-ref: ${{ inputs.current-ref }}
         committer-name: ${{ inputs.committer-name }}
         committer-email: ${{ inputs.committer-email }}
-        postman-api-key: ${{ inputs.postman-api-key }}
-        postman-access-token: ${{ inputs.postman-access-token }}
+        postman-api-key: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
+        postman-access-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}
         credential-preflight: ${{ inputs.credential-preflight }}
         branch-strategy: ${{ inputs.branch-strategy }}
         canonical-branch: ${{ inputs.canonical-branch }}
         channels: ${{ inputs.channels }}
         preview-ttl: ${{ inputs.preview-ttl }}
-        github-token: ${{ inputs.github-token }}
-        gh-fallback-token: ${{ inputs.gh-fallback-token }}
+        github-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.github-token || '' }}
+        gh-fallback-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.gh-fallback-token || '' }}
         org-mode: ${{ inputs.org-mode }}
         integration-backend: ${{ inputs.integration-backend }}
         postman-region: ${{ inputs.postman-region }}
@@ -699,7 +861,7 @@ runs:
       # `postman login --with-api-key`, which has no access-token login path. When
       # postman-api-key is absent (access-token-primary runs), skip the tests with
       # a warning instead of failing the run.
-      if: ${{ inputs.onboarding-scope == 'full' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key == '' }}
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.onboarding-scope == 'full' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key == '' }}
       shell: bash
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
@@ -707,7 +869,7 @@ runs:
         echo "::warning::Skipping built-in smoke and contract tests: no postman-api-key was provided. The Postman CLI (postman login --with-api-key, then postman collection run) has no access-token login, so these tests require a PMAK. Provide postman-api-key to enable them, or set skip-built-in-tests: true to silence this warning."
     - id: install_postman_cli_windows
       name: Install Postman CLI on Windows
-      if: ${{ inputs.onboarding-scope == 'full' && runner.os == 'Windows' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key != '' }}
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.onboarding-scope == 'full' && runner.os == 'Windows' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key != '' }}
       shell: pwsh
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
@@ -723,12 +885,12 @@ runs:
         }
     - id: run_tests_junit
       name: Run smoke and contract collections with JUnit output
-      if: ${{ inputs.onboarding-scope == 'full' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key != '' }}
+      if: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.onboarding-scope == 'full' && steps.bootstrap.outputs.collections-json != '' && inputs.skip-built-in-tests != 'true' && inputs.postman-api-key != '' }}
       shell: bash
       continue-on-error: true
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
-        POSTMAN_API_KEY: ${{ inputs.postman-api-key }}
+        POSTMAN_API_KEY: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}
         POSTMAN_REGION: ${{ inputs.postman-region }}
         PROJECT_NAME: ${{ inputs.project-name }}
         COLLECTIONS_JSON: ${{ steps.bootstrap.outputs.collections-json }}
@@ -824,7 +986,7 @@ runs:
         fi
     - id: upload_junit_artifact
       name: Upload Postman JUnit results
-      if: always() && inputs.onboarding-scope == 'full' && inputs.skip-built-in-tests != 'true'
+      if: always() && steps.branch_decision.outputs.tier != 'gated' && inputs.onboarding-scope == 'full' && inputs.skip-built-in-tests != 'true'
       env:
         POSTMAN_TEAM_ID: ${{ inputs.postman-team-id }}
       uses: actions/upload-artifact@v7.0.1
@@ -845,13 +1007,13 @@ runs:
         environment-id: ${{ fromJSON(steps.repo_sync.outputs.environment-uids-json)[fromJSON(inputs.environments-json)[0]] }}
         system-environment-id: ${{ fromJSON(inputs.system-env-map-json)[fromJSON(inputs.environments-json)[0]] }}
         cluster-name: ${{ inputs.cluster-name }}
-        postman-api-key: ${{ inputs.insights-postman-api-key }}
-        postman-access-token: ${{ inputs.insights-postman-access-token }}
+        postman-api-key: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-api-key || '' }}
+        postman-access-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-access-token || '' }}
         credential-preflight: ${{ inputs.credential-preflight }}
         branch-strategy: ${{ inputs.branch-strategy }}
         canonical-branch: ${{ inputs.canonical-branch }}
         channels: ${{ inputs.channels }}
         postman-team-id: ${{ inputs.postman-team-id }}
-        github-token: ${{ inputs.github-token }}
+        github-token: ${{ steps.branch_decision.outputs.tier != 'gated' && inputs.github-token || '' }}
         postman-region: ${{ inputs.postman-region }}
         postman-stack: ${{ inputs.postman-stack }}

--- a/examples/monorepo-dispatcher.yml
+++ b/examples/monorepo-dispatcher.yml
@@ -41,8 +41,8 @@ jobs:
 
           record_service() {
             local service=$1 relative=$2 skip_onboard=$3
-            if [[ ! "$service" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
-              echo "Unsupported service directory name; use letters, digits, dots, underscores, or hyphens." >&2
+            if (( ${#service} > 100 )) || [[ ! "$service" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+              echo "Unsupported service directory name; use 1-100 letters, digits, dots, underscores, or hyphens." >&2
               exit 1
             fi
             [ -d "services/$service" ] || return 0
@@ -176,7 +176,12 @@ jobs:
           missing << 'environment' unless environment
           abort("Missing Postman resource IDs in .postman/resources.yaml: #{missing.join(', ')}") unless missing.empty?
           values = { 'POSTMAN_SMOKE_COLLECTION_UID' => smoke, 'POSTMAN_CONTRACT_COLLECTION_UID' => contract, 'POSTMAN_ENVIRONMENT_UID' => environment }
-          abort('Postman resource IDs must not contain CR or LF characters') if values.values.any? { |value| value.to_s.match?(/[\r\n]/) }
+          # Keep every env-file record single-line and constrain it to the
+          # public Postman UID shape used by collections and environments.
+          # Reject instead of normalizing so a malformed tracked receipt can
+          # never name a different cloud asset than the one under review.
+          uid_pattern = /\A[A-Za-z0-9][A-Za-z0-9._-]{0,255}\z/
+          abort('Postman resource IDs must be 1-256 safe ASCII identifier characters') unless values.values.all? { |value| value.is_a?(String) && value.match?(uid_pattern) }
           File.open(ENV.fetch('GITHUB_ENV'), 'a') do |file|
             values.each { |name, value| file.puts("#{name}=#{value}") }
           end

--- a/scripts/advance-pins.mjs
+++ b/scripts/advance-pins.mjs
@@ -1,27 +1,51 @@
 #!/usr/bin/env node
 /* global console, process */
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { compareSemver, parseLsRemoteLines } from './check-release-alias.mjs';
+import { compareSemver, parseLsRemoteLines, resolveTagCommit } from './check-release-alias.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const GITHUB_OWNER = 'postman-cs';
+const MAX_GITHUB_RESPONSE_BYTES = 2 * 1024 * 1024;
+const NETWORK_TIMEOUT_MS = 30_000;
 
 // Every file that carries an immutable sibling pin literal. action.yml is the
 // source of truth; the rest mirror it and are normalized on every run so docs
 // and contract tests can never drift from the manifest.
 export const PIN_FILES = ['action.yml', 'tests/contract.test.ts', 'RELEASE_POLICY.md', 'README.md'];
+export const PINNED_SIBLING_REPOSITORIES = Object.freeze([
+  'postman-bootstrap-action',
+  'postman-insights-onboarding-action',
+  'postman-repo-sync-action',
+  'postman-smoke-flow-action'
+]);
+export const EXPECTED_SIBLING_PACKAGE_NAMES = Object.freeze({
+  'postman-bootstrap-action': '@postman-cs/onboarding-bootstrap',
+  'postman-insights-onboarding-action': '@postman-cs/onboarding-insights',
+  'postman-repo-sync-action': '@postman-cs/onboarding-repo-sync',
+  'postman-smoke-flow-action': '@postman-cs/onboarding-smoke-flow'
+});
 
+const PINNED_SIBLING_SET = new Set(PINNED_SIBLING_REPOSITORIES);
 const USES_PIN = /uses:\s*postman-cs\/(postman-[a-z-]+-action)@(v\d+\.\d+\.\d+)/g;
 const IMMUTABLE_FULL = /^v(\d+)\.(\d+)\.(\d+)$/;
+const SHA1 = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+function trustedAssetApiUrl(repo, value) {
+  return typeof value === 'string' && new RegExp(
+    `^https://api\\.github\\.com/repos/${GITHUB_OWNER}/${repo}/releases/assets/[1-9][0-9]*$`
+  ).test(value);
+}
 
 /**
  * Extract the immutable sibling pins from the composite manifest.
- * The recorded major of each pin is the major of the pinned tag itself, so an
- * advance can never cross a major boundary: majors move only through a
- * reviewed commit, per RELEASE_POLICY.md.
+ * The repository allowlist is deliberately closed so a manifest edit cannot
+ * make scheduled automation contact or select an unreviewed sibling.
  * @param {string} actionYamlText
  * @returns {Array<{ repo: string, tag: string, major: number }>}
  */
@@ -30,6 +54,9 @@ export function extractPins(actionYamlText) {
   const pins = new Map();
   for (const match of String(actionYamlText).matchAll(USES_PIN)) {
     const [, repo, tag] = match;
+    if (!PINNED_SIBLING_SET.has(repo)) {
+      throw new Error(`unexpected sibling repository in action.yml: ${repo}`);
+    }
     const parts = tag.match(IMMUTABLE_FULL);
     if (!parts) continue;
     const existing = pins.get(repo);
@@ -38,37 +65,174 @@ export function extractPins(actionYamlText) {
     }
     pins.set(repo, { repo, tag, major: Number(parts[1]) });
   }
+  const missing = PINNED_SIBLING_REPOSITORIES.filter((repo) => !pins.has(repo));
+  if (missing.length > 0) {
+    throw new Error(`action.yml is missing required immutable sibling pins: ${missing.join(', ')}`);
+  }
   return [...pins.values()];
 }
 
 /**
- * Pick the newest immutable vX.Y.Z tag of the given major.
- * @param {Iterable<string>} tagNames
- * @param {number} major
- * @returns {string | null}
+ * Resolve one promoted immutable full tag from the rolling major alias.
+ * Newer immutable tags that do not match the alias are intentionally ignored:
+ * publication alone is not promotion evidence.
+ * @param {{ repo: string, major: number, lsRemoteText: string }} input
+ * @returns {{ repo: string, tag: string, commit: string }}
  */
-export function latestImmutableForMajor(tagNames, major) {
-  let latest = null;
-  for (const name of tagNames) {
-    const parts = name.match(IMMUTABLE_FULL);
-    if (!parts || Number(parts[1]) !== major) continue;
-    if (latest === null || compareSemver(name, latest) > 0) latest = name;
+export function selectPromotedImmutable({ repo, major, lsRemoteText }) {
+  if (!PINNED_SIBLING_SET.has(repo)) throw new Error(`unexpected sibling repository: ${repo}`);
+  if (!Number.isSafeInteger(major) || major <= 0) throw new Error(`invalid recorded major for ${repo}`);
+  const tags = parseLsRemoteLines(lsRemoteText);
+  const alias = `v${major}`;
+  const aliasCommit = resolveTagCommit(tags, alias);
+  if (!aliasCommit || !SHA1.test(aliasCommit)) {
+    throw new Error(`${repo}: promoted rolling alias ${alias} is missing or malformed`);
   }
-  return latest;
+
+  const matches = [];
+  for (const name of tags.keys()) {
+    const version = name.match(IMMUTABLE_FULL);
+    if (!version || Number(version[1]) !== major) continue;
+    if (resolveTagCommit(tags, name) === aliasCommit) matches.push(name);
+  }
+  const unique = [...new Set(matches)];
+  if (unique.length !== 1) {
+    throw new Error(
+      `${repo}: rolling alias ${alias} must resolve to exactly one immutable v${major}.x.y tag; found ${unique.length}`
+    );
+  }
+  return { repo, tag: unique[0], commit: aliasCommit };
 }
 
 /**
- * Decide which pins move, holding each inside its recorded major.
- * @param {Array<{ repo: string, tag: string, major: number }>} pins
- * @param {Map<string, Iterable<string>>} tagsByRepo
- * @returns {Array<{ repo: string, from: string, to: string }>}
+ * Validate the GitHub Release and its immutable release-manifest asset against
+ * the promoted tag/commit selected from Git refs.
+ * @param {{
+ *   repo: string,
+ *   promoted: { tag: string, commit: string },
+ *   release: Record<string, unknown>,
+ *   manifest: Record<string, unknown>,
+ *   manifestDigest: string
+ * }} input
+ * @returns {{ repo: string, tag: string, commit: string, releaseId: number, artifactDigest: string }}
  */
-export function planAdvance(pins, tagsByRepo) {
+export function validateReleaseIdentity({ repo, promoted, release, manifest, manifestDigest }) {
+  if (!PINNED_SIBLING_SET.has(repo)) throw new Error(`unexpected sibling repository: ${repo}`);
+  if (!IMMUTABLE_FULL.test(promoted?.tag ?? '') || !SHA1.test(promoted?.commit ?? '')) {
+    throw new Error(`${repo}: promoted tag identity is malformed`);
+  }
+  if (!release || typeof release !== 'object' || Array.isArray(release)) {
+    throw new Error(`${repo}@${promoted.tag}: GitHub Release response is malformed`);
+  }
+  if (
+    !Number.isSafeInteger(release.id) ||
+    release.id <= 0 ||
+    release.tag_name !== promoted.tag ||
+    release.draft !== false ||
+    release.prerelease !== false
+  ) {
+    throw new Error(`${repo}@${promoted.tag}: GitHub Release identity does not match the promoted tag`);
+  }
+
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const manifestAssets = assets.filter((asset) => asset?.name === 'release-manifest.json');
+  const tarballAssets = assets.filter((asset) => asset?.name === 'release.tgz');
+  if (manifestAssets.length !== 1 || tarballAssets.length !== 1) {
+    throw new Error(`${repo}@${promoted.tag}: release must contain exactly one manifest and release.tgz asset`);
+  }
+  for (const asset of [...manifestAssets, ...tarballAssets]) {
+    if (
+      asset.state !== 'uploaded' ||
+      !Number.isSafeInteger(asset.size) ||
+      asset.size <= 0 ||
+      !trustedAssetApiUrl(repo, asset.url) ||
+      typeof asset.digest !== 'string' ||
+      !/^sha256:[a-f0-9]{64}$/.test(asset.digest)
+    ) {
+      throw new Error(`${repo}@${promoted.tag}: required release asset identity is incomplete`);
+    }
+  }
+  const manifestAsset = manifestAssets[0];
+  const tarballAsset = tarballAssets[0];
+  if (!SHA256.test(manifestDigest ?? '') || manifestAsset.digest !== `sha256:${manifestDigest}`) {
+    throw new Error(`${repo}@${promoted.tag}: downloaded release manifest digest does not match its asset identity`);
+  }
+
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error(`${repo}@${promoted.tag}: release manifest is malformed`);
+  }
+  const expectedRepository = `${GITHUB_OWNER}/${repo}`;
+  if (
+    manifest.schema_version !== 1 ||
+    manifest.repository !== expectedRepository ||
+    manifest.tag !== promoted.tag ||
+    manifest.commit_sha !== promoted.commit ||
+    manifest.package_version !== promoted.tag.slice(1) ||
+    manifest.package_name !== EXPECTED_SIBLING_PACKAGE_NAMES[repo]
+  ) {
+    throw new Error(`${repo}@${promoted.tag}: release manifest identity does not match the promoted ref`);
+  }
+
+  const artifacts = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
+  const paths = new Set();
+  for (const artifact of artifacts) {
+    if (
+      !artifact ||
+      typeof artifact !== 'object' ||
+      typeof artifact.path !== 'string' ||
+      !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(artifact.path) ||
+      typeof artifact.sha256 !== 'string' ||
+      !SHA256.test(artifact.sha256) ||
+      paths.has(artifact.path)
+    ) {
+      throw new Error(`${repo}@${promoted.tag}: release manifest artifact identity is malformed`);
+    }
+    paths.add(artifact.path);
+  }
+  const releaseTarball = artifacts.find((artifact) => artifact.path === 'release.tgz');
+  if (!releaseTarball) {
+    throw new Error(`${repo}@${promoted.tag}: release manifest does not identify release.tgz`);
+  }
+  if (tarballAsset.digest !== `sha256:${releaseTarball.sha256}`) {
+    throw new Error(`${repo}@${promoted.tag}: release.tgz manifest digest does not match its asset identity`);
+  }
+  return {
+    repo,
+    tag: promoted.tag,
+    commit: promoted.commit,
+    releaseId: release.id,
+    artifactDigest: releaseTarball.sha256
+  };
+}
+
+/**
+ * Decide which pins move, holding each inside its recorded major and refusing
+ * to regress a pin that is unexpectedly ahead of the promoted alias.
+ * @param {Array<{ repo: string, tag: string, major: number }>} pins
+ * @param {Map<string, { repo: string, tag: string, commit: string, releaseId: number, artifactDigest: string }>} promotedByRepo
+ * @returns {Array<{ repo: string, from: string, to: string, commit: string, artifactDigest: string }>}
+ */
+export function planAdvance(pins, promotedByRepo) {
   const plan = [];
   for (const { repo, tag, major } of pins) {
-    const latest = latestImmutableForMajor(tagsByRepo.get(repo) ?? [], major);
-    if (latest && compareSemver(latest, tag) > 0) {
-      plan.push({ repo, from: tag, to: latest });
+    const promoted = promotedByRepo.get(repo);
+    if (!promoted) throw new Error(`${repo}: verified promoted release identity is missing`);
+    const parts = promoted.tag.match(IMMUTABLE_FULL);
+    if (!parts || Number(parts[1]) !== major) {
+      throw new Error(`${repo}: promoted tag ${promoted.tag} crossed recorded major v${major}`);
+    }
+    const order = compareSemver(promoted.tag, tag);
+    if (order < 0) {
+      throw new Error(`${repo}: current pin ${tag} is ahead of promoted alias target ${promoted.tag}`);
+    }
+    if (order > 0) {
+      plan.push({
+        repo,
+        from: tag,
+        to: promoted.tag,
+        commit: promoted.commit,
+        artifactDigest: promoted.artifactDigest
+      });
     }
   }
   return plan;
@@ -87,30 +251,110 @@ export function rewritePinLiterals(text, repo, to) {
   return text.replace(literal, `postman-cs/${repo}@${to}`);
 }
 
-function lsRemoteTags(repo) {
-  const remote = `https://github.com/postman-cs/${repo}.git`;
-  const output = execFileSync('git', ['ls-remote', '--tags', remote], { encoding: 'utf8' });
-  return [...parseLsRemoteLines(output).keys()];
+function lsRemoteTags(repo, major) {
+  const remote = `https://github.com/${GITHUB_OWNER}/${repo}.git`;
+  return execFileSync(
+    'git',
+    [
+      'ls-remote',
+      '--tags',
+      remote,
+      `refs/tags/v${major}`,
+      `refs/tags/v${major}^{}`,
+      `refs/tags/v${major}.*`,
+      `refs/tags/v${major}.*^{}`
+    ],
+    { encoding: 'utf8', maxBuffer: MAX_GITHUB_RESPONSE_BYTES, timeout: NETWORK_TIMEOUT_MS }
+  );
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const dryRun = process.argv.includes('--dry-run');
-  const manifest = readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
-  const pins = extractPins(manifest);
-  if (pins.length === 0) {
-    console.error('No immutable sibling pins found in action.yml');
-    process.exit(1);
+function githubApiJson(endpoint) {
+  const text = execFileSync('gh', ['api', endpoint], {
+    encoding: 'utf8',
+    maxBuffer: MAX_GITHUB_RESPONSE_BYTES,
+    timeout: NETWORK_TIMEOUT_MS
+  });
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`GitHub API returned unreadable JSON for ${endpoint}`);
+  }
+}
+
+function fetchReleaseEnvelope(repo, tag) {
+  const release = githubApiJson(`repos/${GITHUB_OWNER}/${repo}/releases/tags/${tag}`);
+  const manifestAssets = Array.isArray(release?.assets)
+    ? release.assets.filter((asset) => asset?.name === 'release-manifest.json')
+    : [];
+  if (manifestAssets.length !== 1) {
+    throw new Error(`${repo}@${tag}: GitHub Release does not expose exactly one release-manifest.json asset`);
+  }
+  const assetUrl = manifestAssets[0]?.url;
+  if (!trustedAssetApiUrl(repo, assetUrl)) {
+    throw new Error(`${repo}@${tag}: release manifest asset URL is not a trusted GitHub API URL`);
+  }
+  const bytes = execFileSync('gh', ['api', '-H', 'Accept: application/octet-stream', assetUrl], {
+    maxBuffer: MAX_GITHUB_RESPONSE_BYTES,
+    timeout: NETWORK_TIMEOUT_MS
+  });
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw new Error(`${repo}@${tag}: release-manifest.json is unreadable`);
+  }
+  const manifestDigest = createHash('sha256').update(bytes).digest('hex');
+  return { release, manifest, manifestDigest };
+}
+
+function main() {
+  const check = process.argv.includes('--check');
+  const dryRun = check || process.argv.includes('--dry-run');
+  const manifestText = readFileSync(path.join(repoRoot, 'action.yml'), 'utf8');
+  const pins = extractPins(manifestText);
+  const promotedByRepo = new Map();
+  for (const pin of pins) {
+    const promoted = selectPromotedImmutable({
+      repo: pin.repo,
+      major: pin.major,
+      lsRemoteText: lsRemoteTags(pin.repo, pin.major)
+    });
+    const envelope = fetchReleaseEnvelope(pin.repo, promoted.tag);
+    const verified = validateReleaseIdentity({
+      repo: pin.repo,
+      promoted,
+      release: envelope.release,
+      manifest: envelope.manifest,
+      manifestDigest: envelope.manifestDigest
+    });
+    const confirmed = selectPromotedImmutable({
+      repo: pin.repo,
+      major: pin.major,
+      lsRemoteText: lsRemoteTags(pin.repo, pin.major)
+    });
+    if (confirmed.tag !== promoted.tag || confirmed.commit !== promoted.commit) {
+      throw new Error(`${pin.repo}: promoted alias changed while its release identity was being verified`);
+    }
+    promotedByRepo.set(pin.repo, verified);
   }
 
-  const tagsByRepo = new Map(pins.map(({ repo }) => [repo, lsRemoteTags(repo)]));
-  const plan = planAdvance(pins, tagsByRepo);
+  const plan = planAdvance(pins, promotedByRepo);
+  if (check && plan.length > 0) {
+    throw new Error(
+      `sibling pins do not match verified promoted releases: ${plan.map(({ repo, from, to }) => `${repo} ${from} -> ${to}`).join(', ')}`
+    );
+  }
   const targets = new Map(pins.map(({ repo, tag }) => [repo, tag]));
   for (const { repo, to } of plan) targets.set(repo, to);
 
-  for (const { repo, from, to } of plan) {
-    console.log(`advance ${repo}: ${from} -> ${to}`);
+  for (const { repo, from, to, commit, artifactDigest } of plan) {
+    console.log(
+      `advance ${repo}: ${from} -> ${to} (commit ${commit.slice(0, 12)}, release.tgz sha256 ${artifactDigest.slice(0, 12)}...)`
+    );
   }
-  if (plan.length === 0) console.log('All sibling pins are already at the newest tag of their majors.');
+  if (plan.length === 0) {
+    console.log('All sibling pins already match their verified promoted rolling aliases.');
+  }
 
   let wroteNormalization = false;
   for (const file of PIN_FILES) {
@@ -121,6 +365,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       after = rewritePinLiterals(after, repo, to);
     }
     if (after === before) continue;
+    if (check) throw new Error(`${file} contains stale sibling pin literals`);
     if (plan.length === 0) wroteNormalization = true;
     if (dryRun) {
       console.log(`would update ${file}`);
@@ -131,5 +376,14 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   }
   if (wroteNormalization) {
     console.log('Normalized stale pin literals to the pins recorded in action.yml.');
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
   }
 }

--- a/scripts/advance-pins.mjs
+++ b/scripts/advance-pins.mjs
@@ -16,7 +16,15 @@ const NETWORK_TIMEOUT_MS = 30_000;
 // Every file that carries an immutable sibling pin literal. action.yml is the
 // source of truth; the rest mirror it and are normalized on every run so docs
 // and contract tests can never drift from the manifest.
-export const PIN_FILES = ['action.yml', 'tests/contract.test.ts', 'RELEASE_POLICY.md', 'README.md'];
+export const PIN_FILES = [
+  'action.yml',
+  '.github/workflows/release.yml',
+  'scripts/verify-e2e-release.test.mjs',
+  'tests/contract.test.ts',
+  'tests/release-workflow.test.ts',
+  'RELEASE_POLICY.md',
+  'README.md'
+];
 export const PINNED_SIBLING_REPOSITORIES = Object.freeze([
   'postman-bootstrap-action',
   'postman-insights-onboarding-action',
@@ -247,8 +255,14 @@ export function planAdvance(pins, promotedByRepo) {
  * @returns {string}
  */
 export function rewritePinLiterals(text, repo, to) {
-  const literal = new RegExp(`postman-cs/${repo}@v\\d+\\.\\d+\\.\\d+`, 'g');
-  return text.replace(literal, `postman-cs/${repo}@${to}`);
+  const actionLiteral = new RegExp(`postman-cs/${repo}@v\\d+\\.\\d+\\.\\d+`, 'g');
+  const peerMapLiteral = new RegExp(
+    `(["']postman-cs/${repo}["']\\s*:\\s*["'])v\\d+\\.\\d+\\.\\d+(["'])`,
+    'g'
+  );
+  return text
+    .replace(actionLiteral, `postman-cs/${repo}@${to}`)
+    .replace(peerMapLiteral, `$1${to}$2`);
 }
 
 function lsRemoteTags(repo, major) {

--- a/scripts/check-sibling-pins.mjs
+++ b/scripts/check-sibling-pins.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { TextDecoder } from 'node:util';
 import { parse } from 'yaml';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -47,6 +48,8 @@ export const REPO_SYNC_SUMMARY_GATED_KEYS = ['status', 'reason'];
 
 /** Upper bound for git ls-remote and raw.githubusercontent.com fetches in main(). */
 export const SIBLING_PIN_NETWORK_TIMEOUT_MS = 30_000;
+/** Upper bound for each decoded sibling action/source response. */
+export const SIBLING_PIN_MAX_SOURCE_BYTES = 2 * 1024 * 1024;
 
 /**
  * @param {string} repo
@@ -72,6 +75,53 @@ export function gitTagExistsExecOptions(timeoutMs = SIBLING_PIN_NETWORK_TIMEOUT_
  */
 export function pinnedFileFetchInit(timeoutMs = SIBLING_PIN_NETWORK_TIMEOUT_MS) {
   return { signal: globalThis.AbortSignal.timeout(timeoutMs) };
+}
+
+/**
+ * Consume a Fetch response without ever buffering more than maxBytes. A
+ * Content-Length check rejects obvious oversize responses early, while the
+ * streaming count remains authoritative for missing, compressed, or false
+ * length headers.
+ * @param {Response} response
+ * @param {number} [maxBytes]
+ * @returns {Promise<string>}
+ */
+export async function readBoundedResponseText(response, maxBytes = SIBLING_PIN_MAX_SOURCE_BYTES) {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) throw new Error('sibling source byte cap must be positive');
+  const declaredLength = response.headers.get('content-length');
+  if (declaredLength !== null) {
+    if (!/^(0|[1-9][0-9]*)$/.test(declaredLength)) throw new Error('sibling source Content-Length is malformed');
+    if (Number(declaredLength) > maxBytes) throw new Error(`sibling source exceeds ${maxBytes} bytes`);
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('sibling source response has no readable body');
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let byteCount = 0;
+  let text = '';
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteCount += value.byteLength;
+      if (byteCount > maxBytes) {
+        try {
+          await reader.cancel('sibling source byte cap exceeded');
+        } catch {
+          // Preserve the deterministic size violation if stream cancellation fails.
+        }
+        throw new Error(`sibling source exceeds ${maxBytes} bytes`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error('sibling source is not valid UTF-8', { cause: error });
+    }
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 /**
@@ -448,7 +498,7 @@ async function fetchPinnedFile(repo, tag, filePath) {
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
   }
-  return response.text();
+  return readBoundedResponseText(response);
 }
 
 async function main() {

--- a/scripts/verify-e2e-release.mjs
+++ b/scripts/verify-e2e-release.mjs
@@ -1,28 +1,57 @@
 #!/usr/bin/env node
 
 import { Buffer } from 'node:buffer';
-import { appendFile } from 'node:fs/promises';
-import process from 'node:process';
+import { createHash } from 'node:crypto';
+import { appendFileSync } from 'node:fs';
 import { pathToFileURL, URLSearchParams } from 'node:url';
+import { TextDecoder } from 'node:util';
+import { inflateRawSync } from 'node:zlib';
+import process from 'node:process';
 
 export const GITHUB_API_VERSION = '2022-11-28';
-export const DEFAULT_E2E_REPOSITORY = 'postman-cs/postman-actions-e2e';
-export const DEFAULT_E2E_WORKFLOW = 'e2e.yml';
-export const DEFAULT_E2E_WORKFLOW_REF = 'main';
 export const DEFAULT_DISPATCH_TIMEOUT_MS = 30_000;
 export const DEFAULT_LOOKUP_TIMEOUT_MS = 120_000;
-export const DEFAULT_VERIFICATION_TIMEOUT_MS = 45 * 60 * 1000;
-export const DEFAULT_INITIAL_POLL_MS = 2_000;
+export const DEFAULT_VERIFICATION_TIMEOUT_MS = 30 * 60_000;
+export const DEFAULT_INITIAL_POLL_MS = 5_000;
 export const DEFAULT_MAX_POLL_MS = 30_000;
-export const SUPPORTED_SUITES = new Set(['smoke', 'full', 'branch-aware']);
+export const RELEASE_EVIDENCE_MAX_BYTES = 32 * 1024;
+export const RESULT_ARCHIVE_MAX_BYTES = 256 * 1024;
+export const REDACTED_TOKEN_MARKER = '[REDACTED]';
 
-const TERMINAL_OUTCOMES = new Map([
-  ['success', 'success'],
-  ['failure', 'failure'],
-  ['cancelled', 'cancelled'],
-  ['timed_out', 'timed_out']
+const E2E_REPOSITORY = 'postman-cs/postman-actions-e2e';
+const E2E_WORKFLOW = 'e2e.yml';
+const RELEASE_REPOSITORY = 'postman-cs/postman-api-onboarding-action';
+const RELEASE_ACTION = 'postman-api-onboarding-action';
+const COMPOSITE_REPOSITORY = 'postman-cs/postman-api-onboarding-action';
+const INSIGHTS_REPOSITORY = 'postman-cs/postman-insights-onboarding-action';
+const ACTION_REPOSITORIES = Object.freeze([
+  COMPOSITE_REPOSITORY,
+  'postman-cs/postman-repo-sync-action',
+  INSIGHTS_REPOSITORY,
+  'postman-cs/postman-bootstrap-action',
+  'postman-cs/postman-resolve-service-token-action',
+  'postman-cs/postman-smoke-flow-action'
 ]);
+const PEER_REPOSITORIES = Object.freeze(
+  ACTION_REPOSITORIES.filter((repository) => repository !== RELEASE_REPOSITORY)
+);
+const SHA = /^[a-f0-9]{40}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const ACTION_TAG = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+const PROVIDER_TAG = /^e2e-provider-v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+const PATH_SEGMENT = /^[A-Za-z0-9_.-]+$/;
+const RUN_ID = /^[1-9]\d{0,19}$/;
+const CORRELATION_ID = /^[A-Za-z0-9_.-]{1,200}$/;
 const PENDING_STATUSES = new Set(['queued', 'in_progress', 'waiting', 'requested', 'pending']);
+const TOP_LEVEL_RESULT_KEYS = Object.freeze([
+  'manifestDigest',
+  'outcome',
+  'provider',
+  'release',
+  'run',
+  'schemaVersion',
+  'suite'
+]);
 
 export class ReleaseVerificationError extends Error {
   constructor(code, message, details = {}) {
@@ -33,50 +62,109 @@ export class ReleaseVerificationError extends Error {
   }
 }
 
-function requireEnv(env, name) {
-  const value = env[name]?.trim();
-  if (!value) throw new ReleaseVerificationError('blocked', `Missing required environment variable ${name}`);
-  return value;
+function fail(code, message, details = {}) {
+  throw new ReleaseVerificationError(code, message, details);
+}
+
+function plain(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value, expected) {
+  if (!plain(value)) return false;
+  const actual = Object.keys(value).sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function sorted(value) {
+  if (Array.isArray(value)) return value.map(sorted);
+  if (!plain(value)) return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sorted(value[key])]));
+}
+
+export function canonicalJsonStringify(value) {
+  return `${JSON.stringify(sorted(value))}\n`;
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function redactTokenOccurrences(text, token) {
+  const source = text == null ? '' : String(text);
+  return token ? source.split(token).join(REDACTED_TOKEN_MARKER) : source;
+}
+
+function requireNonEmpty(value, name) {
+  const normalized = value?.trim();
+  if (!normalized) fail('blocked', `${name} is required`);
+  return normalized;
 }
 
 function parsePositiveInteger(value, fallback, name) {
-  if (value === undefined || value === '') return fallback;
+  if (value == null || String(value).trim() === '') return fallback;
   const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new ReleaseVerificationError('blocked', `${name} must be a positive integer`);
-  }
+  if (!Number.isInteger(parsed) || parsed <= 0) fail('blocked', `${name} must be a positive integer`);
   return parsed;
 }
 
-function sanitize(value, fallback) {
-  const cleaned = value.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 96);
-  return cleaned || fallback;
+function strictUtf8(bytes, code, message) {
+  try {
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    if (text.charCodeAt(0) === 0xfeff) fail(code, message);
+    return text;
+  } catch (error) {
+    if (error instanceof ReleaseVerificationError) throw error;
+    return fail(code, message);
+  }
 }
 
-function redact(message, secrets = []) {
-  let safe = String(message ?? '');
-  for (const secret of secrets.filter(Boolean)) safe = safe.split(secret).join('[REDACTED]');
-  return safe;
+function parseCanonicalJson(bytes, maxBytes, code, label) {
+  const buffer = Buffer.from(bytes);
+  if (buffer.length === 0 || buffer.length > maxBytes) {
+    fail(code, `${label} must contain 1..${maxBytes} bytes`);
+  }
+  const text = strictUtf8(buffer, code, `${label} must be valid UTF-8 without a BOM`);
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return fail(code, `${label} must be valid JSON`);
+  }
+  if (canonicalJsonStringify(value) !== text) {
+    fail(code, `${label} must be canonical JSON with no duplicate or unordered keys`);
+  }
+  return value;
 }
 
-function apiHeaders(token) {
-  return {
-    Accept: 'application/vnd.github+json',
-    Authorization: `Bearer ${token}`,
-    'Content-Type': 'application/json',
-    'X-GitHub-Api-Version': GITHUB_API_VERSION
-  };
+export function parsePeerTags(raw) {
+  const text = requireNonEmpty(raw, 'E2E_GATE_PEER_TAGS');
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return fail('blocked', 'E2E_GATE_PEER_TAGS must be canonical JSON');
+  }
+  if (!exactKeys(value, [...PEER_REPOSITORIES].sort())) {
+    fail('blocked', 'E2E_GATE_PEER_TAGS must contain the exact five-repository peer census');
+  }
+  for (const repository of PEER_REPOSITORIES) {
+    if (!ACTION_TAG.test(value[repository])) {
+      fail('blocked', `E2E_GATE_PEER_TAGS has a non-immutable tag for ${repository}`);
+    }
+  }
+  if (canonicalJsonStringify(value).trimEnd() !== text) {
+    fail('blocked', 'E2E_GATE_PEER_TAGS must use canonical key ordering');
+  }
+  return value;
 }
 
-export function buildCorrelationId({ repository, runId, runAttempt, refName, sourceDigest }) {
-  const repositoryName = repository.split('/').at(-1) ?? repository;
-  return [
-    sanitize(repositoryName, 'release'),
-    sanitize(runId, 'run'),
-    sanitize(runAttempt, 'attempt'),
-    sanitize(refName, 'ref'),
-    sourceDigest.slice(0, 16)
-  ].join('-');
+export function buildCorrelationId({ repository, runId, runAttempt, refName, manifestDigest }) {
+  if (!SHA256.test(manifestDigest)) fail('blocked', 'release manifest digest must be lowercase sha256');
+  return `${repository}-${runId}-${runAttempt}-${refName}-${manifestDigest.slice(0, 16)}`.replace(
+    /[^A-Za-z0-9_.-]+/g,
+    '-'
+  );
 }
 
 export function expectedRunTitle({ action, refName, correlationId }) {
@@ -88,474 +176,1089 @@ export function buildDispatchInputs({
   refName,
   correlationId,
   suite,
-  registryRevision,
-  contractScenarios
+  manifestBytes,
+  manifestDigest
 }) {
-  const inputs = {
+  if (
+    action !== RELEASE_ACTION ||
+    !ACTION_TAG.test(refName) ||
+    !CORRELATION_ID.test(correlationId) ||
+    suite !== 'full'
+  ) {
+    fail('blocked', 'release dispatch tuple is invalid');
+  }
+  if (!SHA256.test(manifestDigest)) fail('blocked', 'release manifest digest must be lowercase sha256');
+  const bytes = Buffer.from(manifestBytes);
+  if (bytes.length === 0 || bytes.length > RELEASE_EVIDENCE_MAX_BYTES) {
+    fail('blocked', 'release manifest bytes are outside the provider limit');
+  }
+  return {
     action,
     ref: refName,
     gate_correlation_id: correlationId,
+    release_manifest_base64: bytes.toString('base64'),
+    release_manifest_sha256: manifestDigest,
     suite
   };
-  if (registryRevision) inputs.registry_revision = registryRevision;
-  if (contractScenarios) inputs.contract_scenarios = contractScenarios;
-  return inputs;
 }
 
-export function buildDispatchPayload(config) {
+export function buildDispatchPayload(input) {
+  if (!PROVIDER_TAG.test(input.providerTag)) fail('blocked', 'provider workflow ref must be immutable');
   return {
-    ref: config.workflowRef,
+    ref: input.providerTag,
     return_run_details: true,
-    inputs: buildDispatchInputs(config)
+    inputs: buildDispatchInputs(input)
   };
 }
 
-export function parseDispatchRunDetails(status, body) {
-  if (status === 204 || !body.trim()) return null;
-  let parsed;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    throw new ReleaseVerificationError('dispatch_error', 'Verifier dispatch returned unreadable run details');
+export function buildDispatchUrl(targetRepository, workflow) {
+  if (targetRepository !== E2E_REPOSITORY || workflow !== E2E_WORKFLOW) {
+    fail('blocked', 'E2E target must be the fixed provider repository and workflow');
   }
-  const workflowRunId = parsed.workflow_run_id ?? parsed.workflow_run?.id ?? parsed.run_id ?? parsed.id;
-  if (workflowRunId === undefined || workflowRunId === null) {
-    throw new ReleaseVerificationError('dispatch_error', 'Verifier dispatch response omitted workflow run ID');
+  const [owner, repo] = targetRepository.split('/');
+  return `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(workflow)}/dispatches`;
+}
+
+function githubHeaders(token, accept = 'application/vnd.github+json') {
+  return {
+    Accept: accept,
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': GITHUB_API_VERSION
+  };
+}
+
+async function readBoundedResponse(response, maxBytes, code, operation) {
+  const contentLength = response.headers?.get?.('content-length');
+  if (contentLength != null && contentLength !== '') {
+    const parsed = Number(contentLength);
+    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > maxBytes) {
+      fail(code, `${operation} response exceeds ${maxBytes} bytes`);
+    }
+  }
+  const chunks = [];
+  let size = 0;
+  if (response.body?.getReader) {
+    const reader = response.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = Buffer.from(value);
+      size += chunk.length;
+      if (size > maxBytes) {
+        await reader.cancel().catch(() => {});
+        fail(code, `${operation} response exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(chunk);
+    }
+  } else if (typeof response.arrayBuffer === 'function') {
+    const chunk = Buffer.from(await response.arrayBuffer());
+    if (chunk.length > maxBytes) fail(code, `${operation} response exceeds ${maxBytes} bytes`);
+    chunks.push(chunk);
+  } else if (typeof response.text === 'function') {
+    const chunk = Buffer.from(await response.text(), 'utf8');
+    if (chunk.length > maxBytes) fail(code, `${operation} response exceeds ${maxBytes} bytes`);
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function responseDetail(response, token) {
+  try {
+    const body = await readBoundedResponse(response, 16 * 1024, 'verifier_unavailable', 'GitHub error');
+    return redactTokenOccurrences(
+      strictUtf8(body, 'verifier_unavailable', 'GitHub error was not UTF-8'),
+      token
+    ).slice(0, 300);
+  } catch {
+    return '<response body unavailable>';
+  }
+}
+
+async function githubJson({ url, token, fetchImpl, signal, operation }) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'GET',
+      headers: githubHeaders(token),
+      redirect: 'error',
+      signal
+    });
+  } catch (error) {
+    const message = redactTokenOccurrences(error instanceof Error ? error.message : String(error), token);
+    throw new ReleaseVerificationError('verifier_unavailable', `${operation} failed: ${message}`);
+  }
+  if (!response.ok) {
+    const detail = await responseDetail(response, token);
+    fail('verifier_unavailable', `${operation} failed with HTTP ${response.status}: ${detail}`);
+  }
+  const bytes = await readBoundedResponse(response, 1024 * 1024, 'verifier_unavailable', operation);
+  try {
+    return JSON.parse(strictUtf8(bytes, 'verifier_unavailable', `${operation} returned invalid UTF-8`));
+  } catch (error) {
+    if (error instanceof ReleaseVerificationError) throw error;
+    return fail('verifier_unavailable', `${operation} returned invalid JSON`);
+  }
+}
+
+async function githubBytes({
+  url,
+  token,
+  fetchImpl,
+  signal,
+  maxBytes,
+  operation,
+  accept,
+  redirect = 'error'
+}) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'GET',
+      headers: githubHeaders(token, accept),
+      redirect,
+      signal
+    });
+  } catch (error) {
+    const message = redactTokenOccurrences(error instanceof Error ? error.message : String(error), token);
+    throw new ReleaseVerificationError('verifier_unavailable', `${operation} failed: ${message}`);
+  }
+  if (!response.ok) {
+    const detail = await responseDetail(response, token);
+    fail('verifier_unavailable', `${operation} failed with HTTP ${response.status}: ${detail}`);
+  }
+  return readBoundedResponse(response, maxBytes, 'verifier_unavailable', operation);
+}
+
+function repositoryApiPath(repository) {
+  const [owner, repo] = repository.split('/');
+  if (!PATH_SEGMENT.test(owner ?? '') || !PATH_SEGMENT.test(repo ?? '')) {
+    fail('blocked', `invalid fixed repository ${repository}`);
+  }
+  return `repos/${owner}/${repo}`;
+}
+
+export async function resolveImmutableTagCommit({
+  repository,
+  tag,
+  providerSourceDigest,
+  token,
+  fetchImpl,
+  signal
+}) {
+  const expectedPattern = repository === E2E_REPOSITORY ? PROVIDER_TAG : ACTION_TAG;
+  if (!ACTION_REPOSITORIES.includes(repository) && repository !== E2E_REPOSITORY) {
+    fail('blocked', `repository is outside the release closure: ${repository}`);
+  }
+  if (!expectedPattern.test(tag)) fail('blocked', `tag is not immutable for ${repository}`);
+  if (repository === E2E_REPOSITORY && !SHA256.test(providerSourceDigest ?? '')) {
+    fail('blocked', 'pinned provider source-manifest digest is invalid');
+  }
+  const expectedRef = `refs/tags/${tag}`;
+  const ref = await githubJson({
+    url: `https://api.github.com/${repositoryApiPath(repository)}/git/ref/tags/${encodeURIComponent(tag)}`,
+    token,
+    fetchImpl,
+    signal,
+    operation: `${repository}@${tag} ref lookup`
+  });
+  if (
+    ref?.ref !== expectedRef ||
+    !plain(ref.object) ||
+    !SHA.test(String(ref.object.sha ?? '')) ||
+    (ref.object.type !== 'tag' && ref.object.type !== 'commit')
+  ) {
+    fail('verifier_unavailable', `${repository}@${tag} did not resolve to a valid Git ref`);
+  }
+  if (repository === E2E_REPOSITORY && ref.object.type !== 'tag') {
+    fail('correlation_mismatch', 'immutable provider tag must be an annotated tag');
+  }
+  let object = ref.object;
+  for (let depth = 0; object.type === 'tag' && depth < 4; depth += 1) {
+    const annotated = await githubJson({
+      url: `https://api.github.com/${repositoryApiPath(repository)}/git/tags/${object.sha}`,
+      token,
+      fetchImpl,
+      signal,
+      operation: `${repository}@${tag} annotated tag lookup`
+    });
+    if (
+      (depth === 0 && annotated?.tag !== tag) ||
+      !plain(annotated?.object) ||
+      !SHA.test(String(annotated.object.sha ?? '')) ||
+      (annotated.object.type !== 'tag' && annotated.object.type !== 'commit')
+    ) {
+      fail('verifier_unavailable', `${repository}@${tag} annotated tag is invalid`);
+    }
+    if (
+      repository === E2E_REPOSITORY &&
+      depth === 0 &&
+      annotated.message !==
+        `E2E provider ${tag}\n\ne2e-provider-source-manifest-sha256:${providerSourceDigest}`
+    ) {
+      fail('correlation_mismatch', 'immutable provider annotation digest does not match its pin');
+    }
+    object = annotated.object;
+  }
+  if (object.type !== 'commit' || !SHA.test(object.sha)) {
+    fail('verifier_unavailable', `${repository}@${tag} tag chain did not terminate in a commit`);
+  }
+  return object.sha;
+}
+
+export async function digestRepositoryFile({
+  repository,
+  commit,
+  file,
+  token,
+  fetchImpl,
+  signal
+}) {
+  if (
+    !ACTION_REPOSITORIES.includes(repository) ||
+    !SHA.test(commit) ||
+    !['action.yml', 'dist/cli.cjs'].includes(file)
+  ) {
+    fail('blocked', 'invalid release-closure file request');
+  }
+  const encodedPath = file.split('/').map(encodeURIComponent).join('/');
+  const bytes = await githubBytes({
+    url: `https://api.github.com/${repositoryApiPath(repository)}/contents/${encodedPath}?ref=${encodeURIComponent(commit)}`,
+    token,
+    fetchImpl,
+    signal,
+    maxBytes: file === 'action.yml' ? 2 * 1024 * 1024 : 64 * 1024 * 1024,
+    operation: `${repository}@${commit}:${file} read`,
+    accept: 'application/vnd.github.raw+json'
+  });
+  return sha256(bytes);
+}
+
+export async function buildReleaseEvidenceManifest(config, dependencies = {}) {
+  if (
+    config.repository !== RELEASE_REPOSITORY ||
+    config.action !== RELEASE_ACTION ||
+    config.suite !== 'full' ||
+    !ACTION_TAG.test(config.refName) ||
+    !SHA.test(config.releaseCommit) ||
+    !SHA256.test(config.sourceDigest) ||
+    !PROVIDER_TAG.test(config.providerTag) ||
+    !SHA.test(config.providerCommit) ||
+    !SHA256.test(config.providerSourceDigest)
+  ) {
+    fail('blocked', 'release evidence configuration is invalid');
+  }
+  const resolveTag = dependencies.resolveTagCommit ?? resolveImmutableTagCommit;
+  const digestFile = dependencies.digestRepositoryFile ?? digestRepositoryFile;
+  const request = (extra) => ({
+    ...extra,
+    token: config.token,
+    fetchImpl: dependencies.fetchImpl ?? globalThis.fetch,
+    signal: dependencies.abortSignal ?? globalThis.AbortSignal.timeout(config.dispatchTimeoutMs)
+  });
+  const actualProviderCommit = await resolveTag(
+    request({
+      repository: E2E_REPOSITORY,
+      tag: config.providerTag,
+      providerSourceDigest: config.providerSourceDigest
+    })
+  );
+  if (actualProviderCommit !== config.providerCommit) {
+    fail('correlation_mismatch', 'immutable provider tag does not resolve to the pinned provider commit');
+  }
+  const actions = {};
+  for (const repository of ACTION_REPOSITORIES) {
+    const tag = repository === RELEASE_REPOSITORY ? config.refName : config.peerTags[repository];
+    const commit = await resolveTag(request({ repository, tag }));
+    if (repository === RELEASE_REPOSITORY && commit !== config.releaseCommit) {
+      fail('correlation_mismatch', 'release tag does not resolve to the release workflow commit');
+    }
+    const digestKind =
+      repository === COMPOSITE_REPOSITORY || repository === INSIGHTS_REPOSITORY
+        ? 'action-definition-sha256'
+        : 'cli-bundle-sha256';
+    const digest = await digestFile(
+      request({
+        repository,
+        commit,
+        file: digestKind === 'action-definition-sha256' ? 'action.yml' : 'dist/cli.cjs'
+      })
+    );
+    if (!SHA256.test(digest)) fail('verifier_unavailable', `invalid digest for ${repository}`);
+    actions[repository] = {
+      commit,
+      digest,
+      digestKind,
+      role: repository === COMPOSITE_REPOSITORY ? 'composite' : 'peer',
+      tag
+    };
+  }
+  const manifest = {
+    actions,
+    provider: {
+      commit: config.providerCommit,
+      repository: E2E_REPOSITORY,
+      tag: config.providerTag
+    },
+    release: {
+      artifactDigest: config.sourceDigest,
+      commit: config.releaseCommit,
+      kind: 'composite',
+      repository: RELEASE_REPOSITORY,
+      tag: config.refName
+    },
+    schemaVersion: 1,
+    suite: 'full'
+  };
+  const bytes = Buffer.from(canonicalJsonStringify(manifest), 'utf8');
+  if (bytes.length > RELEASE_EVIDENCE_MAX_BYTES) {
+    fail('blocked', 'release evidence manifest exceeds provider limit');
+  }
+  return { bytes, digest: sha256(bytes), manifest };
+}
+
+export function parseDispatchRunDetails(status, text) {
+  const bodyText = String(text ?? '').trim();
+  if (status === 204 && bodyText === '') return null;
+  if (!bodyText) return null;
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return fail('dispatch_error', 'workflow dispatch returned invalid JSON');
+  }
+  const id = body?.workflow_run_id;
+  const runUrl = body?.run_url;
+  const htmlUrl = body?.html_url;
+  if ((typeof id !== 'number' && typeof id !== 'string') || !RUN_ID.test(String(id))) {
+    fail('dispatch_error', 'workflow dispatch response omitted a valid workflow_run_id');
+  }
+  if (
+    (runUrl !== undefined && typeof runUrl !== 'string') ||
+    (htmlUrl !== undefined && typeof htmlUrl !== 'string')
+  ) {
+    fail('dispatch_error', 'workflow dispatch response has invalid URLs');
   }
   return {
-    workflowRunId: String(workflowRunId),
-    runApiUrl: parsed.workflow_run?.url ?? parsed.run_url ?? parsed.url ?? null,
-    runUrl: parsed.workflow_run?.html_url ?? parsed.html_url ?? null
+    workflowRunId: String(id),
+    runApiUrl: typeof runUrl === 'string' && runUrl ? runUrl : undefined,
+    runUrl: typeof htmlUrl === 'string' && htmlUrl ? htmlUrl : undefined
   };
 }
 
-function workflowPathMatches(path, workflow) {
+function runCreatedAt(run) {
+  const parsed = Date.parse(String(run?.created_at ?? ''));
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function workflowPathMatches(path, workflow, providerTag) {
   if (typeof path !== 'string') return false;
-  return path.split('@', 1)[0].endsWith(`/${workflow}`) || path.split('@', 1)[0] === workflow;
-}
-
-function runMatches(run, expected) {
-  if (!run || typeof run !== 'object') return false;
-  if (run.event !== 'workflow_dispatch') return false;
-  if (run.head_branch !== expected.workflowRef) return false;
-  if (run.display_title !== expected.runTitle) return false;
-  if (!workflowPathMatches(run.path, expected.workflow)) return false;
-  const createdAt = Date.parse(run.created_at ?? '');
-  return Number.isFinite(createdAt) && createdAt >= expected.notBeforeMs;
-}
-
-export function electCorrelatedRun(runs, expected) {
-  const matches = runs.filter((candidate) => runMatches(candidate, expected));
-  if (matches.length > 1) {
-    throw new ReleaseVerificationError(
-      'correlation_mismatch',
-      `Correlation ${expected.correlationId} matched multiple workflow runs`,
-      { runIds: matches.map((run) => String(run.id)) }
-    );
-  }
-  return matches[0] ?? null;
+  const [base, ref, ...extra] = path.split('@');
+  if (extra.length > 0 || (base !== `.github/workflows/${workflow}` && base !== workflow)) return false;
+  return ref === undefined || ref === `refs/tags/${providerTag}`;
 }
 
 export function validateRunIdentity(run, expected) {
-  const createdAt = Date.parse(run?.created_at ?? '');
-  const mismatch = [];
-  if (!run || typeof run !== 'object') mismatch.push('missing run');
-  if (expected.runId && String(run?.id) !== String(expected.runId)) mismatch.push('run id');
-  if (run?.event !== 'workflow_dispatch') mismatch.push('event');
-  if (run?.head_branch !== expected.workflowRef) mismatch.push('workflow ref');
-  if (run?.display_title !== expected.runTitle) mismatch.push('action/ref/correlation/digest');
-  if (!workflowPathMatches(run?.path, expected.workflow)) mismatch.push('workflow path');
-  if (!Number.isFinite(createdAt) || createdAt < expected.notBeforeMs) mismatch.push('dispatch time');
-  if (mismatch.length > 0) {
-    throw new ReleaseVerificationError(
+  if (!plain(run)) fail('correlation_mismatch', 'workflow run payload is missing');
+  const mismatches = [];
+  if (!RUN_ID.test(String(run.id ?? '')) || String(run.id ?? '') !== String(expected.runId ?? run.id ?? '')) {
+    mismatches.push('run id');
+  }
+  if (run.event !== 'workflow_dispatch') mismatches.push('event');
+  if (run.head_branch !== expected.providerTag) mismatches.push('provider tag ref');
+  if (run.head_sha !== expected.providerCommit) mismatches.push('provider commit');
+  if (run.repository?.full_name !== expected.targetRepository) mismatches.push('repository');
+  if (run.display_title !== expected.runTitle) mismatches.push('action/ref/correlation title');
+  if (!workflowPathMatches(run.path, expected.workflow, expected.providerTag)) mismatches.push('workflow path');
+  if (!Number.isSafeInteger(run.run_attempt) || Number(run.run_attempt) !== expected.runAttempt) {
+    mismatches.push('run attempt');
+  }
+  const createdAt = runCreatedAt(run);
+  if (!Number.isFinite(createdAt) || createdAt < expected.notBeforeMs) mismatches.push('created_at');
+  if (mismatches.length > 0) {
+    fail(
       'correlation_mismatch',
-      `Workflow run does not match exact release correlation: ${mismatch.join(', ')}`,
-      { runId: run?.id ? String(run.id) : null, mismatch }
+      `downstream run correlation mismatch: ${mismatches.join(', ')}`,
+      { runId: run.id == null ? undefined : String(run.id) }
     );
   }
   return run;
 }
 
+export function electCorrelatedRun(runs, expected) {
+  if (!Array.isArray(runs)) fail('verifier_unavailable', 'workflow run lookup omitted workflow_runs');
+  const matches = runs
+    .filter((run) => {
+      try {
+        validateRunIdentity(run, expected);
+        return true;
+      } catch (error) {
+        if (error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch') return false;
+        throw error;
+      }
+    })
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+  if (matches.length > 1) {
+    fail('correlation_mismatch', `multiple downstream runs matched exact correlation ${expected.correlationId}`);
+  }
+  return matches[0] ?? null;
+}
+
 export function classifyTerminalRun(run) {
-  if (run.status !== 'completed') {
-    if (PENDING_STATUSES.has(String(run.status ?? ''))) return { terminal: false };
-    throw new ReleaseVerificationError('blocked', `Verifier returned unsupported status ${String(run.status ?? '<missing>')}`);
-  }
-  const conclusion = run.conclusion ?? 'unknown';
-  return {
-    terminal: true,
-    outcome: TERMINAL_OUTCOMES.get(conclusion) ?? 'blocked'
-  };
-}
-
-export function shouldFailRelease(mode, outcome) {
-  return (mode ?? 'enforce') !== 'report-only' && outcome !== 'success';
-}
-
-export function assertCompositeUsesCapability(workflowText) {
-  const hasActionInput = /inputs\.action\s*==\s*['"]postman-api-onboarding-action['"]/.test(workflowText);
-  const hasCheckout = /repository:\s*postman-cs\/postman-api-onboarding-action\b/.test(workflowText);
-  const hasUses = /uses:\s*(?:\.\/postman-api-onboarding-action|postman-cs\/postman-api-onboarding-action@\$\{\{\s*inputs\.ref\s*\}\})/.test(workflowText);
-  const hasExactRef = /inputs\.action\s*==\s*['"]postman-api-onboarding-action['"]\s*&&\s*inputs\.ref/.test(workflowText);
-  const hasSandboxGuard =
-    workflowText.includes('POSTMAN_E2E_API_KEY_NON_ORG_MODE is required for composite smoke.') &&
-    workflowText.includes("postman-team-id: '10490519'") &&
-    workflowText.includes('repo-write-mode: none');
-  const hasReporterDependency = /needs:\s*\[failure-injection, plan, monitor, composite-smoke\]/.test(workflowText);
-  if (
-    !hasActionInput ||
-    (!hasCheckout && !hasUses) ||
-    !hasUses ||
-    !hasExactRef ||
-    !hasSandboxGuard ||
-    !hasReporterDependency
-  ) {
-    throw new ReleaseVerificationError(
+  if (run?.status !== 'completed') {
+    if (PENDING_STATUSES.has(String(run?.status ?? ''))) return { terminal: false };
+    fail(
       'blocked',
-      'E2E_COMPOSITE_USES_UNAVAILABLE: verifier lacks exact-ref native composite execution, sandbox guards, or reporter evidence'
+      `downstream verifier returned unsupported status ${String(run?.status ?? '<missing>')}`,
+      { runId: run?.id == null ? undefined : String(run.id) }
     );
   }
-}
-
-async function responseText(response) {
-  try {
-    return await response.text();
-  } catch {
-    return '';
+  const conclusion = String(run.conclusion ?? '');
+  if (['success', 'failure', 'cancelled', 'timed_out'].includes(conclusion)) {
+    return { terminal: true, outcome: conclusion };
   }
+  return { terminal: true, outcome: 'blocked' };
 }
 
-async function fetchWithDeadline(fetchImpl, url, options, timeoutMs, code, secrets) {
-  try {
-    return await fetchImpl(url, { ...options, signal: globalThis.AbortSignal.timeout(timeoutMs) });
-  } catch (error) {
-    const message = redact(error instanceof Error ? error.message : error, secrets);
-    throw new ReleaseVerificationError(code, `Request failed: ${message}`);
+export function computeBackoffMs(attempt, initialMs, maxMs) {
+  return Math.min(initialMs * 2 ** Math.max(0, attempt), maxMs);
+}
+
+export function resolveConfig(env = process.env) {
+  const token = requireNonEmpty(env.E2E_DISPATCH_TOKEN, 'E2E_DISPATCH_TOKEN');
+  if ((env.E2E_GATE_MODE?.trim() || 'enforce') !== 'enforce') {
+    fail('blocked', 'E2E release verification is fail-closed and supports only enforce mode');
   }
-}
-
-async function fetchJson({ fetchImpl, url, token, timeoutMs, code, method = 'GET', body }) {
-  const response = await fetchWithDeadline(
-    fetchImpl,
-    url,
-    {
-      method,
-      headers: apiHeaders(token),
-      ...(body === undefined ? {} : { body: JSON.stringify(body) })
-    },
-    timeoutMs,
-    code,
-    [token]
+  const repository = requireNonEmpty(env.GITHUB_REPOSITORY, 'GITHUB_REPOSITORY');
+  const refName = requireNonEmpty(env.E2E_GATE_REF || env.GITHUB_REF_NAME, 'E2E_GATE_REF');
+  const sourceDigest = requireNonEmpty(env.E2E_GATE_SOURCE_DIGEST, 'E2E_GATE_SOURCE_DIGEST');
+  const releaseCommit = requireNonEmpty(
+    env.E2E_GATE_RELEASE_COMMIT || env.GITHUB_SHA,
+    'E2E_GATE_RELEASE_COMMIT'
   );
-  const text = await responseText(response);
-  if (!response.ok) {
-    const failureCode =
-      code !== 'blocked' && (response.status === 401 || response.status === 403)
-        ? `${code.replace(/_error$/, '')}_auth_error`
-        : code;
-    throw new ReleaseVerificationError(
-      failureCode,
-      `GitHub API returned HTTP ${response.status}: ${redact(text.slice(0, 500), [token])}`,
-      { status: response.status }
-    );
-  }
-  if (!text.trim()) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw new ReleaseVerificationError(code, 'GitHub API returned unreadable JSON');
-  }
-}
-
-async function assertCompositeCapability(config, fetchImpl) {
-  const [owner, repo] = config.e2eRepository.split('/');
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/.github/workflows/${config.e2eWorkflow}?ref=${encodeURIComponent(config.workflowRef)}`;
-  const payload = await fetchJson({
-    fetchImpl,
-    url,
-    token: config.token,
-    timeoutMs: config.dispatchTimeoutMs,
-    code: 'blocked'
-  });
-  if (typeof payload?.content !== 'string') {
-    throw new ReleaseVerificationError('blocked', 'Unable to inspect E2E workflow capability');
-  }
-  const text = Buffer.from(payload.content, payload.encoding === 'base64' ? 'base64' : 'utf8').toString('utf8');
-  assertCompositeUsesCapability(text);
-}
-
-async function dispatchWorkflow(config, fetchImpl) {
-  const [owner, repo] = config.e2eRepository.split('/');
-  const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(config.e2eWorkflow)}/dispatches`;
-  const response = await fetchWithDeadline(
-    fetchImpl,
-    url,
-    { method: 'POST', headers: apiHeaders(config.token), body: JSON.stringify(buildDispatchPayload(config)) },
-    config.dispatchTimeoutMs,
-    'dispatch_error',
-    [config.token]
+  const action = env.E2E_GATE_ACTION?.trim() || repository.split('/').at(-1);
+  const providerTag = requireNonEmpty(env.E2E_GATE_PROVIDER_TAG, 'E2E_GATE_PROVIDER_TAG');
+  const providerCommit = requireNonEmpty(env.E2E_GATE_PROVIDER_COMMIT, 'E2E_GATE_PROVIDER_COMMIT');
+  const providerSourceDigest = requireNonEmpty(
+    env.E2E_GATE_PROVIDER_SOURCE_DIGEST,
+    'E2E_GATE_PROVIDER_SOURCE_DIGEST'
   );
-  const body = await responseText(response);
-  if (!response.ok) {
-    const code = response.status === 401 || response.status === 403 ? 'dispatch_auth_error' : 'dispatch_error';
-    throw new ReleaseVerificationError(
-      code,
-      `Verifier dispatch returned HTTP ${response.status}: ${redact(body.slice(0, 500), [config.token])}`,
-      { status: response.status }
-    );
+  const suite = env.E2E_GATE_SUITE?.trim() || 'full';
+  if (env.E2E_GATE_REPOSITORY !== undefined || env.E2E_GATE_WORKFLOW !== undefined) {
+    fail('blocked', 'fixed provider repository and workflow do not accept environment overrides');
   }
-  return parseDispatchRunDetails(response.status, body);
-}
-
-async function fetchRun(config, fetchImpl, runId) {
-  const [owner, repo] = config.e2eRepository.split('/');
-  return fetchJson({
-    fetchImpl,
-    url: `https://api.github.com/repos/${owner}/${repo}/actions/runs/${encodeURIComponent(runId)}`,
-    token: config.token,
-    timeoutMs: config.dispatchTimeoutMs,
-    code: 'blocked'
-  });
-}
-
-async function listCandidateRuns(config, fetchImpl, createdDate) {
-  const [owner, repo] = config.e2eRepository.split('/');
-  const query = new URLSearchParams({
-    branch: config.workflowRef,
-    event: 'workflow_dispatch',
-    created: `>=${createdDate}`,
-    per_page: '100'
-  });
-  const payload = await fetchJson({
-    fetchImpl,
-    url: `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(config.e2eWorkflow)}/runs?${query}`,
-    token: config.token,
-    timeoutMs: config.dispatchTimeoutMs,
-    code: 'blocked'
-  });
-  if (!Array.isArray(payload?.workflow_runs)) {
-    throw new ReleaseVerificationError('blocked', 'Verifier run listing omitted workflow_runs');
+  const targetRepository = E2E_REPOSITORY;
+  const workflow = E2E_WORKFLOW;
+  const requestedCorrelationId = env.E2E_GATE_CORRELATION_ID?.trim() || '';
+  const runId = requireNonEmpty(env.GITHUB_RUN_ID, 'GITHUB_RUN_ID');
+  const runAttempt = requireNonEmpty(env.GITHUB_RUN_ATTEMPT, 'GITHUB_RUN_ATTEMPT');
+  buildDispatchUrl(targetRepository, workflow);
+  if (
+    repository !== RELEASE_REPOSITORY ||
+    action !== RELEASE_ACTION ||
+    suite !== 'full' ||
+    !ACTION_TAG.test(refName) ||
+    !SHA256.test(sourceDigest) ||
+    !SHA.test(releaseCommit) ||
+    !PROVIDER_TAG.test(providerTag) ||
+    !SHA.test(providerCommit) ||
+    !SHA256.test(providerSourceDigest) ||
+    (requestedCorrelationId !== '' && !CORRELATION_ID.test(requestedCorrelationId)) ||
+    !RUN_ID.test(runId) ||
+    !RUN_ID.test(runAttempt) ||
+    !Number.isSafeInteger(Number(runAttempt))
+  ) {
+    fail('blocked', 'release/provider identity inputs are invalid');
   }
-  return payload.workflow_runs;
-}
-
-export async function lookupCorrelatedRun({ config, expected, fetchImpl, now = Date.now, sleep }) {
-  const deadline = now() + config.lookupTimeoutMs;
-  const createdDate = new Date(expected.notBeforeMs).toISOString().slice(0, 10);
-  let delayMs = config.initialPollMs;
-  while (now() <= deadline) {
-    const elected = electCorrelatedRun(await listCandidateRuns(config, fetchImpl, createdDate), expected);
-    if (elected) return elected;
-    const remaining = deadline - now();
-    if (remaining <= 0) break;
-    await sleep(Math.min(delayMs, remaining));
-    delayMs = Math.min(config.maxPollMs, delayMs * 2);
-  }
-  throw new ReleaseVerificationError('blocked', `No exact workflow run appeared for correlation ${expected.correlationId}`);
-}
-
-function isPendingRunTitle(error) {
-  const mismatch = error instanceof ReleaseVerificationError ? error.details?.mismatch : null;
-  return (
-    error?.code === 'correlation_mismatch' &&
-    Array.isArray(mismatch) &&
-    mismatch.length === 1 &&
-    mismatch[0] === 'action/ref/correlation/digest'
-  );
-}
-
-export async function waitForExactRunIdentity({ config, runId, expected, fetchRun: getRun, now = Date.now, sleep }) {
-  const deadline = now() + config.lookupTimeoutMs;
-  let delayMs = config.initialPollMs;
-  let titleError;
-  while (now() <= deadline) {
-    try {
-      return validateRunIdentity(await getRun(runId), { ...expected, runId });
-    } catch (error) {
-      if (!isPendingRunTitle(error)) throw error;
-      titleError = error;
-    }
-    const remaining = deadline - now();
-    if (remaining <= 0) break;
-    await sleep(Math.min(delayMs, remaining));
-    delayMs = Math.min(config.maxPollMs, delayMs * 2);
-  }
-  throw titleError;
-}
-
-export async function waitForTerminalRun({ config, runId, expected, fetchRun: getRun, now = Date.now, sleep }) {
-  const deadline = now() + config.verificationTimeoutMs;
-  let delayMs = config.initialPollMs;
-  while (now() <= deadline) {
-    const run = validateRunIdentity(await getRun(runId), { ...expected, runId });
-    const terminal = classifyTerminalRun(run);
-    if (terminal.terminal) return { ...terminal, run };
-    const remaining = deadline - now();
-    if (remaining <= 0) break;
-    await sleep(Math.min(delayMs, remaining));
-    delayMs = Math.min(config.maxPollMs, delayMs * 2);
-  }
-  throw new ReleaseVerificationError('verification_timeout', `Timed out waiting for exact workflow run ${runId}`);
-}
-
-function parseConfig(env) {
-  const token = requireEnv(env, 'E2E_DISPATCH_TOKEN');
-  const action = requireEnv(env, 'E2E_GATE_ACTION');
-  const refName = requireEnv(env, 'E2E_GATE_REF');
-  const sourceDigest = requireEnv(env, 'E2E_GATE_SOURCE_DIGEST').toLowerCase();
-  const suite = (env.E2E_GATE_SUITE || 'full').trim();
-  const mode = (env.E2E_GATE_MODE || 'enforce').trim();
-  const e2eRepository = (env.E2E_REPOSITORY || DEFAULT_E2E_REPOSITORY).trim();
-  const e2eWorkflow = (env.E2E_WORKFLOW || DEFAULT_E2E_WORKFLOW).trim();
-  const workflowRef = (env.E2E_WORKFLOW_REF || DEFAULT_E2E_WORKFLOW_REF).trim();
-  const repository = requireEnv(env, 'GITHUB_REPOSITORY');
-  const runId = requireEnv(env, 'GITHUB_RUN_ID');
-  const runAttempt = env.GITHUB_RUN_ATTEMPT?.trim() || '1';
-  if (!SUPPORTED_SUITES.has(suite)) throw new ReleaseVerificationError('blocked', `Unsupported E2E suite ${suite}`);
-  if (!['enforce', 'report-only'].includes(mode)) throw new ReleaseVerificationError('blocked', `Unsupported E2E_GATE_MODE ${mode}`);
-  if (!/^[a-f0-9]{64}$/.test(sourceDigest)) throw new ReleaseVerificationError('blocked', 'E2E_GATE_SOURCE_DIGEST must be a lowercase SHA-256 digest');
-  if (!/^[\w.-]+\/[\w.-]+$/.test(e2eRepository)) throw new ReleaseVerificationError('blocked', 'E2E_REPOSITORY must be owner/repository');
-  const correlationId = buildCorrelationId({ repository, runId, runAttempt, refName, sourceDigest });
   return {
     token,
-    action,
+    repository,
     refName,
     sourceDigest,
+    releaseCommit,
+    action,
+    targetRepository,
+    workflow,
+    providerTag,
+    providerCommit,
+    providerSourceDigest,
+    peerTags: parsePeerTags(env.E2E_GATE_PEER_TAGS),
     suite,
-    mode,
-    e2eRepository,
-    e2eWorkflow,
-    workflowRef,
-    repository,
+    requestedCorrelationId,
     runId,
     runAttempt,
-    correlationId,
-    registryRevision: env.E2E_GATE_REGISTRY_REVISION?.trim() || '',
-    contractScenarios: env.E2E_GATE_CONTRACT_SCENARIOS?.trim() || '',
-    dispatchTimeoutMs: parsePositiveInteger(env.E2E_DISPATCH_TIMEOUT_MS, DEFAULT_DISPATCH_TIMEOUT_MS, 'E2E_DISPATCH_TIMEOUT_MS'),
-    lookupTimeoutMs: parsePositiveInteger(env.E2E_LOOKUP_TIMEOUT_MS, DEFAULT_LOOKUP_TIMEOUT_MS, 'E2E_LOOKUP_TIMEOUT_MS'),
-    verificationTimeoutMs: parsePositiveInteger(env.E2E_VERIFICATION_TIMEOUT_MS, DEFAULT_VERIFICATION_TIMEOUT_MS, 'E2E_VERIFICATION_TIMEOUT_MS'),
-    initialPollMs: parsePositiveInteger(env.E2E_INITIAL_POLL_MS, DEFAULT_INITIAL_POLL_MS, 'E2E_INITIAL_POLL_MS'),
-    maxPollMs: parsePositiveInteger(env.E2E_MAX_POLL_MS, DEFAULT_MAX_POLL_MS, 'E2E_MAX_POLL_MS')
+    dispatchTimeoutMs: parsePositiveInteger(
+      env.E2E_GATE_DISPATCH_TIMEOUT_MS,
+      DEFAULT_DISPATCH_TIMEOUT_MS,
+      'E2E_GATE_DISPATCH_TIMEOUT_MS'
+    ),
+    lookupTimeoutMs: parsePositiveInteger(
+      env.E2E_GATE_LOOKUP_TIMEOUT_MS,
+      DEFAULT_LOOKUP_TIMEOUT_MS,
+      'E2E_GATE_LOOKUP_TIMEOUT_MS'
+    ),
+    verificationTimeoutMs: parsePositiveInteger(
+      env.E2E_GATE_VERIFICATION_TIMEOUT_MS,
+      DEFAULT_VERIFICATION_TIMEOUT_MS,
+      'E2E_GATE_VERIFICATION_TIMEOUT_MS'
+    ),
+    initialPollMs: parsePositiveInteger(
+      env.E2E_GATE_INITIAL_POLL_MS,
+      DEFAULT_INITIAL_POLL_MS,
+      'E2E_GATE_INITIAL_POLL_MS'
+    ),
+    maxPollMs: parsePositiveInteger(
+      env.E2E_GATE_MAX_POLL_MS,
+      DEFAULT_MAX_POLL_MS,
+      'E2E_GATE_MAX_POLL_MS'
+    )
   };
 }
 
-async function appendOutputs(outputPath, values) {
-  if (!outputPath) return;
-  const lines = Object.entries(values)
-    .filter(([, value]) => value !== undefined && value !== null && value !== '')
-    .map(([key, value]) => `${key}=${String(value)}\n`)
-    .join('');
-  if (lines) await appendFile(outputPath, lines, 'utf8');
-}
-
-function sleepMs(ms) {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
-}
-
-function errorResult(error, config) {
-  const code = error instanceof ReleaseVerificationError ? error.code : 'blocked';
-  return {
-    outcome: code,
-    correlationId: config?.correlationId ?? null,
-    workflowRunId: error?.details?.runId ?? null,
-    runUrl: null,
-    message: error instanceof Error ? error.message : String(error)
-  };
-}
-
-export async function runReleaseVerificationCli(env = process.env, dependencies = {}) {
-  const fetchImpl = dependencies.fetchImpl ?? globalThis.fetch;
-  const log = dependencies.log ?? globalThis.console.log;
-  const errorLog = dependencies.error ?? globalThis.console.error;
-  const now = dependencies.now ?? Date.now;
-  const sleep = dependencies.sleep ?? sleepMs;
-  let config;
+async function dispatchWorkflow(config, evidence, fetchImpl, startedAtMs) {
+  const url = buildDispatchUrl(config.targetRepository, config.workflow);
+  const payload = buildDispatchPayload({
+    providerTag: config.providerTag,
+    action: config.action,
+    refName: config.refName,
+    correlationId: config.correlationId,
+    suite: config.suite,
+    manifestBytes: evidence.bytes,
+    manifestDigest: evidence.digest
+  });
+  let response;
   try {
-    config = parseConfig(env);
-    const expected = {
-      workflow: config.e2eWorkflow,
-      workflowRef: config.workflowRef,
-      runTitle: expectedRunTitle(config),
-      correlationId: config.correlationId,
-      notBeforeMs: now() - 5_000
-    };
-    await assertCompositeCapability(config, fetchImpl);
-    const dispatchDetails = await dispatchWorkflow(config, fetchImpl);
-    let run;
-    if (dispatchDetails?.workflowRunId) {
-      run = await waitForExactRunIdentity({
-        config,
-        runId: dispatchDetails.workflowRunId,
-        expected,
-        fetchRun: (id) => fetchRun(config, fetchImpl, id),
-        now,
-        sleep
-      });
-    } else {
-      run = await lookupCorrelatedRun({ config, expected, fetchImpl, now, sleep });
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { ...githubHeaders(config.token), 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      redirect: 'error',
+      signal: globalThis.AbortSignal.timeout(config.dispatchTimeoutMs)
+    });
+  } catch (error) {
+    const message = redactTokenOccurrences(
+      error instanceof Error ? error.message : String(error),
+      config.token
+    );
+    throw new ReleaseVerificationError('dispatch_error', `workflow dispatch failed: ${message}`);
+  }
+  if (!response.ok) {
+    const code =
+      response.status === 401 || response.status === 403 ? 'dispatch_auth_error' : 'dispatch_error';
+    const detail = await responseDetail(response, config.token);
+    fail(code, `workflow dispatch failed with HTTP ${response.status}: ${detail}`);
+  }
+  const text = strictUtf8(
+    await readBoundedResponse(response, 1024 * 1024, 'dispatch_error', 'workflow dispatch'),
+    'dispatch_error',
+    'workflow dispatch returned invalid UTF-8'
+  );
+  return { details: parseDispatchRunDetails(response.status, text), payload, startedAtMs, url };
+}
+
+async function fetchExactRun(config, runId, dependencies) {
+  const [owner, repo] = config.targetRepository.split('/');
+  return githubJson({
+    url: `https://api.github.com/repos/${owner}/${repo}/actions/runs/${encodeURIComponent(runId)}`,
+    token: config.token,
+    fetchImpl: dependencies.fetchImpl,
+    signal: globalThis.AbortSignal.timeout(config.dispatchTimeoutMs),
+    operation: `exact workflow run ${runId} read`
+  });
+}
+
+async function lookupCorrelatedRun(config, expected, dependencies) {
+  const deadline = dependencies.now() + config.lookupTimeoutMs;
+  let attempt = 0;
+  while (dependencies.now() <= deadline) {
+    const [owner, repo] = config.targetRepository.split('/');
+    const query = new URLSearchParams({
+      event: 'workflow_dispatch',
+      created: `>=${new Date(expected.notBeforeMs).toISOString()}`,
+      per_page: '100'
+    });
+    const body = await githubJson({
+      url: `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(config.workflow)}/runs?${query}`,
+      token: config.token,
+      fetchImpl: dependencies.fetchImpl,
+      signal: globalThis.AbortSignal.timeout(config.dispatchTimeoutMs),
+      operation: 'correlated workflow run lookup'
+    });
+    const run = electCorrelatedRun(body?.workflow_runs, expected);
+    if (run) return run;
+    const delay = computeBackoffMs(attempt, config.initialPollMs, config.maxPollMs);
+    attempt += 1;
+    const remaining = deadline - dependencies.now();
+    if (remaining <= 0) break;
+    await dependencies.sleep(Math.min(delay, remaining));
+  }
+  fail(
+    'verifier_unavailable',
+    `no downstream run matched exact correlation ${config.correlationId} before lookup timeout`
+  );
+}
+
+export async function waitForRunIdentity({ config, runId, expected, fetchRun, now, sleep }) {
+  const deadline = now() + config.lookupTimeoutMs;
+  let attempt = 0;
+  let lastHydrationMismatch;
+  while (now() <= deadline) {
+    try {
+      return validateRunIdentity(await fetchRun(runId), { ...expected, runId });
+    } catch (error) {
+      const hydrating =
+        error instanceof ReleaseVerificationError &&
+        error.code === 'correlation_mismatch' &&
+        /(?:action\/ref\/correlation title|provider tag ref|run attempt)/.test(error.message);
+      if (!hydrating) throw error;
+      lastHydrationMismatch = error;
     }
-    const workflowRunId = String(run.id);
-    const runUrl = dispatchDetails?.runUrl ?? run.html_url ?? null;
-    const terminal = await waitForTerminalRun({
-      config,
-      runId: workflowRunId,
+    const delay = computeBackoffMs(attempt, config.initialPollMs, config.maxPollMs);
+    attempt += 1;
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(delay, remaining));
+  }
+  throw (
+    lastHydrationMismatch ??
+    new ReleaseVerificationError(
+      'correlation_mismatch',
+      `downstream run ${runId} identity did not hydrate before lookup timeout`,
+      { runId: String(runId) }
+    )
+  );
+}
+
+export async function waitForTerminalRun({ config, runId, expected, fetchRun, now, sleep }) {
+  const deadline = now() + config.verificationTimeoutMs;
+  let attempt = 0;
+  while (now() <= deadline) {
+    const run = validateRunIdentity(await fetchRun(runId), { ...expected, runId });
+    const classified = classifyTerminalRun(run);
+    if (classified.terminal) {
+      if (classified.outcome === 'success') return run;
+      fail(classified.outcome, `downstream verifier ${runId} concluded ${classified.outcome}`, {
+        runId: String(runId),
+        runUrl: run.html_url
+      });
+    }
+    const delay = computeBackoffMs(attempt, config.initialPollMs, config.maxPollMs);
+    attempt += 1;
+    const remaining = deadline - now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(delay, remaining));
+  }
+  fail('verification_timeout', `downstream verifier ${runId} did not complete before timeout`, {
+    runId: String(runId)
+  });
+}
+
+function assertArtifactIdentity(artifact, expected) {
+  return (
+    plain(artifact) &&
+    String(artifact.name ?? '') === expected.name &&
+    artifact.expired === false &&
+    RUN_ID.test(String(artifact.id ?? '')) &&
+    Number.isSafeInteger(artifact.size_in_bytes) &&
+    artifact.size_in_bytes > 0 &&
+    artifact.size_in_bytes <= RESULT_ARCHIVE_MAX_BYTES &&
+    String(artifact.workflow_run?.id ?? '') === expected.runId &&
+    artifact.workflow_run?.head_sha === expected.providerCommit &&
+    artifact.workflow_run?.head_branch === expected.providerTag
+  );
+}
+
+async function lookupTerminalArtifact(config, expected, dependencies) {
+  const deadline = dependencies.now() + config.lookupTimeoutMs;
+  let attempt = 0;
+  while (dependencies.now() <= deadline) {
+    const [owner, repo] = config.targetRepository.split('/');
+    const body = await githubJson({
+      url: `https://api.github.com/repos/${owner}/${repo}/actions/runs/${expected.runId}/artifacts?per_page=100`,
+      token: config.token,
+      fetchImpl: dependencies.fetchImpl,
+      signal: globalThis.AbortSignal.timeout(config.dispatchTimeoutMs),
+      operation: `terminal result artifact lookup for run ${expected.runId}`
+    });
+    if (
+      !Array.isArray(body?.artifacts) ||
+      !Number.isSafeInteger(body?.total_count) ||
+      body.total_count !== body.artifacts.length ||
+      body.total_count > 100
+    ) {
+      fail('verifier_unavailable', 'terminal artifact response was incomplete or invalid');
+    }
+    const named = body.artifacts.filter((artifact) => artifact?.name === expected.name);
+    if (named.length > 1) fail('correlation_mismatch', 'multiple exact terminal result artifacts were returned');
+    if (named.length === 1) {
+      if (!assertArtifactIdentity(named[0], expected)) {
+        fail('correlation_mismatch', 'terminal result artifact identity is invalid');
+      }
+      return named[0];
+    }
+    const delay = computeBackoffMs(attempt, config.initialPollMs, config.maxPollMs);
+    attempt += 1;
+    const remaining = deadline - dependencies.now();
+    if (remaining <= 0) break;
+    await dependencies.sleep(Math.min(delay, remaining));
+  }
+  fail('verifier_unavailable', 'exact terminal result artifact was not available before timeout');
+}
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export function parseSingleFileZip(archive, expectedName) {
+  const bytes = Buffer.from(archive);
+  if (
+    bytes.length < 22 ||
+    bytes.length > RESULT_ARCHIVE_MAX_BYTES ||
+    !PATH_SEGMENT.test(expectedName)
+  ) {
+    fail('artifact_invalid', 'terminal result ZIP size or filename is invalid');
+  }
+  const minimum = Math.max(0, bytes.length - 22 - 0xffff);
+  let eocd = -1;
+  for (let offset = bytes.length - 22; offset >= minimum; offset -= 1) {
+    if (bytes.readUInt32LE(offset) === 0x06054b50) {
+      const commentLength = bytes.readUInt16LE(offset + 20);
+      if (offset + 22 + commentLength === bytes.length) {
+        eocd = offset;
+        break;
+      }
+    }
+  }
+  if (
+    eocd < 0 ||
+    bytes.readUInt16LE(eocd + 4) !== 0 ||
+    bytes.readUInt16LE(eocd + 6) !== 0 ||
+    bytes.readUInt16LE(eocd + 8) !== 1 ||
+    bytes.readUInt16LE(eocd + 10) !== 1
+  ) {
+    fail('artifact_invalid', 'terminal result ZIP must contain exactly one non-ZIP64 entry');
+  }
+  const centralSize = bytes.readUInt32LE(eocd + 12);
+  const centralOffset = bytes.readUInt32LE(eocd + 16);
+  if (
+    centralSize === 0xffffffff ||
+    centralOffset === 0xffffffff ||
+    centralOffset + centralSize !== eocd ||
+    centralOffset + 46 > eocd ||
+    bytes.readUInt32LE(centralOffset) !== 0x02014b50
+  ) {
+    fail('artifact_invalid', 'terminal result ZIP central directory is invalid');
+  }
+  const madeBy = bytes.readUInt16LE(centralOffset + 4);
+  const flags = bytes.readUInt16LE(centralOffset + 8);
+  const method = bytes.readUInt16LE(centralOffset + 10);
+  const expectedCrc = bytes.readUInt32LE(centralOffset + 16);
+  const compressedSize = bytes.readUInt32LE(centralOffset + 20);
+  const uncompressedSize = bytes.readUInt32LE(centralOffset + 24);
+  const nameLength = bytes.readUInt16LE(centralOffset + 28);
+  const extraLength = bytes.readUInt16LE(centralOffset + 30);
+  const commentLength = bytes.readUInt16LE(centralOffset + 32);
+  const diskStart = bytes.readUInt16LE(centralOffset + 34);
+  const externalAttributes = bytes.readUInt32LE(centralOffset + 38);
+  const localOffset = bytes.readUInt32LE(centralOffset + 42);
+  const centralEnd = centralOffset + 46 + nameLength + extraLength + commentLength;
+  const name = bytes.subarray(centralOffset + 46, centralOffset + 46 + nameLength).toString('utf8');
+  const unixMode = madeBy >>> 8 === 3 ? externalAttributes >>> 16 : 0;
+  if (
+    centralEnd !== eocd ||
+    name !== expectedName ||
+    diskStart !== 0 ||
+    compressedSize === 0xffffffff ||
+    uncompressedSize === 0xffffffff ||
+    uncompressedSize === 0 ||
+    uncompressedSize > RELEASE_EVIDENCE_MAX_BYTES ||
+    ![0, 8].includes(method) ||
+    (flags & ~0x080e) !== 0 ||
+    (flags & 0x0001) !== 0 ||
+    (unixMode !== 0 && (unixMode & 0o170000) !== 0o100000) ||
+    localOffset + 30 > centralOffset ||
+    bytes.readUInt32LE(localOffset) !== 0x04034b50
+  ) {
+    fail('artifact_invalid', 'terminal result ZIP entry metadata is invalid');
+  }
+  const localFlags = bytes.readUInt16LE(localOffset + 6);
+  const localMethod = bytes.readUInt16LE(localOffset + 8);
+  const localCrc = bytes.readUInt32LE(localOffset + 14);
+  const localCompressedSize = bytes.readUInt32LE(localOffset + 18);
+  const localUncompressedSize = bytes.readUInt32LE(localOffset + 22);
+  const localNameLength = bytes.readUInt16LE(localOffset + 26);
+  const localExtraLength = bytes.readUInt16LE(localOffset + 28);
+  const localNameStart = localOffset + 30;
+  const dataStart = localNameStart + localNameLength + localExtraLength;
+  const dataEnd = dataStart + compressedSize;
+  const localName = bytes.subarray(localNameStart, localNameStart + localNameLength).toString('utf8');
+  if (
+    localFlags !== flags ||
+    localMethod !== method ||
+    localName !== expectedName ||
+    dataEnd > centralOffset ||
+    ((flags & 0x0008) === 0 &&
+      (localCrc !== expectedCrc ||
+        localCompressedSize !== compressedSize ||
+        localUncompressedSize !== uncompressedSize))
+  ) {
+    fail('artifact_invalid', 'terminal result ZIP local entry is invalid');
+  }
+  const descriptor = bytes.subarray(dataEnd, centralOffset);
+  if ((flags & 0x0008) !== 0) {
+    const signed = descriptor.length === 16 && descriptor.readUInt32LE(0) === 0x08074b50;
+    const base = signed ? 4 : 0;
+    if (
+      (!signed && descriptor.length !== 12) ||
+      descriptor.readUInt32LE(base) !== expectedCrc ||
+      descriptor.readUInt32LE(base + 4) !== compressedSize ||
+      descriptor.readUInt32LE(base + 8) !== uncompressedSize
+    ) {
+      fail('artifact_invalid', 'terminal result ZIP data descriptor is invalid');
+    }
+  } else if (descriptor.length !== 0) {
+    fail('artifact_invalid', 'terminal result ZIP has unexpected bytes before its central directory');
+  }
+  let result;
+  try {
+    result =
+      method === 0
+        ? Buffer.from(bytes.subarray(dataStart, dataEnd))
+        : inflateRawSync(bytes.subarray(dataStart, dataEnd), {
+            maxOutputLength: RELEASE_EVIDENCE_MAX_BYTES + 1
+          });
+  } catch {
+    return fail('artifact_invalid', 'terminal result ZIP decompression failed');
+  }
+  if (result.length !== uncompressedSize || crc32(result) !== expectedCrc) {
+    fail('artifact_invalid', 'terminal result ZIP checksum or length is invalid');
+  }
+  return result;
+}
+
+export function validateReleaseEvidenceResult(bytes, expected) {
+  const value = parseCanonicalJson(
+    bytes,
+    RELEASE_EVIDENCE_MAX_BYTES,
+    'artifact_invalid',
+    'terminal release result'
+  );
+  if (
+    !exactKeys(value, TOP_LEVEL_RESULT_KEYS) ||
+    value.schemaVersion !== 1 ||
+    value.outcome !== 'success' ||
+    value.manifestDigest !== expected.manifestDigest ||
+    value.suite !== expected.manifest.suite ||
+    !exactKeys(value.provider, ['commit', 'repository', 'tag']) ||
+    !exactKeys(value.release, ['artifactDigest', 'commit', 'kind', 'repository', 'tag']) ||
+    !exactKeys(value.run, ['attempt', 'id']) ||
+    !RUN_ID.test(String(value.run.id ?? '')) ||
+    !Number.isSafeInteger(value.run.attempt) ||
+    value.run.attempt < 1 ||
+    value.run.id !== expected.runId ||
+    value.run.attempt !== expected.runAttempt ||
+    canonicalJsonStringify(value.provider) !== canonicalJsonStringify(expected.manifest.provider) ||
+    canonicalJsonStringify(value.release) !== canonicalJsonStringify(expected.manifest.release)
+  ) {
+    fail(
+      'artifact_invalid',
+      'terminal release result does not match the dispatched closed manifest and run'
+    );
+  }
+  return value;
+}
+
+async function downloadAndValidateResult(config, evidence, terminal, dependencies) {
+  const runId = String(terminal.id);
+  const runAttempt = Number(terminal.run_attempt);
+  const name = `e2e-release-result-${runId}-${runAttempt}`;
+  const artifact = await lookupTerminalArtifact(
+    config,
+    {
+      name,
+      providerCommit: config.providerCommit,
+      providerTag: config.providerTag,
+      runId
+    },
+    dependencies
+  );
+  const [owner, repo] = config.targetRepository.split('/');
+  const archive = await githubBytes({
+    url: `https://api.github.com/repos/${owner}/${repo}/actions/artifacts/${artifact.id}/zip`,
+    token: config.token,
+    fetchImpl: dependencies.fetchImpl,
+    signal: globalThis.AbortSignal.timeout(config.dispatchTimeoutMs),
+    maxBytes: RESULT_ARCHIVE_MAX_BYTES,
+    operation: `terminal result artifact ${artifact.id} download`,
+    accept: 'application/vnd.github+json',
+    redirect: 'follow'
+  });
+  const resultBytes = parseSingleFileZip(archive, 'e2e-release-result.json');
+  return validateReleaseEvidenceResult(resultBytes, {
+    manifest: evidence.manifest,
+    manifestDigest: evidence.digest,
+    runAttempt,
+    runId
+  });
+}
+
+export async function verifyCorrelatedRelease(config, dependencies = {}) {
+  const fetchImpl = dependencies.fetchImpl ?? globalThis.fetch;
+  const now = dependencies.now ?? Date.now;
+  const sleep = dependencies.sleep ??
+    ((ms) => new Promise((resolve) => globalThis.setTimeout(resolve, ms)));
+  const log = dependencies.log ?? globalThis.console.log.bind(globalThis.console);
+  const evidence = dependencies.buildEvidence
+    ? await dependencies.buildEvidence(config)
+    : await buildReleaseEvidenceManifest(config, { ...dependencies, fetchImpl });
+  if (
+    !plain(evidence.manifest) ||
+    !Buffer.isBuffer(evidence.bytes) ||
+    !SHA256.test(evidence.digest) ||
+    sha256(evidence.bytes) !== evidence.digest ||
+    canonicalJsonStringify(evidence.manifest) !== evidence.bytes.toString('utf8')
+  ) {
+    fail('blocked', 'constructed release evidence is internally inconsistent');
+  }
+  const correlationId =
+    config.requestedCorrelationId ||
+    buildCorrelationId({
+      repository: config.repository,
+      runId: config.runId,
+      runAttempt: config.runAttempt,
+      refName: config.refName,
+      manifestDigest: evidence.digest
+    });
+  const active = { ...config, correlationId };
+  const startedAtMs = now();
+  const notBeforeMs = startedAtMs - 2_000;
+  log(
+    `::notice::Dispatching immutable-provider E2E verifier action=${active.action} ref=${active.refName} provider=${active.providerTag}@${active.providerCommit} manifest=${evidence.digest} correlation=${correlationId}`
+  );
+  const dispatched = await dispatchWorkflow(active, evidence, fetchImpl, startedAtMs);
+  const expected = {
+    workflow: active.workflow,
+    providerTag: active.providerTag,
+    providerCommit: active.providerCommit,
+    targetRepository: active.targetRepository,
+    runTitle: expectedRunTitle(active),
+    correlationId,
+    notBeforeMs,
+    runAttempt: 1
+  };
+  let initialRun;
+  if (dispatched.details) {
+    initialRun = await waitForRunIdentity({
+      config: active,
+      runId: dispatched.details.workflowRunId,
       expected,
-      fetchRun: (id) => fetchRun(config, fetchImpl, id),
+      fetchRun: async (id) => fetchExactRun(active, id, { fetchImpl }),
       now,
       sleep
     });
-    const result = {
-      outcome: terminal.outcome,
-      correlationId: config.correlationId,
-      workflowRunId,
-      runUrl: terminal.run.html_url ?? runUrl,
-      message: `Verifier run ${workflowRunId} completed with ${terminal.run.conclusion}`
-    };
-    await appendOutputs(env.GITHUB_OUTPUT, {
-      e2e_outcome: result.outcome,
-      e2e_correlation_id: result.correlationId,
-      e2e_workflow_run_id: result.workflowRunId,
-      e2e_run_url: result.runUrl
-    });
-    if (shouldFailRelease(config.mode, result.outcome)) {
-      errorLog(`::error::Correlated E2E verification failed (${result.outcome}): ${result.message}`);
-      return { exitCode: 1, result };
-    }
-    if (config.mode === 'report-only' && result.outcome !== 'success') {
-      log(`::warning::REPORT-ONLY: correlated E2E verification produced ${result.outcome}; rolling alias may advance by explicit operator choice`);
-    } else {
-      log(`Correlated E2E verification succeeded: ${result.runUrl ?? result.workflowRunId}`);
-    }
+  } else {
+    initialRun = await lookupCorrelatedRun(active, expected, { fetchImpl, now, sleep });
+  }
+  const runId = String(initialRun.id);
+  const terminal = await waitForTerminalRun({
+    config: active,
+    runId,
+    expected,
+    fetchRun: async (id) => fetchExactRun(active, id, { fetchImpl }),
+    now,
+    sleep
+  });
+  await downloadAndValidateResult(active, evidence, terminal, { fetchImpl, now, sleep });
+  const runUrl = terminal.html_url ?? dispatched.details?.runUrl;
+  log(`::notice::Exact closed release evidence succeeded: ${runUrl ?? runId}`);
+  return {
+    outcome: 'success',
+    correlationId,
+    manifestDigest: evidence.digest,
+    providerCommit: active.providerCommit,
+    providerTag: active.providerTag,
+    workflowRunId: runId,
+    runUrl
+  };
+}
+
+function appendOutput(path, key, value) {
+  if (!path) return;
+  appendFileSync(path, `${key}=${String(value ?? '')}\n`, 'utf8');
+}
+
+function appendSummary(path, result) {
+  if (!path) return;
+  const lines = [
+    '## Immutable-provider release verification',
+    '',
+    `- **Outcome:** \`${result.outcome}\``,
+    `- **Manifest:** \`${result.manifestDigest ?? 'unavailable'}\``,
+    `- **Provider:** \`${result.providerTag ?? 'unavailable'}@${result.providerCommit ?? 'unavailable'}\``,
+    `- **Correlation:** \`${result.correlationId ?? 'unavailable'}\``,
+    `- **Workflow run:** ${result.runUrl ?? result.workflowRunId ?? '_unavailable_'}`,
+    ''
+  ];
+  appendFileSync(path, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function writeResult(env, result) {
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_outcome', result.outcome);
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_correlation_id', result.correlationId);
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_manifest_sha256', result.manifestDigest);
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_provider_commit', result.providerCommit);
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_provider_tag', result.providerTag);
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_workflow_run_id', result.workflowRunId);
+  appendOutput(env.GITHUB_OUTPUT, 'e2e_run_url', result.runUrl);
+  appendSummary(env.GITHUB_STEP_SUMMARY, result);
+}
+
+export async function runReleaseVerificationCli(env = process.env, dependencies = {}) {
+  let config;
+  try {
+    config = resolveConfig(env);
+    const result = await verifyCorrelatedRelease(config, dependencies);
+    writeResult(env, result);
     return { exitCode: 0, result };
   } catch (error) {
-    const result = errorResult(error, config);
-    const secrets = [config?.token, env.E2E_DISPATCH_TOKEN];
-    result.message = redact(result.message, secrets);
-    await appendOutputs(env.GITHUB_OUTPUT, {
-      e2e_outcome: result.outcome,
-      e2e_correlation_id: result.correlationId,
-      e2e_workflow_run_id: result.workflowRunId,
-      e2e_run_url: result.runUrl
-    });
-    if (config?.mode === 'report-only') {
-      log(`::warning::REPORT-ONLY: correlated E2E verification produced ${result.outcome}: ${result.message}`);
-      return { exitCode: 0, result };
-    }
-    errorLog(`::error::Correlated E2E verification failed (${result.outcome}): ${result.message}`);
+    const classified =
+      error instanceof ReleaseVerificationError
+        ? error
+        : new ReleaseVerificationError(
+            'verifier_unavailable',
+            error instanceof Error ? error.message : String(error)
+          );
+    const result = {
+      outcome: classified.code,
+      correlationId: config?.requestedCorrelationId,
+      providerCommit: config?.providerCommit,
+      providerTag: config?.providerTag,
+      workflowRunId: classified.details?.runId,
+      runUrl: classified.details?.runUrl
+    };
+    writeResult(env, result);
+    const safeMessage = redactTokenOccurrences(classified.message, env.E2E_DISPATCH_TOKEN);
+    (dependencies.error ?? globalThis.console.error)(
+      `::error::Closed E2E verification outcome=${classified.code}: ${safeMessage}`
+    );
     return { exitCode: 1, result };
   }
 }
 
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-if (isMain) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   if (process.argv.includes('--help')) {
     globalThis.console.log(
       'Usage: node scripts/verify-e2e-release.mjs\n' +
-        'Requires E2E_DISPATCH_TOKEN, E2E_GATE_ACTION, E2E_GATE_REF, E2E_GATE_SOURCE_DIGEST, GITHUB_REPOSITORY, GITHUB_RUN_ID, and GITHUB_RUN_ATTEMPT.'
+        'Requires a pinned provider tag/commit, canonical five-peer tag map, release tag/commit/artifact digest, and GitHub run identity.'
     );
   } else {
-    const { exitCode } = await runReleaseVerificationCli();
-    process.exitCode = exitCode;
+    const execution = await runReleaseVerificationCli();
+    process.exitCode = execution.exitCode;
   }
 }

--- a/scripts/verify-e2e-release.test.mjs
+++ b/scripts/verify-e2e-release.test.mjs
@@ -1,42 +1,189 @@
 import assert from 'node:assert/strict';
 import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
 import test from 'node:test';
 
 import {
   ReleaseVerificationError,
-  assertCompositeUsesCapability,
   buildCorrelationId,
   buildDispatchInputs,
   buildDispatchPayload,
+  buildReleaseEvidenceManifest,
+  canonicalJsonStringify,
   classifyTerminalRun,
   electCorrelatedRun,
   parseDispatchRunDetails,
+  parsePeerTags,
+  parseSingleFileZip,
+  resolveConfig,
+  resolveImmutableTagCommit,
   runReleaseVerificationCli,
-  shouldFailRelease,
+  validateReleaseEvidenceResult,
   validateRunIdentity,
-  waitForExactRunIdentity,
+  verifyCorrelatedRelease,
+  waitForRunIdentity,
   waitForTerminalRun
 } from './verify-e2e-release.mjs';
 
-const DIGEST = 'a'.repeat(64);
-const CORRELATION = 'postman-api-onboarding-action-42-1-v3.2.1-aaaaaaaaaaaaaaaa';
-const RUN_TITLE = `release monitor postman-api-onboarding-action@v3.2.1 ${CORRELATION}`;
+const RELEASE_SHA = 'a'.repeat(40);
+const PROVIDER_SHA = 'b'.repeat(40);
+const SOURCE_DIGEST = 'c'.repeat(64);
+const PROVIDER_SOURCE_DIGEST = 'd'.repeat(64);
+const PROVIDER_TAG = 'e2e-provider-v1.2.0';
+const RELEASE_TAG = 'v9.9.9';
+const PEER_TAGS = {
+  'postman-cs/postman-repo-sync-action': 'v2.10.3',
+  'postman-cs/postman-insights-onboarding-action': 'v2.5.2',
+  'postman-cs/postman-bootstrap-action': 'v2.21.5',
+  'postman-cs/postman-resolve-service-token-action': 'v2.2.4',
+  'postman-cs/postman-smoke-flow-action': 'v3.7.3'
+};
+const PEER_TAGS_JSON = canonicalJsonStringify(PEER_TAGS).trimEnd();
+const NOW = Date.parse('2026-08-29T04:00:00.000Z');
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function storedZip(name, data, { unixMode = 0o100644 } = {}) {
+  const filename = Buffer.from(name);
+  const content = Buffer.from(data);
+  const checksum = crc32(content);
+  const local = Buffer.alloc(30 + filename.length + content.length);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(20, 4);
+  local.writeUInt16LE(0x0800, 6);
+  local.writeUInt16LE(0, 8);
+  local.writeUInt32LE(checksum, 14);
+  local.writeUInt32LE(content.length, 18);
+  local.writeUInt32LE(content.length, 22);
+  local.writeUInt16LE(filename.length, 26);
+  filename.copy(local, 30);
+  content.copy(local, 30 + filename.length);
+
+  const central = Buffer.alloc(46 + filename.length);
+  central.writeUInt32LE(0x02014b50, 0);
+  central.writeUInt16LE((3 << 8) | 20, 4);
+  central.writeUInt16LE(20, 6);
+  central.writeUInt16LE(0x0800, 8);
+  central.writeUInt16LE(0, 10);
+  central.writeUInt32LE(checksum, 16);
+  central.writeUInt32LE(content.length, 20);
+  central.writeUInt32LE(content.length, 24);
+  central.writeUInt16LE(filename.length, 28);
+  central.writeUInt32LE((unixMode << 16) >>> 0, 38);
+  filename.copy(central, 46);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(central.length, 12);
+  eocd.writeUInt32LE(local.length, 16);
+  return Buffer.concat([local, central, eocd]);
+}
+
+function response(body, { status = 200 } = {}) {
+  const bytes = Buffer.isBuffer(body) ? body : Buffer.from(body ?? '');
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => String(bytes.length) },
+    async arrayBuffer() {
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    }
+  };
+}
+
+function jsonResponse(value, options) {
+  return response(JSON.stringify(value), options);
+}
+
+function baseConfig() {
+  return {
+    token: 'test-token',
+    repository: 'postman-cs/postman-api-onboarding-action',
+    refName: RELEASE_TAG,
+    sourceDigest: SOURCE_DIGEST,
+    releaseCommit: RELEASE_SHA,
+    action: 'postman-api-onboarding-action',
+    targetRepository: 'postman-cs/postman-actions-e2e',
+    workflow: 'e2e.yml',
+    providerTag: PROVIDER_TAG,
+    providerCommit: PROVIDER_SHA,
+    providerSourceDigest: PROVIDER_SOURCE_DIGEST,
+    peerTags: PEER_TAGS,
+    suite: 'full',
+    requestedCorrelationId: '',
+    runId: '42',
+    runAttempt: '1',
+    dispatchTimeoutMs: 1000,
+    lookupTimeoutMs: 1000,
+    verificationTimeoutMs: 1000,
+    initialPollMs: 1,
+    maxPollMs: 2
+  };
+}
+
+async function evidenceFixture() {
+  return buildReleaseEvidenceManifest(baseConfig(), {
+    resolveTagCommit: async ({ repository }) => {
+      if (repository === 'postman-cs/postman-actions-e2e') return PROVIDER_SHA;
+      if (repository === 'postman-cs/postman-api-onboarding-action') return RELEASE_SHA;
+      return sha256(repository).slice(0, 40);
+    },
+    digestRepositoryFile: async ({ repository, file }) => sha256(`${repository}:${file}`)
+  });
+}
+
+function terminalResult(evidence, overrides = {}) {
+  return {
+    manifestDigest: evidence.digest,
+    outcome: 'success',
+    provider: evidence.manifest.provider,
+    release: evidence.manifest.release,
+    run: { attempt: 1, id: '77' },
+    schemaVersion: 1,
+    suite: 'full',
+    ...overrides
+  };
+}
+
+const CORRELATION = 'postman-cs-postman-api-onboarding-action-42-1-v9.9.9-deadbeefdeadbeef';
+const RUN_TITLE = `release monitor postman-api-onboarding-action@${RELEASE_TAG} ${CORRELATION}`;
 const EXPECTED = {
   workflow: 'e2e.yml',
-  workflowRef: 'main',
+  providerTag: PROVIDER_TAG,
+  providerCommit: PROVIDER_SHA,
+  targetRepository: 'postman-cs/postman-actions-e2e',
   runTitle: RUN_TITLE,
   correlationId: CORRELATION,
-  notBeforeMs: Date.parse('2026-08-03T12:00:00.000Z')
+  notBeforeMs: NOW,
+  runAttempt: 1
 };
 
 function run(overrides = {}) {
   return {
     id: 77,
     event: 'workflow_dispatch',
-    head_branch: 'main',
+    head_branch: PROVIDER_TAG,
+    head_sha: PROVIDER_SHA,
+    repository: { full_name: 'postman-cs/postman-actions-e2e' },
     display_title: RUN_TITLE,
-    path: '.github/workflows/e2e.yml@refs/heads/main',
-    created_at: '2026-08-03T12:00:01.000Z',
+    path: `.github/workflows/e2e.yml@refs/tags/${PROVIDER_TAG}`,
+    run_attempt: 1,
+    created_at: '2026-08-29T04:00:01.000Z',
     status: 'completed',
     conclusion: 'success',
     html_url: 'https://github.test/postman-cs/postman-actions-e2e/actions/runs/77',
@@ -44,7 +191,175 @@ function run(overrides = {}) {
   };
 }
 
-test('dispatch response parsing captures the exact workflow run and supports fallback', () => {
+test('peer map is an exact canonical five-repository immutable-tag census', () => {
+  assert.deepEqual(parsePeerTags(PEER_TAGS_JSON), PEER_TAGS);
+  assert.throws(
+    () => parsePeerTags(JSON.stringify(Object.fromEntries(Object.entries(PEER_TAGS).reverse()))),
+    /canonical key ordering/
+  );
+  assert.throws(
+    () => parsePeerTags(canonicalJsonStringify({ ...PEER_TAGS, extra: 'v1.0.0' }).trimEnd()),
+    /exact five-repository/
+  );
+  assert.throws(
+    () =>
+      parsePeerTags(
+        canonicalJsonStringify({
+          ...PEER_TAGS,
+          'postman-cs/postman-smoke-flow-action': 'main'
+        }).trimEnd()
+      ),
+    /non-immutable/
+  );
+});
+
+test('closed manifest binds the provider, release artifact, and exact six-action closure', async () => {
+  const resolved = [];
+  const digested = [];
+  const evidence = await buildReleaseEvidenceManifest(baseConfig(), {
+    resolveTagCommit: async ({ repository, tag }) => {
+      resolved.push([repository, tag]);
+      if (repository === 'postman-cs/postman-actions-e2e') return PROVIDER_SHA;
+      if (repository === 'postman-cs/postman-api-onboarding-action') return RELEASE_SHA;
+      return sha256(repository).slice(0, 40);
+    },
+    digestRepositoryFile: async ({ repository, file }) => {
+      digested.push([repository, file]);
+      return sha256(`${repository}:${file}`);
+    }
+  });
+  assert.equal(resolved.length, 7);
+  assert.equal(digested.length, 6);
+  assert.equal(Object.keys(evidence.manifest.actions).length, 6);
+  assert.deepEqual(evidence.manifest.provider, {
+    commit: PROVIDER_SHA,
+    repository: 'postman-cs/postman-actions-e2e',
+    tag: PROVIDER_TAG
+  });
+  assert.deepEqual(evidence.manifest.release, {
+    artifactDigest: SOURCE_DIGEST,
+    commit: RELEASE_SHA,
+    kind: 'composite',
+    repository: 'postman-cs/postman-api-onboarding-action',
+    tag: RELEASE_TAG
+  });
+  assert.equal(
+    evidence.manifest.actions['postman-cs/postman-api-onboarding-action'].role,
+    'composite'
+  );
+  assert.equal(
+    evidence.manifest.actions['postman-cs/postman-repo-sync-action'].role,
+    'peer'
+  );
+  assert.deepEqual(
+    Object.values(evidence.manifest.actions).map(({ role }) => role).sort(),
+    ['composite', 'peer', 'peer', 'peer', 'peer', 'peer']
+  );
+  assert.equal(
+    evidence.manifest.actions['postman-cs/postman-insights-onboarding-action'].digestKind,
+    'action-definition-sha256'
+  );
+  assert.equal(
+    evidence.manifest.actions['postman-cs/postman-api-onboarding-action'].digestKind,
+    'action-definition-sha256'
+  );
+  assert.equal(evidence.bytes.toString(), canonicalJsonStringify(evidence.manifest));
+  assert.equal(evidence.digest, sha256(evidence.bytes));
+});
+
+test('manifest construction fails when provider or release tags do not resolve to pinned commits', async () => {
+  const common = {
+    digestRepositoryFile: async () => 'd'.repeat(64)
+  };
+  await assert.rejects(
+    () =>
+      buildReleaseEvidenceManifest(baseConfig(), {
+        ...common,
+        resolveTagCommit: async ({ repository }) =>
+          repository === 'postman-cs/postman-actions-e2e' ? 'f'.repeat(40) : RELEASE_SHA
+      }),
+    /provider tag does not resolve/
+  );
+  await assert.rejects(
+    () =>
+      buildReleaseEvidenceManifest(baseConfig(), {
+        ...common,
+        resolveTagCommit: async ({ repository }) =>
+          repository === 'postman-cs/postman-actions-e2e' ? PROVIDER_SHA : 'f'.repeat(40)
+      }),
+    /release tag does not resolve/
+  );
+});
+
+test('annotated provider tags are peeled to their exact commit', async () => {
+  const tagObject = 'e'.repeat(40);
+  const seen = [];
+  const commit = await resolveImmutableTagCommit({
+    repository: 'postman-cs/postman-actions-e2e',
+    tag: PROVIDER_TAG,
+    providerSourceDigest: PROVIDER_SOURCE_DIGEST,
+    token: 'test-token',
+    signal: globalThis.AbortSignal.timeout(1000),
+    fetchImpl: async (url) => {
+      seen.push(url);
+      if (url.endsWith(`/git/ref/tags/${PROVIDER_TAG}`)) {
+        return jsonResponse({
+          ref: `refs/tags/${PROVIDER_TAG}`,
+          object: { type: 'tag', sha: tagObject }
+        });
+      }
+      return jsonResponse({
+        tag: PROVIDER_TAG,
+        message: `E2E provider ${PROVIDER_TAG}\n\ne2e-provider-source-manifest-sha256:${PROVIDER_SOURCE_DIGEST}`,
+        object: { type: 'commit', sha: PROVIDER_SHA }
+      });
+    }
+  });
+  assert.equal(commit, PROVIDER_SHA);
+  assert.equal(seen.length, 2);
+});
+
+test('dispatch sends only the closed manifest protocol at the immutable provider tag', async () => {
+  const evidence = await evidenceFixture();
+  const correlationId = buildCorrelationId({
+    repository: 'postman-cs/postman-api-onboarding-action',
+    runId: '42',
+    runAttempt: '1',
+    refName: RELEASE_TAG,
+    manifestDigest: evidence.digest
+  });
+  const inputs = buildDispatchInputs({
+    action: 'postman-api-onboarding-action',
+    refName: RELEASE_TAG,
+    correlationId,
+    suite: 'full',
+    manifestBytes: evidence.bytes,
+    manifestDigest: evidence.digest
+  });
+  assert.deepEqual(Object.keys(inputs).sort(), [
+    'action',
+    'gate_correlation_id',
+    'ref',
+    'release_manifest_base64',
+    'release_manifest_sha256',
+    'suite'
+  ]);
+  assert.deepEqual(
+    buildDispatchPayload({
+      providerTag: PROVIDER_TAG,
+      action: 'postman-api-onboarding-action',
+      refName: RELEASE_TAG,
+      correlationId,
+      suite: 'full',
+      manifestBytes: evidence.bytes,
+      manifestDigest: evidence.digest
+    }),
+    { ref: PROVIDER_TAG, return_run_details: true, inputs }
+  );
+  assert.equal(Buffer.from(inputs.release_manifest_base64, 'base64').toString(), evidence.bytes.toString());
+});
+
+test('dispatch response parsing captures an exact run id and supports the 204 fallback', () => {
   assert.deepEqual(
     parseDispatchRunDetails(
       200,
@@ -67,74 +382,15 @@ test('dispatch response parsing captures the exact workflow run and supports fal
   );
 });
 
-test('dispatch pins exact action/ref/correlation/suite and registry scenario metadata', () => {
-  const correlationId = buildCorrelationId({
-    repository: 'postman-cs/postman-api-onboarding-action',
-    runId: '42',
-    runAttempt: '1',
-    refName: 'v3.2.1',
-    sourceDigest: DIGEST
-  });
-  assert.equal(correlationId, CORRELATION);
-  const inputs = buildDispatchInputs({
-    action: 'postman-api-onboarding-action',
-    refName: 'v3.2.1',
-    correlationId,
-    suite: 'full',
-    registryRevision: 'b'.repeat(64),
-    contractScenarios: '["composite.real-uses-all-protocols"]'
-  });
-  assert.deepEqual(inputs, {
-    action: 'postman-api-onboarding-action',
-    ref: 'v3.2.1',
-    gate_correlation_id: correlationId,
-    suite: 'full',
-    registry_revision: 'b'.repeat(64),
-    contract_scenarios: '["composite.real-uses-all-protocols"]'
-  });
-  assert.deepEqual(
-    buildDispatchPayload({
-      workflowRef: 'main',
-      action: 'postman-api-onboarding-action',
-      refName: 'v3.2.1',
-      correlationId,
-      suite: 'full'
-    }),
-    {
-      ref: 'main',
-      return_run_details: true,
-      inputs: {
-        action: 'postman-api-onboarding-action',
-        ref: 'v3.2.1',
-        gate_correlation_id: correlationId,
-        suite: 'full'
-      }
-    }
-  );
-});
-
-test('fallback elects one exact correlated run and refuses ambiguity or unrelated runs', () => {
-  const unrelated = [
-    run({ id: 1, display_title: `release monitor postman-api-onboarding-action@v3.2.0 ${CORRELATION}` }),
-    run({ id: 2, event: 'schedule' }),
-    run({ id: 3, head_branch: 'other' }),
-    run({ id: 4, created_at: '2026-08-03T11:59:00.000Z' })
-  ];
-  assert.equal(electCorrelatedRun([...unrelated, run()], EXPECTED)?.id, 77);
-  assert.equal(electCorrelatedRun(unrelated, EXPECTED), null);
-  assert.throws(
-    () => electCorrelatedRun([run({ id: 77 }), run({ id: 78 })], EXPECTED),
-    (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
-  );
-});
-
-test('run identity rejects ref, action, correlation, digest, and run-id mismatches', () => {
+test('run correlation binds provider tag, commit, repository, attempt, title, and workflow', () => {
   assert.equal(validateRunIdentity(run(), { ...EXPECTED, runId: '77' }).id, 77);
   for (const mismatch of [
-    run({ head_branch: 'release' }),
-    run({ display_title: RUN_TITLE.replace('v3.2.1', 'v3.2.0') }),
-    run({ display_title: RUN_TITLE.replace('aaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb') }),
-    run({ path: undefined }),
+    run({ head_branch: 'main' }),
+    run({ head_sha: 'e'.repeat(40) }),
+    run({ repository: { full_name: 'postman-cs/other' } }),
+    run({ run_attempt: 2 }),
+    run({ display_title: RUN_TITLE.replace(RELEASE_TAG, 'v9.9.8') }),
+    run({ path: '.github/workflows/other.yml' }),
     run({ id: 88 })
   ]) {
     assert.throws(
@@ -142,93 +398,38 @@ test('run identity rejects ref, action, correlation, digest, and run-id mismatch
       (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
     );
   }
+  assert.equal(electCorrelatedRun([run()], EXPECTED)?.id, 77);
+  assert.equal(electCorrelatedRun([run({ head_sha: 'e'.repeat(40) })], EXPECTED), null);
+  assert.throws(() => electCorrelatedRun([run(), run({ id: 78 })], EXPECTED), /multiple downstream/);
 });
 
-test('exact dispatch waits for run-name propagation but rejects stable identity mismatches', async () => {
-  let clock = 0;
-  let calls = 0;
-  const exact = await waitForExactRunIdentity({
-    config: { lookupTimeoutMs: 10, initialPollMs: 2, maxPollMs: 4 },
+test('run-name hydration is bounded while terminal polling preserves exact identity', async () => {
+  let clock = NOW;
+  let reads = 0;
+  const hydrated = await waitForRunIdentity({
+    config: { lookupTimeoutMs: 20, initialPollMs: 4, maxPollMs: 4 },
     runId: '77',
     expected: EXPECTED,
     fetchRun: async () => {
-      calls += 1;
-      return calls === 1
-        ? run({ display_title: 'e2e (live sandbox)', status: 'queued', conclusion: null })
-        : run({ status: 'queued', conclusion: null });
+      reads += 1;
+      return run({ display_title: reads === 1 ? 'e2e (live sandbox)' : RUN_TITLE });
     },
     now: () => clock,
     sleep: async (ms) => {
-      clock += ms;
+      clock += ms || 1;
     }
   });
-  assert.equal(exact.id, 77);
-  assert.equal(calls, 2);
+  assert.equal(hydrated.id, 77);
+  assert.equal(reads, 2);
 
-  calls = 0;
-  await assert.rejects(
-    () =>
-      waitForExactRunIdentity({
-        config: { lookupTimeoutMs: 10, initialPollMs: 2, maxPollMs: 4 },
-        runId: '77',
-        expected: EXPECTED,
-        fetchRun: async () => {
-          calls += 1;
-          return run({ head_branch: 'release' });
-        },
-        now: () => 0,
-        sleep: async () => {}
-      }),
-    (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
-  );
-  assert.equal(calls, 1);
-});
-
-test('exact dispatch bounds run-name propagation waits', async () => {
-  let clock = 0;
-  await assert.rejects(
-    () =>
-      waitForExactRunIdentity({
-        config: { lookupTimeoutMs: 5, initialPollMs: 2, maxPollMs: 2 },
-        runId: '77',
-        expected: EXPECTED,
-        fetchRun: async () => run({ display_title: 'e2e (live sandbox)' }),
-        now: () => clock,
-        sleep: async (ms) => {
-          clock += ms;
-        }
-      }),
-    (error) => error instanceof ReleaseVerificationError && error.code === 'correlation_mismatch'
-  );
-});
-
-test('terminal conclusions distinguish success, failure, cancelled, timed out, and blocked', () => {
-  assert.deepEqual(classifyTerminalRun(run({ status: 'in_progress', conclusion: null })), { terminal: false });
-  assert.deepEqual(classifyTerminalRun(run({ conclusion: 'success' })), { terminal: true, outcome: 'success' });
-  assert.deepEqual(classifyTerminalRun(run({ conclusion: 'failure' })), { terminal: true, outcome: 'failure' });
-  assert.deepEqual(classifyTerminalRun(run({ conclusion: 'cancelled' })), { terminal: true, outcome: 'cancelled' });
-  assert.deepEqual(classifyTerminalRun(run({ conclusion: 'timed_out' })), { terminal: true, outcome: 'timed_out' });
-  assert.deepEqual(classifyTerminalRun(run({ conclusion: 'skipped' })), { terminal: true, outcome: 'blocked' });
-  assert.throws(
-    () => classifyTerminalRun(run({ status: 'mystery', conclusion: null })),
-    (error) => error instanceof ReleaseVerificationError && error.code === 'blocked'
-  );
-});
-
-test('exact-run polling is bounded and reports verification_timeout', async () => {
-  let clock = 0;
+  clock = NOW;
   await assert.rejects(
     () =>
       waitForTerminalRun({
         config: { verificationTimeoutMs: 10, initialPollMs: 4, maxPollMs: 4 },
         runId: '77',
-        expected: { ...EXPECTED, notBeforeMs: 0 },
-        fetchRun: async () =>
-          run({
-            created_at: '1970-01-01T00:00:00.001Z',
-            status: 'in_progress',
-            conclusion: null
-          }),
+        expected: EXPECTED,
+        fetchRun: async () => run({ status: 'in_progress', conclusion: null }),
         now: () => clock,
         sleep: async (ms) => {
           clock += ms || 1;
@@ -238,109 +439,290 @@ test('exact-run polling is bounded and reports verification_timeout', async () =
   );
 });
 
-test('real released composite uses capability is mandatory and report-only is explicit', () => {
-  assert.throws(
-    () => assertCompositeUsesCapability('name: e2e\n'),
-    (error) =>
-      error instanceof ReleaseVerificationError &&
-      error.code === 'blocked' &&
-      /E2E_COMPOSITE_USES_UNAVAILABLE/.test(error.message)
-  );
-  assert.doesNotThrow(() =>
-    assertCompositeUsesCapability(`
-if: inputs.action == 'postman-api-onboarding-action'
-repository: postman-cs/postman-api-onboarding-action
-ref: \${{ inputs.action == 'postman-api-onboarding-action' && inputs.ref }}
-uses: ./postman-api-onboarding-action
-postman-team-id: '10490519'
-repo-write-mode: none
-echo "::error::POSTMAN_E2E_API_KEY_NON_ORG_MODE is required for composite smoke."
-needs: [failure-injection, plan, monitor, composite-smoke]
-`)
-  );
-  assert.equal(shouldFailRelease(undefined, 'failure'), true);
-  assert.equal(shouldFailRelease('enforce', 'blocked'), true);
-  assert.equal(shouldFailRelease('enforce', 'success'), false);
-  assert.equal(shouldFailRelease('report-only', 'failure'), false);
+test('terminal conclusions distinguish all release decisions', () => {
+  assert.deepEqual(classifyTerminalRun(run({ status: 'in_progress', conclusion: null })), {
+    terminal: false
+  });
+  for (const outcome of ['success', 'failure', 'cancelled', 'timed_out']) {
+    assert.deepEqual(classifyTerminalRun(run({ conclusion: outcome })), {
+      terminal: true,
+      outcome
+    });
+  }
+  assert.deepEqual(classifyTerminalRun(run({ conclusion: 'skipped' })), {
+    terminal: true,
+    outcome: 'blocked'
+  });
 });
 
-test('CLI distinguishes dispatch auth errors and report-only is the only green override', async () => {
+test('terminal artifact ZIP requires one exact regular bounded entry with valid CRC', () => {
+  const content = Buffer.from('proof\n');
+  const archive = storedZip('e2e-release-result.json', content);
+  assert.deepEqual(parseSingleFileZip(archive, 'e2e-release-result.json'), content);
+  assert.throws(() => parseSingleFileZip(archive, 'other.json'), /entry metadata is invalid/);
+  const corrupt = Buffer.from(archive);
+  corrupt[55] ^= 1;
+  assert.throws(() => parseSingleFileZip(corrupt, 'e2e-release-result.json'), /checksum/);
+  for (const unixMode of [0o040755, 0o060600, 0o120777]) {
+    assert.throws(
+      () =>
+        parseSingleFileZip(
+          storedZip('e2e-release-result.json', content, { unixMode }),
+          'e2e-release-result.json'
+        ),
+      /entry metadata is invalid/
+    );
+  }
+});
+
+test('terminal result is canonical and exactly binds manifest, provider, release artifact, and run', async () => {
+  const evidence = await evidenceFixture();
+  const result = terminalResult(evidence);
+  const bytes = Buffer.from(canonicalJsonStringify(result));
+  assert.deepEqual(
+    validateReleaseEvidenceResult(bytes, {
+      manifest: evidence.manifest,
+      manifestDigest: evidence.digest,
+      runId: '77',
+      runAttempt: 1
+    }),
+    result
+  );
+  for (const mismatch of [
+    { outcome: 'failure' },
+    { manifestDigest: 'f'.repeat(64) },
+    { provider: { ...result.provider, commit: 'f'.repeat(40) } },
+    { release: { ...result.release, artifactDigest: 'f'.repeat(64) } },
+    { run: { attempt: 2, id: '77' } }
+  ]) {
+    assert.throws(
+      () =>
+        validateReleaseEvidenceResult(
+          Buffer.from(canonicalJsonStringify({ ...result, ...mismatch })),
+          {
+            manifest: evidence.manifest,
+            manifestDigest: evidence.digest,
+            runId: '77',
+            runAttempt: 1
+          }
+        ),
+      /does not match/
+    );
+  }
+  assert.throws(
+    () =>
+      validateReleaseEvidenceResult(Buffer.from(JSON.stringify(result)), {
+        manifest: evidence.manifest,
+        manifestDigest: evidence.digest,
+        runId: '77',
+        runAttempt: 1
+      }),
+    /canonical JSON/
+  );
+});
+
+test('complete verifier requires the exact terminal artifact after a successful run', async () => {
+  const evidence = await evidenceFixture();
+  const correlationId = buildCorrelationId({
+    repository: 'postman-cs/postman-api-onboarding-action',
+    runId: '42',
+    runAttempt: '1',
+    refName: RELEASE_TAG,
+    manifestDigest: evidence.digest
+  });
+  const title = `release monitor postman-api-onboarding-action@${RELEASE_TAG} ${correlationId}`;
+  const exactRun = run({ display_title: title });
+  const resultBytes = Buffer.from(canonicalJsonStringify(terminalResult(evidence)));
+  const archive = storedZip('e2e-release-result.json', resultBytes);
+  const requests = [];
+  const fetchImpl = async (url, options = {}) => {
+    requests.push({ url, options });
+    if (options.method === 'POST') {
+      const payload = JSON.parse(options.body);
+      assert.equal(payload.ref, PROVIDER_TAG);
+      assert.equal(payload.inputs.release_manifest_sha256, evidence.digest);
+      assert.equal(
+        Buffer.from(payload.inputs.release_manifest_base64, 'base64').toString(),
+        evidence.bytes.toString()
+      );
+      return jsonResponse({ workflow_run_id: 77 });
+    }
+    if (url.includes('/actions/runs/77/artifacts?')) {
+      return jsonResponse({
+        total_count: 1,
+        artifacts: [
+          {
+            id: 91,
+            name: 'e2e-release-result-77-1',
+            expired: false,
+            size_in_bytes: archive.length,
+            workflow_run: {
+              id: 77,
+              head_branch: PROVIDER_TAG,
+              head_sha: PROVIDER_SHA
+            }
+          }
+        ]
+      });
+    }
+    if (url.endsWith('/actions/artifacts/91/zip')) return response(archive);
+    if (url.endsWith('/actions/runs/77')) return jsonResponse(exactRun);
+    throw new Error(`unexpected request: ${url}`);
+  };
+  const result = await verifyCorrelatedRelease(baseConfig(), {
+    buildEvidence: async () => evidence,
+    fetchImpl,
+    now: () => NOW,
+    sleep: async () => {},
+    log() {}
+  });
+  assert.equal(result.outcome, 'success');
+  assert.equal(result.manifestDigest, evidence.digest);
+  assert.ok(requests.some(({ url }) => url.endsWith('/actions/artifacts/91/zip')));
+});
+
+test('terminal artifact lookup rejects an incomplete artifact census', async () => {
+  const evidence = await evidenceFixture();
+  const correlationId = buildCorrelationId({
+    repository: 'postman-cs/postman-api-onboarding-action',
+    runId: '42',
+    runAttempt: '1',
+    refName: RELEASE_TAG,
+    manifestDigest: evidence.digest
+  });
+  const exactRun = run({
+    display_title: `release monitor postman-api-onboarding-action@${RELEASE_TAG} ${correlationId}`
+  });
+  const archive = storedZip(
+    'e2e-release-result.json',
+    Buffer.from(canonicalJsonStringify(terminalResult(evidence)))
+  );
+  const fetchImpl = async (url, options = {}) => {
+    if (options.method === 'POST') return jsonResponse({ workflow_run_id: 77 });
+    if (url.endsWith('/actions/runs/77')) return jsonResponse(exactRun);
+    if (url.includes('/actions/runs/77/artifacts?')) {
+      return jsonResponse({
+        total_count: 2,
+        artifacts: [
+          {
+            id: 91,
+            name: 'e2e-release-result-77-1',
+            expired: false,
+            size_in_bytes: archive.length,
+            workflow_run: { id: 77, head_branch: PROVIDER_TAG, head_sha: PROVIDER_SHA }
+          }
+        ]
+      });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+  await assert.rejects(
+    () =>
+      verifyCorrelatedRelease(baseConfig(), {
+        buildEvidence: async () => evidence,
+        fetchImpl,
+        now: () => NOW,
+        sleep: async () => {},
+        log() {}
+      }),
+    /artifact response was incomplete or invalid/
+  );
+});
+
+test('successful workflow conclusion without an exact terminal artifact fails closed', async () => {
+  const evidence = await evidenceFixture();
+  const correlationId = buildCorrelationId({
+    repository: 'postman-cs/postman-api-onboarding-action',
+    runId: '42',
+    runAttempt: '1',
+    refName: RELEASE_TAG,
+    manifestDigest: evidence.digest
+  });
+  const exactRun = run({
+    display_title: `release monitor postman-api-onboarding-action@${RELEASE_TAG} ${correlationId}`
+  });
+  let clock = NOW;
+  const fetchImpl = async (url, options = {}) => {
+    if (options.method === 'POST') return jsonResponse({ workflow_run_id: 77 });
+    if (url.includes('/actions/runs/77/artifacts?')) {
+      clock += 1001;
+      return jsonResponse({ total_count: 0, artifacts: [] });
+    }
+    if (url.endsWith('/actions/runs/77')) return jsonResponse(exactRun);
+    throw new Error(`unexpected request: ${url}`);
+  };
+  await assert.rejects(
+    () =>
+      verifyCorrelatedRelease(baseConfig(), {
+        buildEvidence: async () => evidence,
+        fetchImpl,
+        now: () => clock,
+        sleep: async () => {},
+        log() {}
+      }),
+    /exact terminal result artifact/
+  );
+});
+
+test('release configuration has no report-only or mutable-provider escape hatch', () => {
   const env = {
     E2E_DISPATCH_TOKEN: 'test-token',
     E2E_GATE_ACTION: 'postman-api-onboarding-action',
-    E2E_GATE_REF: 'v3.2.1',
-    E2E_GATE_SOURCE_DIGEST: DIGEST,
+    E2E_GATE_REF: RELEASE_TAG,
+    E2E_GATE_RELEASE_COMMIT: RELEASE_SHA,
+    E2E_GATE_SOURCE_DIGEST: SOURCE_DIGEST,
+    E2E_GATE_PROVIDER_TAG: PROVIDER_TAG,
+    E2E_GATE_PROVIDER_COMMIT: PROVIDER_SHA,
+    E2E_GATE_PROVIDER_SOURCE_DIGEST: PROVIDER_SOURCE_DIGEST,
+    E2E_GATE_PEER_TAGS: PEER_TAGS_JSON,
     E2E_GATE_SUITE: 'full',
     GITHUB_REPOSITORY: 'postman-cs/postman-api-onboarding-action',
     GITHUB_RUN_ID: '42',
     GITHUB_RUN_ATTEMPT: '1'
   };
-  const workflow = Buffer.from(`
-if: inputs.action == 'postman-api-onboarding-action'
-repository: postman-cs/postman-api-onboarding-action
-ref: \${{ inputs.action == 'postman-api-onboarding-action' && inputs.ref }}
-uses: ./postman-api-onboarding-action
-postman-team-id: '10490519'
-repo-write-mode: none
-echo "::error::POSTMAN_E2E_API_KEY_NON_ORG_MODE is required for composite smoke."
-needs: [failure-injection, plan, monitor, composite-smoke]
-`).toString('base64');
-  const makeFetch = () => {
-    let call = 0;
-    return async () => {
-      call += 1;
-      if (call === 1) {
-        return { ok: true, status: 200, text: async () => JSON.stringify({ encoding: 'base64', content: workflow }) };
-      }
-      return { ok: false, status: 403, text: async () => 'denied test-token' };
-    };
-  };
-  const enforced = await runReleaseVerificationCli(env, { fetchImpl: makeFetch(), log() {}, error() {} });
-  assert.equal(enforced.exitCode, 1);
-  assert.equal(enforced.result.outcome, 'dispatch_auth_error');
-
-  const warnings = [];
-  const reportOnly = await runReleaseVerificationCli(
-    { ...env, E2E_GATE_MODE: 'report-only' },
-    { fetchImpl: makeFetch(), log: (line) => warnings.push(line), error() {} }
+  assert.equal(resolveConfig(env).providerTag, PROVIDER_TAG);
+  assert.throws(() => resolveConfig({ ...env, E2E_GATE_MODE: 'report-only' }), /fail-closed/);
+  assert.throws(() => resolveConfig({ ...env, E2E_GATE_PROVIDER_TAG: 'main' }), /identity inputs/);
+  assert.throws(() => resolveConfig({ ...env, E2E_GATE_SUITE: 'smoke' }), /identity inputs/);
+  assert.throws(
+    () =>
+      resolveConfig({
+        ...env,
+        E2E_GATE_REPOSITORY: 'postman-cs/postman-actions-e2e'
+      }),
+    /do not accept environment overrides/
   );
-  assert.equal(reportOnly.exitCode, 0);
-  assert.equal(reportOnly.result.outcome, 'dispatch_auth_error');
-  assert.ok(warnings.some((line) => line.includes('REPORT-ONLY')));
-  assert.ok(warnings.every((line) => !line.includes('test-token')));
+  assert.throws(
+    () => resolveConfig({ ...env, E2E_GATE_WORKFLOW: 'e2e.yml' }),
+    /do not accept environment overrides/
+  );
 });
 
-test('CLI fails closed with the named blocker before dispatch when real composite uses is absent', async () => {
-  let calls = 0;
-  const result = await runReleaseVerificationCli(
-    {
-      E2E_DISPATCH_TOKEN: 'test-token',
-      E2E_GATE_ACTION: 'postman-api-onboarding-action',
-      E2E_GATE_REF: 'v3.2.1',
-      E2E_GATE_SOURCE_DIGEST: DIGEST,
-      GITHUB_REPOSITORY: 'postman-cs/postman-api-onboarding-action',
-      GITHUB_RUN_ID: '42',
-      GITHUB_RUN_ATTEMPT: '1'
-    },
-    {
-      fetchImpl: async () => {
-        calls += 1;
-        return {
-          ok: true,
-          status: 200,
-          text: async () =>
-            JSON.stringify({
-              encoding: 'base64',
-              content: Buffer.from('name: e2e\n').toString('base64')
-            })
-        };
-      },
-      log() {},
-      error() {}
-    }
-  );
-  assert.equal(result.exitCode, 1);
-  assert.equal(result.result.outcome, 'blocked');
-  assert.match(result.result.message, /E2E_COMPOSITE_USES_UNAVAILABLE/);
-  assert.equal(calls, 1);
+test('CLI redacts dispatch credentials and always fails a dispatch auth error', async () => {
+  const env = {
+    E2E_DISPATCH_TOKEN: 'test-token',
+    E2E_GATE_ACTION: 'postman-api-onboarding-action',
+    E2E_GATE_REF: RELEASE_TAG,
+    E2E_GATE_RELEASE_COMMIT: RELEASE_SHA,
+    E2E_GATE_SOURCE_DIGEST: SOURCE_DIGEST,
+    E2E_GATE_PROVIDER_TAG: PROVIDER_TAG,
+    E2E_GATE_PROVIDER_COMMIT: PROVIDER_SHA,
+    E2E_GATE_PROVIDER_SOURCE_DIGEST: PROVIDER_SOURCE_DIGEST,
+    E2E_GATE_PEER_TAGS: PEER_TAGS_JSON,
+    E2E_GATE_SUITE: 'full',
+    GITHUB_REPOSITORY: 'postman-cs/postman-api-onboarding-action',
+    GITHUB_RUN_ID: '42',
+    GITHUB_RUN_ATTEMPT: '1'
+  };
+  const errors = [];
+  const execution = await runReleaseVerificationCli(env, {
+    buildEvidence: evidenceFixture,
+    fetchImpl: async () => response('denied test-token', { status: 403 }),
+    log() {},
+    error: (line) => errors.push(line)
+  });
+  assert.equal(execution.exitCode, 1);
+  assert.equal(execution.result.outcome, 'dispatch_auth_error');
+  assert.ok(errors.every((line) => !line.includes('test-token')));
+  assert.ok(errors.some((line) => line.includes('[REDACTED]')));
 });

--- a/scripts/verify-e2e-release.test.mjs
+++ b/scripts/verify-e2e-release.test.mjs
@@ -32,11 +32,11 @@ const PROVIDER_SOURCE_DIGEST = 'd'.repeat(64);
 const PROVIDER_TAG = 'e2e-provider-v1.2.0';
 const RELEASE_TAG = 'v9.9.9';
 const PEER_TAGS = {
-  'postman-cs/postman-repo-sync-action': 'v2.10.3',
+  'postman-cs/postman-repo-sync-action': 'v2.10.9',
   'postman-cs/postman-insights-onboarding-action': 'v2.5.2',
-  'postman-cs/postman-bootstrap-action': 'v2.21.5',
+  'postman-cs/postman-bootstrap-action': 'v2.21.10',
   'postman-cs/postman-resolve-service-token-action': 'v2.2.4',
-  'postman-cs/postman-smoke-flow-action': 'v3.7.3'
+  'postman-cs/postman-smoke-flow-action': 'v3.7.4'
 };
 const PEER_TAGS_JSON = canonicalJsonStringify(PEER_TAGS).trimEnd();
 const NOW = Date.parse('2026-08-29T04:00:00.000Z');

--- a/templates/azure-devops/windows-onboarding.yml
+++ b/templates/azure-devops/windows-onboarding.yml
@@ -88,6 +88,22 @@ jobs:
 
       - pwsh: |
           $ErrorActionPreference = 'Stop'
+          $versionByParameter = [ordered]@{
+            resolveVersion = $env:RESOLVE_VERSION
+            bootstrapVersion = $env:BOOTSTRAP_VERSION
+            smokeFlowVersion = $env:SMOKE_FLOW_VERSION
+            repoSyncVersion = $env:REPO_SYNC_VERSION
+            insightsVersion = $env:INSIGHTS_VERSION
+          }
+          # Exact SemVer only. In particular, reject npm tags/ranges and the
+          # URL, Git, and file specs that npm otherwise accepts after `name@`.
+          $semverPattern = '\A(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?\z'
+          foreach ($entry in $versionByParameter.GetEnumerator()) {
+            $value = [string]$entry.Value
+            if ($value.Length -gt 128 -or $value -cnotmatch $semverPattern) {
+              throw "Invalid exact SemVer for $($entry.Key)."
+            }
+          }
           $packages = @(
             "@postman-cs/onboarding-resolve-service-token@$env:RESOLVE_VERSION",
             "@postman-cs/onboarding-bootstrap@$env:BOOTSTRAP_VERSION",

--- a/tests/advance-pins.test.ts
+++ b/tests/advance-pins.test.ts
@@ -400,12 +400,18 @@ describe('pin literal rewriting', () => {
     const text = [
       'uses: postman-cs/postman-bootstrap-action@v2.13.7',
       '`postman-cs/postman-bootstrap-action@v2.13.7`',
+      'E2E_GATE_PEER_TAGS: \'{"postman-cs/postman-bootstrap-action":"v2.13.7"}\'',
+      "'postman-cs/postman-bootstrap-action': 'v2.13.7'",
       'postman-cs/postman-bootstrap-action@v2',
       'postman-cs/postman-repo-sync-action@v2.6.8'
     ].join('\n');
     const result = rewritePinLiterals(text, 'postman-bootstrap-action', 'v2.13.8');
     expect(result).toContain('uses: postman-cs/postman-bootstrap-action@v2.13.8');
     expect(result).toContain('`postman-cs/postman-bootstrap-action@v2.13.8`');
+    expect(result).toContain(
+      'E2E_GATE_PEER_TAGS: \'{"postman-cs/postman-bootstrap-action":"v2.13.8"}\''
+    );
+    expect(result).toContain("'postman-cs/postman-bootstrap-action': 'v2.13.8'");
     expect(result).toContain('postman-cs/postman-bootstrap-action@v2\n');
     expect(result).toContain('postman-cs/postman-repo-sync-action@v2.6.8');
   });
@@ -503,7 +509,17 @@ describe('advance-pins workflow', () => {
   });
 
   it('keeps current real sibling refs in updater-owned contract tests', () => {
-    expect(PIN_FILES).toContain('tests/contract.test.ts');
+    expect(PIN_FILES).toEqual([
+      'action.yml',
+      '.github/workflows/release.yml',
+      'scripts/verify-e2e-release.test.mjs',
+      'tests/contract.test.ts',
+      'tests/release-workflow.test.ts',
+      'RELEASE_POLICY.md',
+      'README.md'
+    ]);
+    const stagedFiles = advanceWorkflow.match(/git add \\\n([\s\S]*?)\n\s+git commit/)?.[1] ?? '';
+    for (const file of PIN_FILES) expect(stagedFiles).toContain(file);
     const pins = extractPins(actionManifest);
     for (const { repo, tag } of pins) {
       expect(contractTests).toContain(`postman-cs/${repo}@${tag}`);

--- a/tests/advance-pins.test.ts
+++ b/tests/advance-pins.test.ts
@@ -1,10 +1,10 @@
 /**
  * Sibling pin auto-advance contract.
  *
- * Pins the invariants that keep the pin-advance path safe: an advance never
- * crosses the recorded major, never touches rolling aliases, and the
- * advance-pins workflow validates the moved pins with the sibling-pin gate
- * and the full test suite before anything is pushed or a PR is opened.
+ * Pins the invariants that keep the pin-advance path safe: an advance selects
+ * only the exact immutable release at the rolling alias commit, verifies its
+ * GitHub Release manifest, never crosses the recorded major, and runs every
+ * gate before a topic branch or pull request is created.
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -12,11 +12,14 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  EXPECTED_SIBLING_PACKAGE_NAMES,
   PIN_FILES,
+  PINNED_SIBLING_REPOSITORIES,
   extractPins,
-  latestImmutableForMajor,
   planAdvance,
-  rewritePinLiterals
+  rewritePinLiterals,
+  selectPromotedImmutable,
+  validateReleaseIdentity
 } from '../scripts/advance-pins.mjs';
 
 const repoRoot = process.cwd();
@@ -26,21 +29,94 @@ const advanceWorkflow = readFileSync(
 ).replace(/\r\n/g, '\n');
 const actionManifest = readFileSync(join(repoRoot, 'action.yml'), 'utf8');
 const contractTests = readFileSync(join(repoRoot, 'tests/contract.test.ts'), 'utf8');
+const selectorSource = readFileSync(join(repoRoot, 'scripts/advance-pins.mjs'), 'utf8');
+
+const oldCommit = 'a'.repeat(40);
+const promotedCommit = 'b'.repeat(40);
+const unpromotedCommit = 'c'.repeat(40);
+const releaseTgzDigest = 'd'.repeat(64);
+const manifestAssetDigest = 'e'.repeat(64);
+
+function annotatedTag(name: string, commit: string, object = 'e'.repeat(40)): string {
+  return [
+    `${object}\trefs/tags/${name}`,
+    `${commit}\trefs/tags/${name}^{}`
+  ].join('\n');
+}
+
+function promotedRefs(extras: string[] = []): string {
+  return [
+    annotatedTag('v2', promotedCommit, '1'.repeat(40)),
+    annotatedTag('v2.13.8', oldCommit, '2'.repeat(40)),
+    annotatedTag('v2.14.0', promotedCommit, '3'.repeat(40)),
+    annotatedTag('v2.15.0', unpromotedCommit, '4'.repeat(40)),
+    ...extras
+  ].join('\n');
+}
+
+function releaseEnvelope(overrides: {
+  release?: Record<string, unknown>;
+  manifest?: Record<string, unknown>;
+  manifestDigest?: string;
+} = {}) {
+  const release = {
+    id: 42,
+    tag_name: 'v2.14.0',
+    draft: false,
+    prerelease: false,
+    assets: [
+      {
+        name: 'release-manifest.json',
+        state: 'uploaded',
+        size: 512,
+        digest: `sha256:${manifestAssetDigest}`,
+        url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/1'
+      },
+      {
+        name: 'release.tgz',
+        state: 'uploaded',
+        size: 4096,
+        digest: `sha256:${releaseTgzDigest}`,
+        url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/2'
+      }
+    ],
+    ...overrides.release
+  };
+  const manifest = {
+    schema_version: 1,
+    repository: 'postman-cs/postman-bootstrap-action',
+    commit_sha: promotedCommit,
+    tag: 'v2.14.0',
+    package_name: '@postman-cs/onboarding-bootstrap',
+    package_version: '2.14.0',
+    artifacts: [{ path: 'release.tgz', sha256: releaseTgzDigest }],
+    ...overrides.manifest
+  };
+  return { release, manifest, manifestDigest: overrides.manifestDigest ?? manifestAssetDigest };
+}
+
+function verifiedPromotion(tag = 'v2.14.0') {
+  return {
+    repo: 'postman-bootstrap-action',
+    tag,
+    commit: promotedCommit,
+    releaseId: 42,
+    artifactDigest: releaseTgzDigest
+  };
+}
 
 describe('pin extraction', () => {
-  it('extracts every immutable sibling pin from the real manifest', () => {
+  it('extracts exactly the closed immutable sibling allowlist from the real manifest', () => {
     const pins = extractPins(actionManifest);
     const repos = pins.map((pin) => pin.repo).sort();
-    expect(repos).toEqual([
-      'postman-bootstrap-action',
-      'postman-insights-onboarding-action',
-      'postman-repo-sync-action',
-      'postman-smoke-flow-action'
-    ]);
+    expect(repos).toEqual([...PINNED_SIBLING_REPOSITORIES].sort());
     for (const pin of pins) {
       expect(pin.tag).toMatch(/^v\d+\.\d+\.\d+$/);
       expect(pin.major).toBe(Number(pin.tag.slice(1).split('.')[0]));
     }
+    expect(Object.keys(EXPECTED_SIBLING_PACKAGE_NAMES).sort()).toEqual(
+      [...PINNED_SIBLING_REPOSITORIES].sort()
+    );
   });
 
   it('rejects conflicting pins for the same sibling', () => {
@@ -50,26 +126,272 @@ describe('pin extraction', () => {
     ].join('\n');
     expect(() => extractPins(text)).toThrow(/conflicting pins/);
   });
+
+  it('rejects missing and unexpected sibling repositories', () => {
+    expect(() =>
+      extractPins(
+        actionManifest.replace(
+          /uses: postman-cs\/postman-bootstrap-action@v\d+\.\d+\.\d+/,
+          ''
+        )
+      )
+    ).toThrow(/missing required immutable sibling pins/);
+    expect(() =>
+      extractPins(`${actionManifest}\nuses: postman-cs/postman-unreviewed-action@v2.1.0`)
+    ).toThrow(/unexpected sibling repository/);
+  });
+});
+
+describe('promoted alias selection', () => {
+  it('selects only the immutable tag at the rolling alias commit', () => {
+    expect(
+      selectPromotedImmutable({
+        repo: 'postman-bootstrap-action',
+        major: 2,
+        lsRemoteText: promotedRefs()
+      })
+    ).toEqual({
+      repo: 'postman-bootstrap-action',
+      tag: 'v2.14.0',
+      commit: promotedCommit
+    });
+  });
+
+  it('ignores a newer immutable tag that the rolling alias has not promoted', () => {
+    const selected = selectPromotedImmutable({
+      repo: 'postman-bootstrap-action',
+      major: 2,
+      lsRemoteText: promotedRefs()
+    });
+    expect(selected.tag).toBe('v2.14.0');
+    expect(selected.tag).not.toBe('v2.15.0');
+  });
+
+  it.each([
+    {
+      label: 'missing alias',
+      refs: annotatedTag('v2.14.0', promotedCommit)
+    },
+    {
+      label: 'alias without an immutable target',
+      refs: annotatedTag('v2', promotedCommit)
+    },
+    {
+      label: 'ambiguous immutable targets',
+      refs: promotedRefs([annotatedTag('v2.14.1', promotedCommit, '5'.repeat(40))])
+    },
+    {
+      label: 'only a cross-major target',
+      refs: [annotatedTag('v2', promotedCommit), annotatedTag('v3.0.0', promotedCommit)].join('\n')
+    }
+  ])('fails closed for $label', ({ refs }) => {
+    expect(() =>
+      selectPromotedImmutable({
+        repo: 'postman-bootstrap-action',
+        major: 2,
+        lsRemoteText: refs
+      })
+    ).toThrow();
+  });
+});
+
+describe('GitHub Release identity', () => {
+  it('binds the promoted tag and commit to the release manifest and tarball digest', () => {
+    const { release, manifest, manifestDigest } = releaseEnvelope();
+    expect(
+      validateReleaseIdentity({
+        repo: 'postman-bootstrap-action',
+        promoted: { tag: 'v2.14.0', commit: promotedCommit },
+        release,
+        manifest,
+        manifestDigest
+      })
+    ).toEqual(verifiedPromotion());
+  });
+
+  it.each([
+    {
+      label: 'wrong release tag',
+      envelope: releaseEnvelope({ release: { tag_name: 'v2.15.0' } })
+    },
+    {
+      label: 'draft release',
+      envelope: releaseEnvelope({ release: { draft: true } })
+    },
+    {
+      label: 'prerelease',
+      envelope: releaseEnvelope({ release: { prerelease: true } })
+    },
+    {
+      label: 'missing manifest asset',
+      envelope: releaseEnvelope({
+        release: {
+          assets: [
+            {
+              name: 'release.tgz',
+              state: 'uploaded',
+              size: 4096,
+              url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/2'
+            }
+          ]
+        }
+      })
+    },
+    {
+      label: 'wrong manifest repository',
+      envelope: releaseEnvelope({ manifest: { repository: 'attacker/repository' } })
+    },
+    {
+      label: 'wrong sibling package name',
+      envelope: releaseEnvelope({ manifest: { package_name: '@postman-cs/onboarding-repo-sync' } })
+    },
+    {
+      label: 'wrong manifest commit',
+      envelope: releaseEnvelope({ manifest: { commit_sha: unpromotedCommit } })
+    },
+    {
+      label: 'wrong manifest tag',
+      envelope: releaseEnvelope({ manifest: { tag: 'v2.15.0' } })
+    },
+    {
+      label: 'invalid tarball digest',
+      envelope: releaseEnvelope({
+        manifest: { artifacts: [{ path: 'release.tgz', sha256: 'not-a-digest' }] }
+      })
+    },
+    {
+      label: 'duplicate artifact path',
+      envelope: releaseEnvelope({
+        manifest: {
+          artifacts: [
+            { path: 'release.tgz', sha256: releaseTgzDigest },
+            { path: 'release.tgz', sha256: 'f'.repeat(64) }
+          ]
+        }
+      })
+    },
+    {
+      label: 'missing manifest asset digest',
+      envelope: releaseEnvelope({
+        release: {
+          assets: [
+            {
+              name: 'release-manifest.json',
+              state: 'uploaded',
+              size: 512,
+              url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/1'
+            },
+            {
+              name: 'release.tgz',
+              state: 'uploaded',
+              size: 4096,
+              digest: `sha256:${releaseTgzDigest}`,
+              url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/2'
+            }
+          ]
+        }
+      })
+    },
+    {
+      label: 'malformed tarball asset digest',
+      envelope: releaseEnvelope({
+        release: {
+          assets: [
+            {
+              name: 'release-manifest.json',
+              state: 'uploaded',
+              size: 512,
+              digest: `sha256:${manifestAssetDigest}`,
+              url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/1'
+            },
+            {
+              name: 'release.tgz',
+              state: 'uploaded',
+              size: 4096,
+              digest: 'sha256:not-a-digest',
+              url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/2'
+            }
+          ]
+        }
+      })
+    },
+    {
+      label: 'downloaded manifest digest mismatch',
+      envelope: releaseEnvelope({ manifestDigest: 'f'.repeat(64) })
+    },
+    {
+      label: 'tarball manifest and asset digest mismatch',
+      envelope: releaseEnvelope({
+        manifest: { artifacts: [{ path: 'release.tgz', sha256: 'f'.repeat(64) }] }
+      })
+    },
+    {
+      label: 'untrusted tarball asset API URL',
+      envelope: releaseEnvelope({
+        release: {
+          assets: [
+            {
+              name: 'release-manifest.json',
+              state: 'uploaded',
+              size: 512,
+              digest: `sha256:${manifestAssetDigest}`,
+              url: 'https://api.github.com/repos/postman-cs/postman-bootstrap-action/releases/assets/1'
+            },
+            {
+              name: 'release.tgz',
+              state: 'uploaded',
+              size: 4096,
+              digest: `sha256:${releaseTgzDigest}`,
+              url: 'https://attacker.example/releases/assets/2'
+            }
+          ]
+        }
+      })
+    }
+  ])('rejects $label', ({ envelope }) => {
+    expect(() =>
+      validateReleaseIdentity({
+        repo: 'postman-bootstrap-action',
+        promoted: { tag: 'v2.14.0', commit: promotedCommit },
+        release: envelope.release,
+        manifest: envelope.manifest,
+        manifestDigest: envelope.manifestDigest
+      })
+    ).toThrow();
+  });
 });
 
 describe('advance planning', () => {
-  const tags = ['v1.9.9', 'v2.13.8', 'v2.14.0', 'v3.0.0', 'v2.14', 'v2', 'not-a-tag'];
-
-  it('selects the newest immutable tag of the recorded major only', () => {
-    expect(latestImmutableForMajor(tags, 2)).toBe('v2.14.0');
-    expect(latestImmutableForMajor(tags, 3)).toBe('v3.0.0');
-    expect(latestImmutableForMajor(tags, 4)).toBeNull();
-  });
-
-  it('advances within the major and never across it', () => {
+  it('advances within the major to the verified promoted release only', () => {
     const pins = [{ repo: 'postman-bootstrap-action', tag: 'v2.13.8', major: 2 }];
-    const plan = planAdvance(pins, new Map([['postman-bootstrap-action', tags]]));
-    expect(plan).toEqual([{ repo: 'postman-bootstrap-action', from: 'v2.13.8', to: 'v2.14.0' }]);
+    const promoted = verifiedPromotion();
+    const plan = planAdvance(pins, new Map([[promoted.repo, promoted]]));
+    expect(plan).toEqual([
+      {
+        repo: 'postman-bootstrap-action',
+        from: 'v2.13.8',
+        to: 'v2.14.0',
+        commit: promotedCommit,
+        artifactDigest: releaseTgzDigest
+      }
+    ]);
   });
 
-  it('plans nothing when the pin is already newest in its major', () => {
+  it('plans nothing when the pin already equals the promoted release', () => {
     const pins = [{ repo: 'postman-bootstrap-action', tag: 'v2.14.0', major: 2 }];
-    expect(planAdvance(pins, new Map([['postman-bootstrap-action', tags]]))).toEqual([]);
+    const promoted = verifiedPromotion();
+    expect(planAdvance(pins, new Map([[promoted.repo, promoted]]))).toEqual([]);
+  });
+
+  it('fails closed for missing evidence, a cross-major target, or an attempted regression', () => {
+    const pin = { repo: 'postman-bootstrap-action', tag: 'v2.14.0', major: 2 };
+    expect(() => planAdvance([pin], new Map())).toThrow(/identity is missing/);
+    const crossMajor = verifiedPromotion('v3.0.0');
+    expect(() => planAdvance([pin], new Map([[crossMajor.repo, crossMajor]]))).toThrow(
+      /crossed recorded major/
+    );
+    const older = verifiedPromotion('v2.13.8');
+    expect(() => planAdvance([pin], new Map([[older.repo, older]]))).toThrow(/ahead of promoted/);
   });
 });
 
@@ -90,22 +412,88 @@ describe('pin literal rewriting', () => {
 });
 
 describe('advance-pins workflow', () => {
-  it('listens for sibling release dispatches with a cron backstop and manual trigger', () => {
+  it('routes sibling notification, cron, and manual triggers through one selector', () => {
     expect(advanceWorkflow).toContain('repository_dispatch');
     expect(advanceWorkflow).toContain('sibling-release');
     expect(advanceWorkflow).toContain('schedule:');
     expect(advanceWorkflow).toContain('workflow_dispatch');
+    expect(advanceWorkflow.match(/node scripts\/advance-pins\.mjs/g)).toHaveLength(2);
+    expect(advanceWorkflow).toContain('node scripts/advance-pins.mjs --check');
+    expect(advanceWorkflow).not.toContain('github.event.client_payload');
+  });
+
+  it('verifies promoted refs and GitHub Release identity before writing pin files', () => {
+    const selection = selectorSource.indexOf('const promoted = selectPromotedImmutable({');
+    const release = selectorSource.indexOf('fetchReleaseEnvelope(pin.repo, promoted.tag)', selection);
+    const planning = selectorSource.indexOf('const plan = planAdvance(pins, promotedByRepo)', release);
+    const write = selectorSource.indexOf('writeFileSync(filePath, after)', planning);
+    expect(selection).toBeGreaterThan(-1);
+    expect(release).toBeGreaterThan(selection);
+    expect(planning).toBeGreaterThan(release);
+    expect(write).toBeGreaterThan(planning);
+    expect(selectorSource).toContain("execFileSync('gh', ['api'");
+    expect(selectorSource).not.toContain('latestImmutableForMajor');
+  });
+
+  it('fails closed and keeps sibling reads separate from composite writes', () => {
+    const readMintStart = advanceWorkflow.indexOf('name: Mint sibling release read token');
+    const writeMintStart = advanceWorkflow.indexOf('name: Mint composite write token');
+    const checkoutStart = advanceWorkflow.indexOf('- uses: actions/checkout@v7');
+    const fullTests = advanceWorkflow.indexOf('npm test');
+    const commitStart = advanceWorkflow.indexOf('name: Commit and open pull request');
+    expect(readMintStart).toBeGreaterThan(-1);
+    expect(checkoutStart).toBeGreaterThan(readMintStart);
+    expect(writeMintStart).toBeGreaterThan(fullTests);
+    expect(commitStart).toBeGreaterThan(writeMintStart);
+
+    const readMint = advanceWorkflow.slice(readMintStart, checkoutStart);
+    const writeMint = advanceWorkflow.slice(writeMintStart, commitStart);
+    expect(readMint).not.toContain('continue-on-error');
+    expect(writeMint).not.toContain('continue-on-error');
+    for (const repo of PINNED_SIBLING_REPOSITORIES) {
+      expect(readMint).toContain(`            ${repo}`);
+      expect(writeMint).not.toContain(repo);
+    }
+    expect(
+      readMint
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => PINNED_SIBLING_REPOSITORIES.includes(line))
+    ).toEqual([...PINNED_SIBLING_REPOSITORIES]);
+    expect(readMint).not.toContain('postman-api-onboarding-action');
+    expect(readMint).toContain('permission-contents: read');
+    expect(readMint).not.toContain('permission-contents: write');
+    expect(readMint).not.toContain('permission-pull-requests:');
+    expect(readMint).not.toContain('permission-actions:');
+    expect(writeMint).toContain('repositories: postman-api-onboarding-action');
+    expect(writeMint).toContain('permission-contents: write');
+    expect(writeMint).toContain('permission-pull-requests: write');
+    expect(writeMint).toContain('permission-actions: write');
+    expect(writeMint).toContain("if: steps.advance.outputs.changed == 'true'");
+
+    expect(advanceWorkflow).toContain('token: ${{ github.token }}');
+    expect(advanceWorkflow).toContain('persist-credentials: false');
+    expect(advanceWorkflow).toContain(
+      'GH_TOKEN: ${{ steps.sibling-read-token.outputs.token }}'
+    );
+    expect(advanceWorkflow).toContain(
+      'GH_TOKEN: ${{ steps.composite-write-token.outputs.token }}'
+    );
+    expect(advanceWorkflow).not.toContain('|| github.token');
   });
 
   it('validates moved pins with the sibling-pin gate and full tests before opening a PR', () => {
     const validate = advanceWorkflow.indexOf('node scripts/check-sibling-pins.mjs');
+    const promotionCheck = advanceWorkflow.indexOf('node scripts/advance-pins.mjs --check');
     const fullTests = advanceWorkflow.indexOf('npm test');
     const branchPush = advanceWorkflow.indexOf('git push origin "HEAD:refs/heads/${BRANCH}"');
     const prCreate = advanceWorkflow.indexOf('gh pr create');
     expect(validate).toBeGreaterThan(-1);
+    expect(promotionCheck).toBeGreaterThan(-1);
     expect(fullTests).toBeGreaterThan(-1);
     expect(branchPush).toBeGreaterThan(-1);
     expect(prCreate).toBeGreaterThan(-1);
+    expect(promotionCheck).toBeLessThan(validate);
     expect(validate).toBeLessThan(branchPush);
     expect(fullTests).toBeLessThan(branchPush);
     expect(branchPush).toBeLessThan(prCreate);
@@ -145,11 +533,30 @@ describe('advance-pins workflow', () => {
     expect(advanceWorkflow).not.toContain('App-backed push to main failed');
   });
 
-  it('keeps write credentials scoped to the branch push and pull request', () => {
-    expect(advanceWorkflow).toContain('pull-requests: write');
-    expect(advanceWorkflow).toContain(
-      'GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}'
+  it('uses read credentials for selection and exposes write credentials only during PR publication', () => {
+    const advanceStart = advanceWorkflow.indexOf('name: Advance pins');
+    const validateStart = advanceWorkflow.indexOf('name: Validate advanced pins');
+    const writeMintStart = advanceWorkflow.indexOf('name: Mint composite write token');
+    const commitStart = advanceWorkflow.indexOf('name: Commit and open pull request');
+    const advanceStep = advanceWorkflow.slice(advanceStart, validateStart);
+    const validateStep = advanceWorkflow.slice(validateStart, writeMintStart);
+    const commitStep = advanceWorkflow.slice(commitStart);
+    expect(advanceStep).toContain('GH_TOKEN: ${{ steps.sibling-read-token.outputs.token }}');
+    expect(validateStep).toContain('GH_TOKEN: ${{ steps.sibling-read-token.outputs.token }}');
+    expect(commitStep).toContain('GH_TOKEN: ${{ steps.composite-write-token.outputs.token }}');
+    expect(commitStep).toContain('gh auth setup-git');
+    expect(advanceStep).not.toContain('composite-write-token');
+    expect(validateStep).not.toContain('composite-write-token');
+    expect(commitStep).not.toContain('sibling-read-token');
+
+    const jobPermissions = advanceWorkflow.slice(
+      advanceWorkflow.indexOf('  advance:'),
+      advanceWorkflow.indexOf('    steps:')
     );
+    expect(jobPermissions).toContain('contents: read');
+    expect(jobPermissions).not.toContain('contents: write');
+    expect(jobPermissions).not.toContain('pull-requests: write');
+    expect(jobPermissions).not.toContain('actions: write');
     expect(advanceWorkflow).not.toContain('APP_TOKEN:');
   });
 });

--- a/tests/azure-devops-windows-template.test.ts
+++ b/tests/azure-devops-windows-template.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -8,6 +9,31 @@ const templatePath = path.resolve(
   process.cwd(),
   'templates/azure-devops/windows-onboarding.yml'
 );
+
+const versionEnvironment = {
+  RESOLVE_VERSION: '2.0.9',
+  BOOTSTRAP_VERSION: '2.17.1',
+  SMOKE_FLOW_VERSION: '2.1.10',
+  REPO_SYNC_VERSION: '2.8.9',
+  INSIGHTS_VERSION: '2.2.1'
+};
+
+function installStep(): { pwsh: string; env: Record<string, string> } {
+  const template = parse(readFileSync(templatePath, 'utf8'));
+  return template.jobs[0].steps.find(
+    (step: { displayName?: string }) => step.displayName === 'Install pinned Postman onboarding CLIs'
+  );
+}
+
+function runVersionValidation(overrides: Partial<typeof versionEnvironment> = {}) {
+  const script = installStep().pwsh;
+  const npmStart = script.indexOf('$packages = @(');
+  if (npmStart < 0) throw new Error('version-validation prefix not found');
+  return spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script.slice(0, npmStart)], {
+    env: { ...process.env, ...versionEnvironment, ...overrides },
+    encoding: 'utf8'
+  });
+}
 
 describe('Azure DevOps Windows onboarding template', () => {
   it('orchestrates the existing CLIs on a native Windows job', () => {
@@ -43,24 +69,47 @@ describe('Azure DevOps Windows onboarding template', () => {
 
   it('pins every installed onboarding package instead of resolving latest', () => {
     const source = readFileSync(templatePath, 'utf8');
-    const template = parse(source);
-    const installStep = template.jobs[0].steps.find(
-      (step: { displayName?: string }) => step.displayName === 'Install pinned Postman onboarding CLIs'
-    );
+    const install = installStep();
     expect(source).not.toContain('@latest');
-    expect(installStep.pwsh).toContain('onboarding-resolve-service-token@$env:RESOLVE_VERSION');
-    expect(installStep.pwsh).toContain('onboarding-bootstrap@$env:BOOTSTRAP_VERSION');
-    expect(installStep.pwsh).toContain('onboarding-smoke-flow@$env:SMOKE_FLOW_VERSION');
-    expect(installStep.pwsh).toContain('onboarding-repo-sync@$env:REPO_SYNC_VERSION');
-    expect(installStep.pwsh).toContain('onboarding-insights@$env:INSIGHTS_VERSION');
-    expect(installStep.pwsh).not.toContain('${{ parameters.');
-    expect(installStep.env).toEqual({
+    expect(install.pwsh).toContain('onboarding-resolve-service-token@$env:RESOLVE_VERSION');
+    expect(install.pwsh).toContain('onboarding-bootstrap@$env:BOOTSTRAP_VERSION');
+    expect(install.pwsh).toContain('onboarding-smoke-flow@$env:SMOKE_FLOW_VERSION');
+    expect(install.pwsh).toContain('onboarding-repo-sync@$env:REPO_SYNC_VERSION');
+    expect(install.pwsh).toContain('onboarding-insights@$env:INSIGHTS_VERSION');
+    expect(install.pwsh).not.toContain('${{ parameters.');
+    expect(install.env).toEqual({
       RESOLVE_VERSION: '${{ parameters.resolveVersion }}',
       BOOTSTRAP_VERSION: '${{ parameters.bootstrapVersion }}',
       SMOKE_FLOW_VERSION: '${{ parameters.smokeFlowVersion }}',
       REPO_SYNC_VERSION: '${{ parameters.repoSyncVersion }}',
       INSIGHTS_VERSION: '${{ parameters.insightsVersion }}'
     });
+  });
+
+  it('accepts exact stable and prerelease SemVer values before npm is invoked', () => {
+    expect(runVersionValidation().status).toBe(0);
+    expect(
+      runVersionValidation({ BOOTSTRAP_VERSION: '2.22.0-rc.1+build.7' }).status
+    ).toBe(0);
+  });
+
+  it.each([
+    ['RESOLVE_VERSION', "1.2.3'; Write-Output pwn; '"],
+    ['BOOTSTRAP_VERSION', '^2.17.1'],
+    ['SMOKE_FLOW_VERSION', 'latest'],
+    ['REPO_SYNC_VERSION', 'https://example.invalid/pwn.tgz'],
+    ['INSIGHTS_VERSION', 'github:attacker/pwn'],
+    ['RESOLVE_VERSION', 'file:C:/pwn'],
+    ['BOOTSTRAP_VERSION', '2.17.1 '],
+    ['SMOKE_FLOW_VERSION', ' 2.1.10'],
+    ['REPO_SYNC_VERSION', '02.8.9'],
+    ['INSIGHTS_VERSION', '2.2']
+  ] as const)('rejects non-exact npm version spec %s=%s before npm', (name, value) => {
+    const result = runVersionValidation({ [name]: value });
+    expect(result.status).not.toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toContain('Invalid exact SemVer');
+    expect(output).not.toContain(value);
   });
 
   it('defaults bootstrapVersion to the pinned immutable 2.17.1', () => {

--- a/tests/branch-decision.test.ts
+++ b/tests/branch-decision.test.ts
@@ -7,6 +7,26 @@ import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
 const repoRoot = path.resolve(__dirname, '..');
+const workflowRepository = { id: 101, full_name: 'postman-cs/example', default_branch: 'main' };
+
+type Repository = { id?: number | string; full_name?: string; default_branch?: string };
+type PullRequest = {
+  head?: { ref?: string; repo?: Repository | null };
+  base?: { ref?: string; repo?: Repository | null };
+};
+type Decision = {
+  tier: string;
+  reason: string;
+  channel?: { pattern: string; code: string };
+  identity: {
+    eventName?: string;
+    isPrContext: boolean;
+    isForkPr: boolean;
+    sameRepository: boolean;
+    eventEligible: boolean;
+    headBranch?: string;
+  };
+};
 
 function branchDecisionScript(): string {
   const manifest = parse(readFileSync(path.join(repoRoot, 'action.yml'), 'utf8')) as {
@@ -18,7 +38,55 @@ function branchDecisionScript(): string {
   return match.groups.script;
 }
 
-function decide(headRepo: string): Record<string, unknown> {
+function repository(overrides: Repository = {}): Repository {
+  return { ...workflowRepository, ...overrides };
+}
+
+function pullRequest(
+  options: {
+    branch?: string;
+    headRepo?: Repository | null;
+    baseRepo?: Repository | null;
+  } = {}
+): PullRequest {
+  return {
+    head: {
+      ref: options.branch ?? 'release/attacker-controlled',
+      repo: options.headRepo === undefined ? repository() : options.headRepo
+    },
+    base: {
+      ref: 'main',
+      repo: options.baseRepo === undefined ? repository() : options.baseRepo
+    }
+  };
+}
+
+function directPrEvent(request: PullRequest, eventRepository: Repository = repository()): Record<string, unknown> {
+  return { repository: eventRepository, pull_request: request };
+}
+
+function nestedPrEvent(
+  eventName: 'workflow_run' | 'check_run' | 'check_suite',
+  requests: PullRequest[],
+  eventRepository: Repository = repository()
+): Record<string, unknown> {
+  return { repository: eventRepository, [eventName]: { pull_requests: requests } };
+}
+
+function decide(
+  options: {
+    eventName?: string;
+    event?: Record<string, unknown>;
+    eventBody?: string;
+    strategy?: 'legacy' | 'publish-gate' | 'preview';
+    ref?: string;
+    refName?: string;
+    headRef?: string;
+    canonicalBranch?: string;
+    workflowRepositoryId?: number | string | null;
+    workflowRepositoryName?: string;
+  } = {}
+): { decision: Decision; status: number; stderr: string; stdout: string } {
   const root = mkdtempSync(path.join(tmpdir(), 'branch-decision-'));
   try {
     const eventPath = path.join(root, 'event.json');
@@ -26,53 +94,319 @@ function decide(headRepo: string): Record<string, unknown> {
     const envPath = path.join(root, 'env.txt');
     writeFileSync(
       eventPath,
-      JSON.stringify({
-        repository: { default_branch: 'main', full_name: 'postman-cs/example' },
-        pull_request: {
-          head: { repo: { full_name: headRepo } },
-          base: { repo: { full_name: 'postman-cs/example' } },
-        },
-      }),
+      options.eventBody ?? JSON.stringify(options.event ?? { repository: repository() })
     );
+    writeFileSync(outputPath, '');
+    writeFileSync(envPath, '');
     const result = spawnSync(process.execPath, ['-e', branchDecisionScript()], {
       env: {
         ...process.env,
-        BRANCH_STRATEGY: 'publish-gate',
-        CANONICAL_BRANCH: 'main',
+        BRANCH_STRATEGY: options.strategy ?? 'publish-gate',
+        CANONICAL_BRANCH: options.canonicalBranch ?? 'main',
         CHANNELS: '',
+        GITHUB_EVENT_NAME: options.eventName ?? 'workflow_dispatch',
         GITHUB_EVENT_PATH: eventPath,
-        GITHUB_REF: 'refs/pull/1/merge',
-        GITHUB_REF_NAME: '1/merge',
-        GITHUB_HEAD_REF: 'release/attacker-controlled',
+        GITHUB_REF: options.ref ?? 'refs/heads/main',
+        GITHUB_REF_NAME: options.refName ?? 'main',
+        GITHUB_HEAD_REF: options.headRef ?? '',
+        GITHUB_REPOSITORY: options.workflowRepositoryName ?? workflowRepository.full_name,
+        GITHUB_REPOSITORY_ID:
+          options.workflowRepositoryId === null
+            ? ''
+            : String(options.workflowRepositoryId ?? workflowRepository.id),
         GITHUB_SHA: '0123456789abcdef',
         GITHUB_OUTPUT: outputPath,
-        GITHUB_ENV: envPath,
+        GITHUB_ENV: envPath
       },
-      encoding: 'utf8',
+      encoding: 'utf8'
     });
-    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
     const serialized = readFileSync(outputPath, 'utf8')
       .split('\n')
       .find((line) => line.startsWith('branch-decision='))
       ?.slice('branch-decision='.length);
-    if (!serialized) throw new Error('branch-decision output not found');
-    return JSON.parse(serialized) as Record<string, unknown>;
+    if (!serialized) {
+      throw new Error(`branch-decision output not found: ${result.stdout}${result.stderr}`);
+    }
+    return {
+      decision: JSON.parse(serialized) as Decision,
+      status: result.status ?? 1,
+      stderr: result.stderr,
+      stdout: result.stdout
+    };
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 }
 
-describe('branch decision fork gating', () => {
-  it('keeps a fork PR gated even when its head branch matches the release channel', () => {
-    const decision = decide('attacker/fork');
-    expect(decision.tier).toBe('gated');
-    expect(decision.reason).toBe('fork PR: credentialed tiers are ineligible');
-    expect(decision).not.toHaveProperty('channel');
+function decideDirectPr(
+  options: {
+    eventName?: 'pull_request' | 'pull_request_target' | 'pull_request_review' | 'pull_request_review_comment';
+    request?: PullRequest;
+    strategy?: 'legacy' | 'publish-gate' | 'preview';
+    headRef?: string;
+    eventRepository?: Repository;
+  } = {}
+): Decision {
+  const request = options.request ?? pullRequest();
+  const branch = request.head?.ref ?? '';
+  return decide({
+    eventName: options.eventName ?? 'pull_request',
+    event: directPrEvent(request, options.eventRepository),
+    strategy: options.strategy,
+    ref: 'refs/pull/1/merge',
+    refName: '1/merge',
+    headRef: options.headRef ?? branch
+  }).decision;
+}
+
+describe('branch decision event trust boundary', () => {
+  it.each(['legacy', 'publish-gate', 'preview'] as const)(
+    'keeps a fork PR gated under %s even when its head matches a release channel',
+    (strategy) => {
+      const decision = decideDirectPr({
+        strategy,
+        request: pullRequest({ headRepo: repository({ id: 202, full_name: 'attacker/fork' }) })
+      });
+      expect(decision.tier).toBe('gated');
+      expect(decision.reason).toContain('credentials and mutations are ineligible');
+      expect(decision.identity).toMatchObject({
+        isPrContext: true,
+        isForkPr: true,
+        sameRepository: false,
+        eventEligible: false
+      });
+      expect(decision).not.toHaveProperty('channel');
+    }
+  );
+
+  it.each(['pull_request', 'pull_request_target', 'pull_request_review', 'pull_request_review_comment'] as const)(
+    'allows a positively identified same-repository %s event',
+    (eventName) => {
+      const decision = decideDirectPr({ eventName });
+      expect(decision.tier).toBe('channel');
+      expect(decision.channel).toEqual({ pattern: 'release/*', code: 'RC' });
+      expect(decision.identity).toMatchObject({
+        eventName,
+        isPrContext: true,
+        isForkPr: false,
+        sameRepository: true,
+        eventEligible: true,
+        headBranch: 'release/attacker-controlled'
+      });
+    }
+  );
+
+  it('allows a positively identified same-repository PR under legacy strategy', () => {
+    const decision = decideDirectPr({ strategy: 'legacy' });
+    expect(decision.tier).toBe('legacy');
+    expect(decision.reason).toContain('same-repository pull_request');
   });
 
-  it('still assigns a same-repository release branch to the injected RC channel', () => {
-    const decision = decide('postman-cs/example');
+  it('uses equal valid IDs as primary identity while rejecting a present conflicting name', () => {
+    const missingNames = repository({ full_name: undefined });
+    const byId = decideDirectPr({
+      request: pullRequest({ headRepo: missingNames, baseRepo: missingNames }),
+      eventRepository: missingNames
+    });
+    expect(byId.tier).toBe('channel');
+    expect(byId.identity).toMatchObject({ sameRepository: true, isForkPr: false });
+
+    const conflictingName = decideDirectPr({
+      request: pullRequest({ headRepo: repository({ full_name: 'attacker/fork' }) })
+    });
+    expect(conflictingName.tier).toBe('gated');
+    expect(conflictingName.identity.isForkPr).toBe(true);
+  });
+
+  it('uses normalized names only when both repository IDs are absent', () => {
+    const nameOnly = repository({ id: undefined, full_name: 'POSTMAN-CS/EXAMPLE' });
+    const decision = decide({
+      eventName: 'pull_request_target',
+      event: directPrEvent(
+        pullRequest({ headRepo: nameOnly, baseRepo: repository({ id: undefined }) }),
+        repository({ id: undefined })
+      ),
+      ref: 'refs/pull/1/merge',
+      headRef: 'release/attacker-controlled',
+      workflowRepositoryId: null,
+      workflowRepositoryName: 'postman-cs/example'
+    }).decision;
     expect(decision.tier).toBe('channel');
-    expect(decision.channel).toEqual({ pattern: 'release/*', code: 'RC' });
+    expect(decision.identity).toMatchObject({ sameRepository: true, isForkPr: false, eventEligible: true });
+  });
+
+  it.each([
+    { label: 'only one ID is absent', head: repository({ id: undefined }) },
+    { label: 'one ID is malformed', head: repository({ id: 'not-decimal' }) },
+    { label: 'one ID is zero', head: repository({ id: 0 }) },
+    { label: 'one name is malformed', head: repository({ full_name: 'not-a-repository-name' }) }
+  ])('does not use a name fallback when $label', ({ head }) => {
+    const decision = decideDirectPr({ request: pullRequest({ headRepo: head }) });
+    expect(decision.tier).toBe('gated');
+    expect(decision.identity).toMatchObject({ sameRepository: false, isForkPr: true, eventEligible: false });
+  });
+
+  it.each([
+    {
+      label: 'missing head repository',
+      request: pullRequest({ headRepo: null })
+    },
+    {
+      label: 'missing repository ID',
+      request: pullRequest({ headRepo: repository({ id: undefined }) })
+    },
+    {
+      label: 'same name with a different ID',
+      request: pullRequest({ headRepo: repository({ id: 999 }) })
+    },
+    {
+      label: 'same ID with a different name',
+      request: pullRequest({ headRepo: repository({ full_name: 'attacker/fork' }) })
+    },
+    {
+      label: 'base repository mismatch',
+      request: pullRequest({ baseRepo: repository({ id: 303, full_name: 'other/base' }) })
+    },
+    {
+      label: 'missing head branch',
+      request: pullRequest({ branch: '' })
+    }
+  ])('fails closed for direct PR metadata: $label', ({ request }) => {
+    const decision = decideDirectPr({ request });
+    expect(decision.tier).toBe('gated');
+    expect(decision.identity.eventEligible).toBe(false);
+    expect(decision.identity.sameRepository).toBe(false);
+    expect(decision.identity.isForkPr).toBe(true);
+  });
+
+  it('fails closed when payload and GITHUB_HEAD_REF disagree', () => {
+    const decision = decideDirectPr({ headRef: 'release/different' });
+    expect(decision.tier).toBe('gated');
+    expect(decision.reason).toContain('does not match GITHUB_HEAD_REF');
+    expect(decision.identity.isForkPr).toBe(true);
+  });
+
+  it.each(['workflow_run', 'check_run', 'check_suite'] as const)(
+    'accepts one positively identified same-repository PR nested under %s',
+    (eventName) => {
+      const request = pullRequest({ branch: 'release/nested' });
+      const decision = decide({
+        eventName,
+        event: nestedPrEvent(eventName, [request]),
+        ref: 'refs/heads/main',
+        headRef: ''
+      }).decision;
+      expect(decision.tier).toBe('channel');
+      expect(decision.identity).toMatchObject({
+        eventName,
+        isPrContext: true,
+        sameRepository: true,
+        eventEligible: true,
+        headBranch: 'release/nested'
+      });
+    }
+  );
+
+  it.each(['workflow_run', 'check_run', 'check_suite'] as const)(
+    'gates a nested fork under %s',
+    (eventName) => {
+      const request = pullRequest({ headRepo: repository({ id: 202, full_name: 'attacker/fork' }) });
+      const decision = decide({
+        eventName,
+        event: nestedPrEvent(eventName, [request]),
+        ref: 'refs/heads/main',
+        headRef: ''
+      }).decision;
+      expect(decision.tier).toBe('gated');
+      expect(decision.identity).toMatchObject({ isPrContext: true, isForkPr: true, eventEligible: false });
+    }
+  );
+
+  it.each([
+    { eventName: 'workflow_run', requests: [] },
+    { eventName: 'check_run', requests: [pullRequest(), pullRequest({ branch: 'release/second' })] },
+    { eventName: 'check_suite', requests: [pullRequest({ headRepo: null })] }
+  ] as const)('gates ambiguous or incomplete nested metadata for $eventName', ({ eventName, requests }) => {
+    const decision = decide({
+      eventName,
+      event: nestedPrEvent(eventName, [...requests]),
+      ref: 'refs/heads/main',
+      headRef: ''
+    }).decision;
+    expect(decision.tier).toBe('gated');
+    expect(decision.identity).toMatchObject({ eventEligible: false, sameRepository: false, isForkPr: true });
+  });
+
+  it.each(['issue_comment', 'merge_group', 'repository_dispatch', 'status', 'unknown_event'])(
+    'gates non-allowlisted event %s even with a canonical-looking ref',
+    (eventName) => {
+      const decision = decide({ eventName, event: { repository: repository() } }).decision;
+      expect(decision.tier).toBe('gated');
+      expect(decision.reason).toContain('not credential-eligible');
+    }
+  );
+
+  it.each([
+    { eventName: 'workflow_dispatch', ref: 'refs/heads/main', expectedTier: 'canonical' },
+    { eventName: 'push', ref: 'refs/heads/release/trusted', expectedTier: 'channel' },
+    { eventName: 'schedule', ref: 'refs/heads/main', expectedTier: 'canonical' }
+  ])('allows trusted non-PR event $eventName', ({ eventName, ref, expectedTier }) => {
+    const decision = decide({ eventName, ref, refName: ref.slice('refs/heads/'.length) }).decision;
+    expect(decision.tier).toBe(expectedTier);
+    expect(decision.identity).toMatchObject({
+      eventName,
+      isPrContext: false,
+      sameRepository: true,
+      eventEligible: true
+    });
+  });
+
+  it('gates a trusted non-PR event carrying an inconsistent PR head ref', () => {
+    const decision = decide({ eventName: 'push', headRef: 'release/spoofed' }).decision;
+    expect(decision.tier).toBe('gated');
+    expect(decision.identity).toMatchObject({ isPrContext: true, isForkPr: true, eventEligible: false });
+  });
+
+  it('gates a trusted non-PR event carrying a top-level PR marker', () => {
+    const decision = decide({
+      eventName: 'workflow_dispatch',
+      event: { repository: repository(), pull_request: pullRequest() }
+    }).decision;
+    expect(decision.tier).toBe('gated');
+    expect(decision.identity).toMatchObject({ isPrContext: true, isForkPr: true, eventEligible: false });
+  });
+
+  it('gates a self-consistent payload that does not match the runtime workflow repository', () => {
+    const foreign = repository({ id: 404, full_name: 'other/repository' });
+    const decision = decide({
+      eventName: 'pull_request',
+      event: directPrEvent(pullRequest({ headRepo: foreign, baseRepo: foreign }), foreign),
+      ref: 'refs/pull/1/merge',
+      headRef: 'release/attacker-controlled'
+    }).decision;
+    expect(decision.tier).toBe('gated');
+    expect(decision.reason).toContain('does not match the workflow repository');
+  });
+
+  it('gates a missing event name and an unreadable event payload', () => {
+    const missingName = decide({ eventName: '', event: { repository: repository() } }).decision;
+    const unreadable = decide({ eventName: 'workflow_dispatch', eventBody: '{not-json' }).decision;
+    expect(missingName.tier).toBe('gated');
+    expect(missingName.reason).toContain('event name is missing');
+    expect(unreadable.tier).toBe('gated');
+    expect(unreadable.reason).toContain('payload is missing or unreadable');
+  });
+
+  it('bounds GITHUB_EVENT_PATH reads and marks an oversized PR payload unproven', () => {
+    const oversized = decide({
+      eventName: 'pull_request',
+      eventBody: JSON.stringify({ repository: repository(), padding: 'x'.repeat(1024 * 1024) }),
+      ref: 'refs/pull/1/merge',
+      headRef: 'release/attacker-controlled'
+    }).decision;
+    expect(oversized.tier).toBe('gated');
+    expect(oversized.reason).toContain('payload is missing or unreadable');
+    expect(oversized.identity).toMatchObject({ isPrContext: true, isForkPr: true, eventEligible: false });
+    expect(branchDecisionScript()).toContain('MAX_EVENT_PAYLOAD_BYTES = 1 * 1024 * 1024');
   });
 });

--- a/tests/check-sibling-pins.test.ts
+++ b/tests/check-sibling-pins.test.ts
@@ -11,10 +11,12 @@ import {
   COLLECTIONS_JSON_KEYS,
   REPO_SYNC_SUMMARY_GATED_KEYS,
   REPO_SYNC_SUMMARY_KEYS,
+  SIBLING_PIN_MAX_SOURCE_BYTES,
   SIBLING_PIN_NETWORK_TIMEOUT_MS,
   gitTagExistsExecOptions,
   pinnedFileFetchInit,
   pinnedRawFileUrl,
+  readBoundedResponseText,
   validateBranchDecisionInterface,
   validateCollectionsJsonShape,
   validateEnvironmentUidsEmit,
@@ -203,6 +205,59 @@ describe('network timeout bounds', () => {
     expect(
       pinnedRawFileUrl('postman-bootstrap-action', 'v2.15.0', 'action.yml')
     ).toBe('https://raw.githubusercontent.com/postman-cs/postman-bootstrap-action/v2.15.0/action.yml');
+  });
+
+  it('caps each sibling response independently and accepts content exactly at the cap', async () => {
+    expect(SIBLING_PIN_MAX_SOURCE_BYTES).toBe(2 * 1024 * 1024);
+    await expect(readBoundedResponseText(new Response('12345678'), 8)).resolves.toBe(
+      '12345678'
+    );
+  });
+
+  it('rejects an oversized declared Content-Length before consuming the body', async () => {
+    let pulled = false;
+    const response = {
+      headers: new Headers({ 'content-length': '9' }),
+      body: {
+        getReader() {
+          pulled = true;
+          throw new Error('body reader must not be created');
+        }
+      }
+    } as unknown as Response;
+
+    await expect(readBoundedResponseText(response, 8)).rejects.toThrow(
+      'sibling source exceeds 8 bytes'
+    );
+    expect(pulled).toBe(false);
+  });
+
+  it('rejects a streamed response that lies about its smaller Content-Length', async () => {
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('1234'));
+          controller.enqueue(new TextEncoder().encode('56789'));
+          controller.close();
+        }
+      }),
+      { headers: { 'content-length': '1' } }
+    );
+
+    await expect(readBoundedResponseText(response, 8)).rejects.toThrow(
+      'sibling source exceeds 8 bytes'
+    );
+  });
+
+  it('fails closed on malformed lengths and invalid UTF-8', async () => {
+    await expect(
+      readBoundedResponseText(new Response('ok', { headers: { 'content-length': 'NaN' } }), 8)
+    ).rejects.toThrow('sibling source Content-Length is malformed');
+
+    const invalidUtf8 = new Response(Uint8Array.from([0xc3, 0x28]));
+    await expect(readBoundedResponseText(invalidUtf8, 8)).rejects.toThrow(
+      'sibling source is not valid UTF-8'
+    );
   });
 });
 

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -466,11 +466,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       const insightsStep = steps.find((step) => step.id === 'insights_onboarding');
 
       expect(validateStep?.shell).toBe('bash');
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.21.5');
-      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.10.3');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.21.10');
+      expect(repoSyncStep?.uses).toBe('postman-cs/postman-repo-sync-action@v2.10.9');
       expect(junitStep?.shell).toBe('bash');
       expect(uploadStep?.uses).toBe('actions/upload-artifact@v7.0.1');
-      expect(smokeFlowStep?.uses).toBe('postman-cs/postman-smoke-flow-action@v3.7.3');
+      expect(smokeFlowStep?.uses).toBe('postman-cs/postman-smoke-flow-action@v3.7.4');
       expect(insightsStep?.uses).toBe('postman-cs/postman-insights-onboarding-action@v2.5.2');
       for (const step of [bootstrapStep, repoSyncStep, smokeFlowStep, insightsStep]) {
         expect(step?.uses).not.toMatch(/@(main|v0)$/);
@@ -735,13 +735,13 @@ describe('postman-api-onboarding-action composite contract', () => {
         "${{ inputs.spec-url == '' && inputs.spec-files-json || '' }}"
       );
       // Sibling pins stay on the current immutable tags.
-      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.21.5');
+      expect(bootstrapStep?.uses).toBe('postman-cs/postman-bootstrap-action@v2.21.10');
       expect(
         manifest.runs.steps.find((step) => step.id === 'repo_sync')?.uses
-      ).toBe('postman-cs/postman-repo-sync-action@v2.10.3');
+      ).toBe('postman-cs/postman-repo-sync-action@v2.10.9');
       expect(
         manifest.runs.steps.find((step) => step.id === 'smoke_flow')?.uses
-      ).toBe('postman-cs/postman-smoke-flow-action@v3.7.3');
+      ).toBe('postman-cs/postman-smoke-flow-action@v3.7.4');
       expect(
         manifest.runs.steps.find((step) => step.id === 'insights_onboarding')?.uses
       ).toBe('postman-cs/postman-insights-onboarding-action@v2.5.2');

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -509,10 +509,16 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
     });
 
-    it('masks credentials before resolving one branch decision and every child invocation', () => {
+    it('resolves one credential-free branch decision before masking and every child invocation', () => {
       const manifest = loadManifest();
-      expect(manifest.runs.steps[0]?.id).toBe('mask_postman_credentials');
-      expect(manifest.runs.steps[1]?.id).toBe('branch_decision');
+      expect(manifest.runs.steps[0]?.id).toBe('branch_decision');
+      expect(manifest.runs.steps[0]?.env).toEqual({
+        BRANCH_STRATEGY: '${{ inputs.branch-strategy }}',
+        CANONICAL_BRANCH: '${{ inputs.canonical-branch }}',
+        CHANNELS: '${{ inputs.channels }}'
+      });
+      expect(manifest.runs.steps[1]?.id).toBe('mask_postman_credentials');
+      expect(manifest.runs.steps[1]?.if).toContain("tier != 'gated'");
       for (const id of ['bootstrap', 'repo_sync', 'smoke_flow', 'insights_onboarding']) {
         expect(manifest.runs.steps.find((step) => step.id === id)?.env?.POSTMAN_BRANCH_DECISION).toBe('${{ steps.branch_decision.outputs.branch-decision }}');
       }
@@ -779,9 +785,11 @@ describe('postman-api-onboarding-action composite contract', () => {
       );
     });
 
-    it('passes postman-team-id as POSTMAN_TEAM_ID env to all steps', () => {
+    it('withholds postman-team-id from branch classification and forwards it only after classification', () => {
       const manifest = loadManifest();
-      for (const step of manifest.runs.steps) {
+      expect(manifest.runs.steps[0]?.id).toBe('branch_decision');
+      expect(manifest.runs.steps[0]?.env?.POSTMAN_TEAM_ID).toBeUndefined();
+      for (const step of manifest.runs.steps.slice(1)) {
         expect(step.env?.POSTMAN_TEAM_ID).toBe('${{ inputs.postman-team-id }}');
       }
     });
@@ -792,11 +800,21 @@ describe('postman-api-onboarding-action composite contract', () => {
       const repoSync = manifest.runs.steps.find((s) => s.id === 'repo_sync');
       expect(bootstrap?.with?.['postman-api-key']).toContain('inputs.postman-api-key');
       expect(bootstrap?.with?.['postman-access-token']).toContain('inputs.postman-access-token');
-      expect(repoSync?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
-      expect(repoSync?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
+      expect(repoSync?.with?.['postman-api-key']).toContain('inputs.postman-api-key');
+      expect(repoSync?.with?.['postman-access-token']).toContain('inputs.postman-access-token');
       const insights = manifest.runs.steps.find((step) => step.id === 'insights_onboarding');
-      expect(insights?.with?.['postman-api-key']).toBe('${{ inputs.insights-postman-api-key }}');
-      expect(insights?.with?.['postman-access-token']).toBe('${{ inputs.insights-postman-access-token }}');
+      expect(insights?.with?.['postman-api-key']).toContain('inputs.insights-postman-api-key');
+      expect(insights?.with?.['postman-access-token']).toContain('inputs.insights-postman-access-token');
+      for (const value of [
+        bootstrap?.with?.['postman-api-key'],
+        bootstrap?.with?.['postman-access-token'],
+        repoSync?.with?.['postman-api-key'],
+        repoSync?.with?.['postman-access-token'],
+        insights?.with?.['postman-api-key'],
+        insights?.with?.['postman-access-token']
+      ]) {
+        expect(value).toContain("tier != 'gated'");
+      }
     });
 
     it('credential-preflight defaults to warn and is optional', () => {
@@ -843,8 +861,10 @@ describe('postman-api-onboarding-action composite contract', () => {
       const bootstrapStep = manifest.runs.steps.find((s) => s.id === 'bootstrap');
 
       expect(bootstrapStep?.with?.['governance-group']).toBe('${{ inputs.governance-group }}');
-      expect(bootstrapStep?.with?.['github-token']).toBe('${{ inputs.github-token }}');
-      expect(bootstrapStep?.with?.['gh-fallback-token']).toBe('${{ inputs.gh-fallback-token }}');
+      expect(bootstrapStep?.with?.['github-token']).toContain('inputs.github-token');
+      expect(bootstrapStep?.with?.['github-token']).toContain("tier != 'gated'");
+      expect(bootstrapStep?.with?.['gh-fallback-token']).toContain('inputs.gh-fallback-token');
+      expect(bootstrapStep?.with?.['gh-fallback-token']).toContain("tier != 'gated'");
     });
 
     it('passes integration-backend to bootstrap and repo-sync', () => {

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,14 @@
+import { spawnSync } from 'node:child_process';
+
+export default function setup(): void {
+  // Validate and initialize the Ruby runtime before Vitest fans out workers.
+  // The monorepo example tests execute its exact resolver payload with Ruby;
+  // doing the first process start amid parallel test startup makes Windows
+  // runner contention part of an otherwise fast resolver assertion.
+  const result = spawnSync('ruby', ['-e', 'exit'], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(
+      `Ruby runtime preflight failed: ${result.error?.message ?? `${result.stdout}${result.stderr}`}`,
+    );
+  }
+}

--- a/tests/handoff-contract.test.ts
+++ b/tests/handoff-contract.test.ts
@@ -120,7 +120,7 @@ describe('composite handoff edges', () => {
 
   it('covers the full edge surface (ratchet: update this count when edges change)', () => {
     // Every distinct (producer step, output, consuming site) triple.
-    expect(edges.length).toBe(54);
+    expect(edges.length).toBe(81);
     const distinctPairs = new Set(edges.map((edge) => `${edge.step}.${edge.output}`));
     expect(distinctPairs.size).toBe(34);
   });

--- a/tests/monorepo-dispatcher.test.ts
+++ b/tests/monorepo-dispatcher.test.ts
@@ -47,6 +47,13 @@ const resourceResolver =
   workflow.jobs.run?.steps.find(
     (step) => step.name === 'Resolve service Postman resource IDs',
   )?.run ?? '';
+const resourceResolverRubyMatch = resourceResolver.match(
+  /^ruby <<'RUBY'\r?\n([\s\S]*?)\r?\nRUBY\s*$/,
+);
+if (!resourceResolverRubyMatch) {
+  throw new Error('Expected the resource resolver to contain one quoted Ruby heredoc');
+}
+const resourceResolverRuby = resourceResolverRubyMatch[1];
 const temporaryRoots: string[] = [];
 
 function git(root: string, args: string[], env: NodeJS.ProcessEnv = {}): string {
@@ -128,7 +135,10 @@ function runResourceResolver(resourcesYaml: string) {
   writeFileSync(path.join(root, '.postman', 'resources.yaml'), resourcesYaml);
   const githubEnv = path.join(root, 'github-env.txt');
   writeFileSync(githubEnv, 'EXISTING=preserved\n');
-  const result = spawnSync('bash', ['--noprofile', '--norc', '-c', resourceResolver], {
+  // Exercise the exact Ruby payload without an unnecessary Git Bash process.
+  // Starting both shells for every table case is particularly expensive on
+  // Windows and can obscure a resolver regression with harness startup delay.
+  const result = spawnSync('ruby', ['-e', resourceResolverRuby], {
     cwd: root,
     env: { ...process.env, GITHUB_ENV: githubEnv },
     encoding: 'utf8',
@@ -352,7 +362,7 @@ describe('monorepo dispatcher example', () => {
     const { result, githubEnv } = runResourceResolver(resources);
 
     expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-    expect(githubEnv.trim().split('\n')).toEqual([
+    expect(githubEnv.trim().split(/\r?\n/)).toEqual([
       'EXISTING=preserved',
       'POSTMAN_SMOKE_COLLECTION_UID=12345678-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       'POSTMAN_CONTRACT_COLLECTION_UID=12345678-11111111-2222-3333-4444-555555555555',

--- a/tests/monorepo-dispatcher.test.ts
+++ b/tests/monorepo-dispatcher.test.ts
@@ -43,6 +43,10 @@ const exampleText = readFileSync(examplePath, 'utf8');
 const workflow = parse(exampleText) as Workflow;
 const detectJob = workflow.jobs.detect;
 const detector = detectJob?.steps.find((step) => step.id === 'changes')?.run ?? '';
+const resourceResolver =
+  workflow.jobs.run?.steps.find(
+    (step) => step.name === 'Resolve service Postman resource IDs',
+  )?.run ?? '';
 const temporaryRoots: string[] = [];
 
 function git(root: string, args: string[], env: NodeJS.ProcessEnv = {}): string {
@@ -117,6 +121,21 @@ function runDetector(
   return outputs;
 }
 
+function runResourceResolver(resourcesYaml: string) {
+  const root = mkdtempSync(path.join(tmpdir(), 'monorepo-resource-resolver-'));
+  temporaryRoots.push(root);
+  mkdirSync(path.join(root, '.postman'), { recursive: true });
+  writeFileSync(path.join(root, '.postman', 'resources.yaml'), resourcesYaml);
+  const githubEnv = path.join(root, 'github-env.txt');
+  writeFileSync(githubEnv, 'EXISTING=preserved\n');
+  const result = spawnSync('bash', ['--noprofile', '--norc', '-c', resourceResolver], {
+    cwd: root,
+    env: { ...process.env, GITHUB_ENV: githubEnv },
+    encoding: 'utf8',
+  });
+  return { result, githubEnv: readFileSync(githubEnv, 'utf8') };
+}
+
 afterEach(() => {
   while (temporaryRoots.length > 0) rmSync(temporaryRoots.pop()!, { recursive: true, force: true });
 });
@@ -169,7 +188,7 @@ describe('monorepo dispatcher example', () => {
     const run = workflow.jobs.run;
     const combined = run.steps.map((step) => step.run ?? '').join('\n');
     expect(combined).toContain("YAML.safe_load(File.read('.postman/resources.yaml'), aliases: false)");
-    expect(combined).toContain('Postman resource IDs must not contain CR or LF characters');
+    expect(combined).toContain('Postman resource IDs must be 1-256 safe ASCII identifier characters');
     expect(combined).toContain('postman login --with-api-key "$POSTMAN_API_KEY"');
     expect(combined).toContain('postman collection run "$uid"');
     expect(combined).toContain('run_collection Smoke "$POSTMAN_SMOKE_COLLECTION_UID"');
@@ -210,12 +229,145 @@ describe('monorepo dispatcher example', () => {
     expect(existsSync(path.join(root, 'pwned'))).toBe(false);
   });
 
+  it('routes workflow_dispatch service names through the same rejecting validator', () => {
+    const { root } = createFixture();
+    const unsafeService = '$(touch pwned)';
+    mkdirSync(path.join(root, 'services', unsafeService), { recursive: true });
+    const outputPath = path.join(root, 'github-output.txt');
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-c', detector], {
+      cwd: root,
+      env: {
+        ...process.env,
+        EVENT_NAME: 'workflow_dispatch',
+        BEFORE_SHA: '',
+        HEAD_SHA: git(root, ['rev-parse', 'HEAD']),
+        BASE_REF: '',
+        DEFAULT_BRANCH: 'main',
+        SYNC_COMMITTER_NAME: 'Postman',
+        SYNC_COMMITTER_EMAIL: 'support@postman.com',
+        GITHUB_OUTPUT: outputPath,
+        RUNNER_TEMP: root,
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain('Unsupported service directory name');
+    expect(existsSync(path.join(root, 'pwned'))).toBe(false);
+  });
+
+  it('rejects an oversized otherwise-safe service directory name', () => {
+    const { root } = createFixture();
+    const oversizedService = 'a'.repeat(101);
+    mkdirSync(path.join(root, 'services', oversizedService), { recursive: true });
+    const outputPath = path.join(root, 'github-output.txt');
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-c', detector], {
+      cwd: root,
+      env: {
+        ...process.env,
+        EVENT_NAME: 'workflow_dispatch',
+        BEFORE_SHA: '',
+        HEAD_SHA: git(root, ['rev-parse', 'HEAD']),
+        BASE_REF: '',
+        DEFAULT_BRANCH: 'main',
+        SYNC_COMMITTER_NAME: 'Postman',
+        SYNC_COMMITTER_EMAIL: 'support@postman.com',
+        GITHUB_OUTPUT: outputPath,
+        RUNNER_TEMP: root,
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain('use 1-100');
+  });
+
   it('dispatches every existing service deterministically', () => {
     const { root } = createFixture();
     expect(runDetector(root, { EVENT_NAME: 'workflow_dispatch' })).toEqual({
       'changed-code': ['orders', 'payments'],
       'changed-collections': ['orders', 'payments'],
     });
+  });
+
+  it.each([
+    ['LF', '\n'],
+    ['CR', '\r'],
+    ['NUL', '\0'],
+    ['workflow-command delimiter', '<<INJECTED'],
+    ['space', ' '],
+  ])('rejects an executable %s env-file injection before writing GITHUB_ENV', (_label, unsafeText) => {
+    const resources = JSON.stringify({
+      canonical: {
+        collections: {
+          '[Smoke] orders': `smoke${unsafeText}INJECTED=owned`,
+          '[Contract] orders': 'contract',
+        },
+        environments: { prod: 'environment' },
+      },
+    });
+    const { result, githubEnv } = runResourceResolver(resources);
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      'Postman resource IDs must be 1-256 safe ASCII identifier characters',
+    );
+    expect(githubEnv).toBe('EXISTING=preserved\n');
+    expect(githubEnv).not.toContain('INJECTED=owned');
+  });
+
+  it.each([
+    ['empty', ''],
+    ['oversized', 'x'.repeat(257)],
+    ['non-string', 42],
+  ])('rejects an %s resource ID before writing GITHUB_ENV', (_label, unsafeId) => {
+    const resources = JSON.stringify({
+      canonical: {
+        collections: {
+          '[Smoke] orders': unsafeId,
+          '[Contract] orders': '12345678-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        },
+        environments: { prod: '12345678-ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee' },
+      },
+    });
+    const { result, githubEnv } = runResourceResolver(resources);
+
+    expect(result.status).not.toBe(0);
+    expect(githubEnv).toBe('EXISTING=preserved\n');
+  });
+
+  it('accepts owner-prefixed Postman UIDs and writes exactly three records', () => {
+    const resources = JSON.stringify({
+      canonical: {
+        collections: {
+          '[Smoke] orders': '12345678-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          '[Contract] orders': '12345678-11111111-2222-3333-4444-555555555555',
+        },
+        environments: {
+          'postman/environments/prod.postman_environment.json':
+            '12345678-ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee',
+        },
+      },
+    });
+    const { result, githubEnv } = runResourceResolver(resources);
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(githubEnv.trim().split('\n')).toEqual([
+      'EXISTING=preserved',
+      'POSTMAN_SMOKE_COLLECTION_UID=12345678-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'POSTMAN_CONTRACT_COLLECTION_UID=12345678-11111111-2222-3333-4444-555555555555',
+      'POSTMAN_ENVIRONMENT_UID=12345678-ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+  });
+
+  it('rejects an unsafe YAML object tag without mutating GITHUB_ENV', () => {
+    const { result, githubEnv } = runResourceResolver(
+      '--- !ruby/object:Object\ncanonical: {}\n',
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/DisallowedClass|unspecified class/);
+    expect(githubEnv).toBe('EXISTING=preserved\n');
   });
 
   it('classifies code for onboarding and generated artifacts for run-only checks', () => {

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 
 const releaseWorkflow = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8').replace(/\r\n/g, '\n');
 const releasePolicy = readFileSync(join(process.cwd(), 'RELEASE_POLICY.md'), 'utf8').replace(/\r\n/g, '\n');
+const actionDefinition = readFileSync(join(process.cwd(), 'action.yml'), 'utf8').replace(/\r\n/g, '\n');
 
 /** Convert a native path into a Git Bash-safe absolute path on Windows. */
 function bashPath(filePath: string): string {
@@ -101,6 +102,16 @@ function launchedGates(body: string): Array<{ name: string; command: string }> {
     name: match[1] ?? '',
     command: match[2] ?? ''
   }));
+}
+
+function namedStepRunBody(name: string): string {
+  const step = namedStep(name);
+  const match = step.match(/ {8}run: \|\n([\s\S]*)$/);
+  expect(match?.[1]).toBeTruthy();
+  return (match?.[1] ?? '')
+    .split('\n')
+    .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
+    .join('\n');
 }
 
 describe('Windows-portable classifier harness', () => {
@@ -328,7 +339,7 @@ describe('release workflow publishing contract', () => {
   });
 
   it('compares the rolling alias with check-release-alias before push', () => {
-    const alias = namedStep('Advance rolling major alias');
+    const alias = namedStep('Advance rolling major alias without regression');
     expect(alias).toContain('git ls-remote --tags origin');
     expect(alias).toContain('node scripts/check-release-alias.mjs');
     expect(alias).toContain('STATUS=$?');
@@ -359,20 +370,101 @@ describe('release workflow publishing contract', () => {
     expect(aliasJob).not.toContain('token: ${{ github.token }}');
   });
 
-  it('requires exact correlated released-composite E2E evidence before the rolling alias', () => {
+  it('requires exact closed immutable-provider composite evidence before the rolling alias', () => {
     const verifier = job('verify-release-e2e');
     expect(verifier).not.toContain('continue-on-error');
-    expect(verifier).toContain("E2E_GATE_MODE: ${{ inputs.e2e_verification_mode || 'enforce' }}");
+    expect(verifier).toContain('E2E_GATE_MODE: enforce');
     expect(verifier).toContain('E2E_GATE_ACTION: postman-api-onboarding-action');
     expect(verifier).toContain('E2E_GATE_SUITE: full');
     expect(verifier).toContain('E2E_GATE_REF: ${{ github.ref_name }}');
+    expect(verifier).toContain('E2E_GATE_RELEASE_COMMIT: ${{ github.sha }}');
     expect(verifier).toContain('E2E_GATE_SOURCE_DIGEST: ${{ needs.verify-package.outputs.release_tgz_sha256 }}');
+    expect(verifier).toContain('E2E_GATE_PROVIDER_TAG: e2e-provider-v1.2.0');
+    expect(verifier).toContain(
+      'E2E_GATE_PROVIDER_COMMIT: 53c5d10093b7dafb165d3caafbe3f1d70dec687d'
+    );
+    expect(verifier).toContain(
+      'E2E_GATE_PROVIDER_SOURCE_DIGEST: 8c7ee211fccd2869f3901fcbc5ed154d6dea8e3d0d7d2e5312f6c0b57b4f6b78'
+    );
+    expect(verifier).toContain(
+      'E2E_GATE_PEER_TAGS: \'{"postman-cs/postman-bootstrap-action":"v2.21.5","postman-cs/postman-insights-onboarding-action":"v2.5.2","postman-cs/postman-repo-sync-action":"v2.10.3","postman-cs/postman-resolve-service-token-action":"v2.2.4","postman-cs/postman-smoke-flow-action":"v3.7.3"}\''
+    );
+    expect(verifier).not.toContain('E2E_GATE_WORKFLOW_REF: main');
+    expect(verifier).not.toContain('E2E_GATE_REGISTRY_REVISION');
+    expect(verifier).not.toContain('E2E_GATE_CONTRACT_SCENARIOS');
+    expect(verifier).toContain(
+      'manifest_sha256: ${{ steps.verifier.outputs.e2e_manifest_sha256 }}'
+    );
+    expect(verifier).toContain(
+      'provider_commit: ${{ steps.verifier.outputs.e2e_provider_commit }}'
+    );
+    expect(verifier).toContain('provider_tag: ${{ steps.verifier.outputs.e2e_provider_tag }}');
     expect(verifier).toContain('node scripts/verify-e2e-release.mjs');
     expect(job('verify-package')).toContain(
       'release_tgz_sha256: ${{ steps.package-artifact.outputs.release_tgz_sha256 }}'
     );
     expect(job('advance-major-alias')).toContain("needs.verify-release-e2e.result == 'success'");
-    expect(releaseWorkflow).toContain('default: enforce');
+    expect(job('advance-major-alias')).toContain("needs.verify-release-e2e.outputs.outcome == 'success'");
+    const alias = job('advance-major-alias');
+    expect(alias).toContain(
+      'VERIFIED_E2E_MANIFEST_SHA256: ${{ needs.verify-release-e2e.outputs.manifest_sha256 }}'
+    );
+    expect(alias).toContain(
+      'VERIFIED_E2E_PROVIDER_COMMIT: ${{ needs.verify-release-e2e.outputs.provider_commit }}'
+    );
+    expect(alias).toContain(
+      'VERIFIED_E2E_PROVIDER_TAG: ${{ needs.verify-release-e2e.outputs.provider_tag }}'
+    );
+    expect(alias).toContain('[[ "$VERIFIED_E2E_MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]]');
+    expect(alias).toContain("[ \"$VERIFIED_E2E_PROVIDER_TAG\" = 'e2e-provider-v1.2.0' ]");
+    expect(alias).toContain(
+      "[ \"$VERIFIED_E2E_PROVIDER_COMMIT\" = '53c5d10093b7dafb165d3caafbe3f1d70dec687d' ]"
+    );
+    expect(alias).toContain(
+      'git ls-remote --exit-code --tags origin "$RELEASE_TAG_REF" "${RELEASE_TAG_REF}^{}"'
+    );
+    expect(alias).toContain('[ "$REMOTE_RELEASE_COMMIT" = "$GITHUB_SHA" ]');
+    for (const validation of [
+      '[[ "$VERIFIED_E2E_MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]]',
+      "[ \"$VERIFIED_E2E_PROVIDER_TAG\" = 'e2e-provider-v1.2.0' ]",
+      "[ \"$VERIFIED_E2E_PROVIDER_COMMIT\" = '53c5d10093b7dafb165d3caafbe3f1d70dec687d' ]",
+      '[ "$REMOTE_RELEASE_COMMIT" = "$GITHUB_SHA" ]'
+    ]) {
+      expect(alias.indexOf(validation)).toBeLessThan(alias.indexOf('git tag -fa "$MAJOR"'));
+      expect(alias.indexOf(validation)).toBeLessThan(
+        alias.indexOf('git push origin "$MAJOR" --force')
+      );
+    }
+    expect(releaseWorkflow).not.toContain('e2e_verification_mode');
+    expect(releaseWorkflow).not.toContain('report-only');
+  });
+
+  it('keeps the closed-manifest peer census aligned with every immutable composite child pin', () => {
+    const verifier = job('verify-release-e2e');
+    const encodedPeers = verifier.match(/E2E_GATE_PEER_TAGS: '([^'\n]+)'/)?.[1];
+    expect(encodedPeers).toBeTruthy();
+    const peers = JSON.parse(encodedPeers ?? '{}') as Record<string, string>;
+    expect(Object.keys(peers).sort()).toEqual([
+      'postman-cs/postman-bootstrap-action',
+      'postman-cs/postman-insights-onboarding-action',
+      'postman-cs/postman-repo-sync-action',
+      'postman-cs/postman-resolve-service-token-action',
+      'postman-cs/postman-smoke-flow-action'
+    ]);
+    const childPins = Object.fromEntries(
+      [...actionDefinition.matchAll(/uses:\s+(postman-cs\/postman-[a-z-]+-action)@(v\d+\.\d+\.\d+)/g)].map(
+        (match) => [match[1], match[2]]
+      )
+    );
+    expect(Object.keys(childPins).sort()).toEqual([
+      'postman-cs/postman-bootstrap-action',
+      'postman-cs/postman-insights-onboarding-action',
+      'postman-cs/postman-repo-sync-action',
+      'postman-cs/postman-smoke-flow-action'
+    ]);
+    for (const [repository, tag] of Object.entries(childPins)) {
+      expect(peers[repository]).toBe(tag);
+    }
   });
 
   it('mints a target-scoped App token for E2E dispatch instead of consuming a long-lived PAT secret', () => {
@@ -413,7 +505,7 @@ describe('release workflow publishing contract', () => {
 
     // Verifier remains fail-closed: exact capability/correlation enforcement unchanged
     expect(verifier).not.toContain('continue-on-error');
-    expect(verifier).toContain("E2E_GATE_MODE: ${{ inputs.e2e_verification_mode || 'enforce' }}");
+    expect(verifier).toContain('E2E_GATE_MODE: enforce');
     expect(verifier).toContain('E2E_GATE_ACTION: postman-api-onboarding-action');
     expect(verifier).toContain('E2E_GATE_SUITE: full');
     expect(verifier).toContain('E2E_GATE_REF: ${{ github.ref_name }}');
@@ -424,10 +516,101 @@ describe('release workflow publishing contract', () => {
   it('documents publication independence and correlated alias verification in the current v3 release policy', () => {
     expect(releasePolicy).toContain('nightly `full` monitor');
     expect(releasePolicy).toContain('not a PR or immutable-publication gate');
-    expect(releasePolicy).toContain('exact correlated terminal success');
-    expect(releasePolicy).toContain('E2E_COMPOSITE_USES_UNAVAILABLE');
+    expect(releasePolicy).toContain('canonical closed manifest');
+    expect(releasePolicy).toContain('all six suite repositories');
+    expect(releasePolicy).toContain('terminal result artifact');
+    expect(releasePolicy).toContain("release workflow's `GITHUB_SHA`");
     expect(releasePolicy).toContain('v3');
     expect(releasePolicy).toContain('rolling');
     expect(releasePolicy).not.toMatch(/\bv1\b/);
+  });
+});
+
+interface AliasShellResult {
+  status: number;
+  output: string;
+  mutations: string[];
+}
+
+function executeAliasShell(overrides: Record<string, string> = {}): AliasShellResult {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'composite-release-alias-'));
+  const scriptPath = join(tmpDir, 'alias.sh');
+  const mutationPrefix = '__ALIAS_GIT_MUTATION__:';
+  const gitShim = `git() {
+case "\${1:-}" in
+  ls-remote)
+    if [ "\${2:-}" = '--exit-code' ] && [ "$#" -eq 6 ]; then
+      printf '%s\\trefs/tags/%s\\n' "$GIT_STUB_RELEASE_TAG_OBJECT" "$GITHUB_REF_NAME"
+      printf '%s\\trefs/tags/%s^{}\\n' "$GIT_STUB_RELEASE_COMMIT" "$GITHUB_REF_NAME"
+    elif [ "\${2:-}" = '--tags' ] && [ "$#" -eq 6 ]; then
+      return 0
+    else
+      printf 'unexpected git ls-remote call: %s\\n' "$*" >&2
+      return 90
+    fi
+    ;;
+  config) ;;
+  tag|push) printf '${mutationPrefix}%s\\n' "$*" ;;
+  *) printf 'unexpected git call: %s\\n' "$*" >&2; return 90 ;;
+esac
+}
+`;
+  // Git Bash prepends its own /mingw64/bin/git ahead of Windows PATH entries,
+  // so only a shell function deterministically intercepts every git call.
+  writeFileSync(
+    scriptPath,
+    `${gitShim}\n${namedStepRunBody('Advance rolling major alias without regression')}`
+  );
+  try {
+    const result = spawnSync(bashExecutable(), [bashPath(scriptPath)], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: classifierEnv({
+        BASH_ENV: '',
+        ENV: '',
+        GITHUB_REF_NAME: 'v9.9.9',
+        GITHUB_SHA: 'a'.repeat(40),
+        GIT_STUB_RELEASE_COMMIT: 'a'.repeat(40),
+        GIT_STUB_RELEASE_TAG_OBJECT: '1'.repeat(40),
+        VERIFIED_E2E_MANIFEST_SHA256: 'c'.repeat(64),
+        VERIFIED_E2E_PROVIDER_COMMIT: '53c5d10093b7dafb165d3caafbe3f1d70dec687d',
+        VERIFIED_E2E_PROVIDER_TAG: 'e2e-provider-v1.2.0',
+        ...overrides
+      })
+    });
+    const mutations = (result.stdout ?? '')
+      .split('\n')
+      .filter((line) => line.startsWith(mutationPrefix))
+      .map((line) => line.slice(mutationPrefix.length).trim());
+    return {
+      status: result.status ?? -1,
+      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+      mutations
+    };
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('release alias evidence shell', () => {
+  it('mutates the alias only after exact manifest, provider, and release-tag checks pass', () => {
+    const result = executeAliasShell();
+    expect(result.status).toBe(0);
+    expect(result.mutations).toHaveLength(2);
+    expect(result.mutations[0]).toMatch(/^tag -fa v\d+ /);
+    expect(result.mutations[1]).toMatch(/^push origin v\d+ --force$/);
+  });
+
+  it.each([
+    ['missing manifest', { VERIFIED_E2E_MANIFEST_SHA256: '' }, 'manifest digest'],
+    ['non-lowercase manifest', { VERIFIED_E2E_MANIFEST_SHA256: 'C'.repeat(64) }, 'manifest digest'],
+    ['provider tag mismatch', { VERIFIED_E2E_PROVIDER_TAG: 'e2e-provider-v9.9.9' }, 'provider tag mismatch'],
+    ['provider commit mismatch', { VERIFIED_E2E_PROVIDER_COMMIT: 'f'.repeat(40) }, 'provider commit mismatch'],
+    ['moved release tag', { GIT_STUB_RELEASE_COMMIT: 'e'.repeat(40) }, 'immutable release tag moved']
+  ])('fails closed on %s before any alias mutation', (_name, overrides, message) => {
+    const result = executeAliasShell(overrides);
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain(message);
+    expect(result.mutations).toEqual([]);
   });
 });

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -387,7 +387,7 @@ describe('release workflow publishing contract', () => {
       'E2E_GATE_PROVIDER_SOURCE_DIGEST: 8c7ee211fccd2869f3901fcbc5ed154d6dea8e3d0d7d2e5312f6c0b57b4f6b78'
     );
     expect(verifier).toContain(
-      'E2E_GATE_PEER_TAGS: \'{"postman-cs/postman-bootstrap-action":"v2.21.5","postman-cs/postman-insights-onboarding-action":"v2.5.2","postman-cs/postman-repo-sync-action":"v2.10.3","postman-cs/postman-resolve-service-token-action":"v2.2.4","postman-cs/postman-smoke-flow-action":"v3.7.3"}\''
+      'E2E_GATE_PEER_TAGS: \'{"postman-cs/postman-bootstrap-action":"v2.21.10","postman-cs/postman-insights-onboarding-action":"v2.5.2","postman-cs/postman-repo-sync-action":"v2.10.9","postman-cs/postman-resolve-service-token-action":"v2.2.4","postman-cs/postman-smoke-flow-action":"v3.7.4"}\''
     );
     expect(verifier).not.toContain('E2E_GATE_WORKFLOW_REF: main');
     expect(verifier).not.toContain('E2E_GATE_REGISTRY_REVISION');

--- a/tests/validate-inputs.test.ts
+++ b/tests/validate-inputs.test.ts
@@ -92,21 +92,29 @@ describe('composite first-step input validation', () => {
     expect(manifest.inputs['repo-write-mode']?.default).toBe('commit-and-push');
   });
 
-  it('masks credentials, resolves branch decision, then validates before any child', () => {
+  it('resolves a credential-free branch decision before guarded masking and validation', () => {
     const steps = loadManifest().runs.steps;
-    expect(steps[0]?.id).toBe('mask_postman_credentials');
-    expect(steps[1]?.id).toBe('branch_decision');
+    expect(steps[0]?.id).toBe('branch_decision');
+    expect(steps[0]?.env).toEqual({
+      BRANCH_STRATEGY: '${{ inputs.branch-strategy }}',
+      CANONICAL_BRANCH: '${{ inputs.canonical-branch }}',
+      CHANNELS: '${{ inputs.channels }}'
+    });
+    expect(JSON.stringify(steps[0])).not.toMatch(/api-key|access-token|github-token|gh-fallback-token/i);
+    expect(steps[1]?.id).toBe('mask_postman_credentials');
+    expect(steps[1]?.if).toContain("tier != 'gated'");
     const validateStep = steps[2];
     expect(validateStep?.id).toBe('validate_postman_stack');
+    expect(validateStep?.if).toContain("tier != 'gated'");
     expect(validateStep?.env?.REPO_WRITE_MODE).toBe('${{ inputs.repo-write-mode }}');
     expect(validateStep?.env?.WORKING_DIRECTORY).toBe('${{ inputs.working-directory }}');
     expect(validateStep?.env?.SPEC_PATH).toBe('${{ inputs.spec-path }}');
-    expect(validateStep?.env?.POSTMAN_API_KEY).toBe('${{ inputs.postman-api-key }}');
-    expect(validateStep?.env?.POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.postman-access-token }}');
+    expect(validateStep?.env?.POSTMAN_API_KEY).toContain("tier != 'gated'");
+    expect(validateStep?.env?.POSTMAN_ACCESS_TOKEN).toContain("tier != 'gated'");
     expect(validateStep?.env?.ENABLE_INSIGHTS).toBe('${{ inputs.enable-insights }}');
     expect(validateStep?.env?.ONBOARDING_SCOPE).toBe('${{ inputs.onboarding-scope }}');
-    expect(validateStep?.env?.INSIGHTS_POSTMAN_API_KEY).toBe('${{ inputs.insights-postman-api-key }}');
-    expect(validateStep?.env?.INSIGHTS_POSTMAN_ACCESS_TOKEN).toBe('${{ inputs.insights-postman-access-token }}');
+    expect(validateStep?.env?.INSIGHTS_POSTMAN_API_KEY).toContain("tier != 'gated'");
+    expect(validateStep?.env?.INSIGHTS_POSTMAN_ACCESS_TOKEN).toContain("tier != 'gated'");
     expect(validateStep?.env?.BRANCH_TIER).toBe('${{ steps.branch_decision.outputs.tier }}');
     expect(steps.findIndex((step) => step.id === 'bootstrap')).toBeGreaterThan(0);
   });
@@ -180,6 +188,18 @@ describe('composite first-step input validation', () => {
     const result = runValidation({ WORKING_DIRECTORY: '..' });
     expect(result.status).toBe(1);
     expect(combinedOutput(result)).toContain('working-directory does not exist under GITHUB_WORKSPACE');
+  }, 20_000);
+
+  it('rejects an existing sibling whose path merely shares the workspace prefix', () => {
+    const sibling = mkdtempSync(`${repoRoot}-evil-`);
+    try {
+      const result = runValidation({ WORKING_DIRECTORY: sibling });
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('working-directory does not exist under GITHUB_WORKSPACE');
+      expect(combinedOutput(result)).not.toContain(sibling);
+    } finally {
+      rmSync(sibling, { recursive: true, force: true });
+    }
   }, 20_000);
 
   it('accepts an existing repository-relative spec path', () => {
@@ -328,16 +348,20 @@ describe('composite first-step input validation', () => {
 });
 
 describe('child invocation order and credential forwarding', () => {
-  it('masks every Postman credential before branch resolution and child actions', () => {
+  it('masks every Postman credential only after an eligible branch decision', () => {
     const steps = loadManifest().runs.steps;
     const maskStep = steps.find((step) => step.id === 'mask_postman_credentials');
-    expect(steps.indexOf(maskStep!)).toBe(0);
+    expect(steps[0]?.id).toBe('branch_decision');
+    expect(steps.indexOf(maskStep!)).toBe(1);
+    expect(maskStep?.if).toContain("tier != 'gated'");
     expect(maskStep?.env).toEqual({
       POSTMAN_TEAM_ID: '${{ inputs.postman-team-id }}',
-      POSTMAN_API_KEY: '${{ inputs.postman-api-key }}',
-      POSTMAN_ACCESS_TOKEN: '${{ inputs.postman-access-token }}',
-      INSIGHTS_POSTMAN_API_KEY: '${{ inputs.insights-postman-api-key }}',
-      INSIGHTS_POSTMAN_ACCESS_TOKEN: '${{ inputs.insights-postman-access-token }}'
+      POSTMAN_API_KEY: "${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}",
+      POSTMAN_ACCESS_TOKEN: "${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}",
+      INSIGHTS_POSTMAN_API_KEY:
+        "${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-api-key || '' }}",
+      INSIGHTS_POSTMAN_ACCESS_TOKEN:
+        "${{ steps.branch_decision.outputs.tier != 'gated' && inputs.insights-postman-access-token || '' }}"
     });
     expect(maskStep?.run).toContain("value=${value//'%'/%25}");
     expect(maskStep?.run).toContain("value=${value//$'\\n'/%0A}");
@@ -378,18 +402,59 @@ describe('child invocation order and credential forwarding', () => {
     const steps = loadManifest().runs.steps;
     const bootstrap = steps.find((candidate) => candidate.id === 'bootstrap');
     const repoSync = steps.find((candidate) => candidate.id === 'repo_sync');
+    expect(bootstrap?.if).toContain("tier != 'gated'");
     expect(bootstrap?.with?.['postman-api-key']).toBe("${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-api-key || '' }}");
     expect(bootstrap?.with?.['postman-access-token']).toBe("${{ steps.branch_decision.outputs.tier != 'gated' && inputs.postman-access-token || '' }}");
-    expect(repoSync?.with?.['postman-api-key']).toBe('${{ inputs.postman-api-key }}');
-    expect(repoSync?.with?.['postman-access-token']).toBe('${{ inputs.postman-access-token }}');
+    expect(repoSync?.with?.['postman-api-key']).toContain("tier != 'gated'");
+    expect(repoSync?.with?.['postman-access-token']).toContain("tier != 'gated'");
     expect(repoSync?.if).toContain("tier != 'gated'");
   });
 
   it('forwards only dedicated human-user credentials to Insights', () => {
     const insights = loadManifest().runs.steps.find((step) => step.id === 'insights_onboarding');
-    expect(insights?.with?.['postman-api-key']).toBe('${{ inputs.insights-postman-api-key }}');
-    expect(insights?.with?.['postman-access-token']).toBe('${{ inputs.insights-postman-access-token }}');
+    expect(insights?.with?.['postman-api-key']).toContain('inputs.insights-postman-api-key');
+    expect(insights?.with?.['postman-access-token']).toContain('inputs.insights-postman-access-token');
+    expect(insights?.with?.['postman-api-key']).toContain("tier != 'gated'");
+    expect(insights?.with?.['postman-access-token']).toContain("tier != 'gated'");
     expect(insights?.with?.['postman-api-key']).not.toBe('${{ inputs.postman-api-key }}');
     expect(insights?.with?.['postman-access-token']).not.toBe('${{ inputs.postman-access-token }}');
+  });
+
+  it('guards every credential-bearing or mutating inner step from the gated path', () => {
+    const steps = loadManifest().runs.steps;
+    const guardedStepIds = [
+      'mask_postman_credentials',
+      'validate_postman_stack',
+      'bootstrap',
+      'smoke_flow',
+      'repo_sync',
+      'warn_tests_skipped_no_api_key',
+      'install_postman_cli_windows',
+      'run_tests_junit',
+      'upload_junit_artifact',
+      'insights_onboarding'
+    ];
+    for (const id of guardedStepIds) {
+      const step = steps.find((candidate) => candidate.id === id);
+      expect(step, `${id} exists`).toBeTruthy();
+      expect(step?.if, `${id} has a tier guard`).toContain("steps.branch_decision.outputs.tier != 'gated'");
+    }
+
+    const sensitiveInputNames = [
+      'postman-api-key',
+      'postman-access-token',
+      'insights-postman-api-key',
+      'insights-postman-access-token',
+      'github-token',
+      'gh-fallback-token'
+    ];
+    for (const step of steps.slice(1)) {
+      for (const value of [...Object.values(step.env ?? {}), ...Object.values(step.with ?? {})]) {
+        if (!sensitiveInputNames.some((name) => value.includes(`inputs.${name}`))) continue;
+        expect(value, `${step.id ?? step.uses} conditionally empties a sensitive value`).toContain(
+          "steps.branch_decision.outputs.tier != 'gated'"
+        );
+      }
+    }
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    globalSetup: ['./tests/global-setup.ts'],
     include: ['tests/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Hardens composite event trust, credential gating and masking, repository path containment, shipped monorepo and Azure templates, sibling-source bounds, pin promotion identity, and immutable release E2E/alias authorization. Adds deterministic negative coverage for fork/channel bypasses, env and command injection, path escapes, malformed release evidence, and pin-selection failures.\n\nThe package gate is green locally: 345 Vitest tests, 16 release-verifier tests, typecheck, lint, sibling-pin validation, docs-table validation, actionlint, diff checks, and secret scans.\n\nThis PR is intentionally draft while the bottom-up bootstrap/repo-sync strict zero-HTTP-5xx release chain finishes. A final commit will pin only the immutable child tags whose promoted aliases and exact provider artifacts pass; no unverified child release will be merged here.